### PR TITLE
XML Validation Fixes

### DIFF
--- a/bpmn-js-spiffworkflow/app/spiffworkflow/InputOutput/IoInterceptor.js
+++ b/bpmn-js-spiffworkflow/app/spiffworkflow/InputOutput/IoInterceptor.js
@@ -61,7 +61,6 @@ export default class IoInterceptor extends CommandInterceptor {
         if (context.shape.di.$parent) {
           collectionRemove(context.shape.di.$parent.planeElement, context.shape.di);
         }
-        console.log("inputs/outputs", ioSpec.dataInputs, ioSpec.dataOutputs)
         if (ioSpec.dataInputs.length === 0 && ioSpec.dataOutputs.length === 0) {
           process.ioSpecification = null;
         }

--- a/bpmn-js-spiffworkflow/app/spiffworkflow/InputOutput/IoInterceptor.js
+++ b/bpmn-js-spiffworkflow/app/spiffworkflow/InputOutput/IoInterceptor.js
@@ -38,6 +38,7 @@ export default class IoInterceptor extends CommandInterceptor {
         di.bpmnElement = dataIO;
         di.id = dataIO.id + 'DI';
         bpmnUpdater.updateBounds(context.shape);
+
         if (type == 'bpmn:DataInput') {
           collectionAdd(ioSpecification.get('dataInputs'), dataIO);
         } else {
@@ -59,6 +60,10 @@ export default class IoInterceptor extends CommandInterceptor {
         }
         if (context.shape.di.$parent) {
           collectionRemove(context.shape.di.$parent.planeElement, context.shape.di);
+        }
+        console.log("inputs/outputs", ioSpec.dataInputs, ioSpec.dataOutputs)
+        if (ioSpec.dataInputs.length === 0 && ioSpec.dataOutputs.length === 0) {
+          process.ioSpecification = null;
         }
       }
     });
@@ -88,19 +93,23 @@ function assureIOSpecificationExists(process, bpmnFactory) {
   let ioSpecification = process.get('ioSpecification');
 
   if (!ioSpecification) {
+    let inputSet = bpmnFactory.create('bpmn:InputSet');
+    let outputSet = bpmnFactory.create('bpmn:OutputSet');
 
     // Create the BPMN
     ioSpecification = bpmnFactory.create('bpmn:InputOutputSpecification', {
       dataInputs: [],
-      inputSets: [],
+      inputSets: [inputSet],
       dataOutputs: [],
-      outputSets: []
+      outputSets: [outputSet],
     });
     ioSpecification.$parent = process;
     process.ioSpecification = ioSpecification;
   }
   return ioSpecification;
 }
+
+
 
 IoInterceptor.$inject = [ 'eventBus', 'bpmnFactory', 'bpmnUpdater' ];
 

--- a/bpmn-js-spiffworkflow/app/spiffworkflow/messages/propertiesPanel/MessageCorrelationPropertiesArray.js
+++ b/bpmn-js-spiffworkflow/app/spiffworkflow/messages/propertiesPanel/MessageCorrelationPropertiesArray.js
@@ -82,7 +82,7 @@ export function MessageCorrelationPropertiesArray(props) {
         'bpmn:CorrelationPropertyRetrievalExpression'
       );
       const messageRefElement = getMessageRefElement(element);
-      const newFormalExpression = moddle.create('bpmn:FormalExpression');
+      const newFormalExpression = moddle.create('bpmn:messagePath');
       newFormalExpression.body = '';
 
       newRetrievalExpressionElement.messageRef = messageRefElement;

--- a/bpmn-js-spiffworkflow/test/spec/IOInterceptorSpec.js
+++ b/bpmn-js-spiffworkflow/test/spec/IOInterceptorSpec.js
@@ -1,0 +1,63 @@
+import { bootstrapPropertiesPanel } from './helpers';
+import dataObjectInterceptor from '../../app/spiffworkflow/DataObject';
+import { BpmnPropertiesPanelModule, BpmnPropertiesProviderModule } from 'bpmn-js-properties-panel';
+import {
+  inject,
+} from 'bpmn-js/test/helper';
+import { findDataObjects } from '../../app/spiffworkflow/DataObject/DataObjectHelpers';
+import IoInterceptor from '../../app/spiffworkflow/InputOutput/IoInterceptor';
+import InputOutput from '../../app/spiffworkflow/InputOutput';
+
+describe('Input/Output Interceptor', function() {
+
+  let xml = require('./bpmn/empty_diagram.bpmn').default;
+
+  beforeEach(bootstrapPropertiesPanel(xml, {
+    debounceInput: false,
+    additionalModules: [
+      InputOutput,
+      BpmnPropertiesPanelModule,
+      BpmnPropertiesProviderModule,
+    ]
+  }));
+
+  it('New Data Input should create an IOSpecification with a single dataInput object', inject(function(canvas, modeling) {
+
+    expect(canvas.getRootElement().businessObject.ioSpecification).to.be.undefined;
+
+    // IF - a new dataObjectReference is created
+    let rootShape = canvas.getRootElement();
+    const dataInput = modeling.createShape({ type: 'bpmn:DataInput' },
+      { x: 220, y: 220 }, rootShape);
+
+    // THEN - the process should now have an IO Specification
+    const iospec = canvas.getRootElement().businessObject.ioSpecification;
+    expect(iospec).to.not.be.null;
+    expect(iospec.dataInputs.length).to.equal(1)
+  }));
+
+
+  it('IOSpecification always contain input sets and output sets if they exist at all.', inject(function(canvas, modeling) {
+
+    expect(canvas.getRootElement().businessObject.ioSpecification).to.be.undefined;
+
+    // IF - a new dataObjectReference is created
+    let rootShape = canvas.getRootElement();
+    const dataInput = modeling.createShape({type: 'bpmn:DataInput'},
+      {x: 220, y: 220}, rootShape);
+
+    // THEN - there are inputSets and outputSets
+    const iospec = canvas.getRootElement().businessObject.ioSpecification;
+    expect(iospec.inputSets).to.not.be.null;
+    expect(iospec.outputSets).to.not.be.null;
+  }));
+
+    it('After removing all input sets, the ioSpecification should be null.', inject(function(canvas, modeling) {
+    // IF - a new dataObjectReference is created and then deleted.
+    let rootShape = canvas.getRootElement();
+    const dataInput = modeling.createShape({type: 'bpmn:DataInput'},
+      {x: 220, y: 220}, rootShape);
+    modeling.removeShape(dataInput)
+    expect(canvas.getRootElement().businessObject.ioSpecification).to.be.null;
+  }));
+});

--- a/bpmn-js-spiffworkflow/test/spec/bpmn/basic_message.bpmn
+++ b/bpmn-js-spiffworkflow/test/spec/bpmn/basic_message.bpmn
@@ -14,10 +14,10 @@
   </bpmn:collaboration>
   <bpmn:correlationProperty id="message_correlation_property" name="Message Correlation Property">
     <bpmn:correlationPropertyRetrievalExpression messageRef="message_send">
-      <bpmn:formalExpression>to</bpmn:formalExpression>
+      <bpmn:messagePath>to</bpmn:messagePath>
     </bpmn:correlationPropertyRetrievalExpression>
     <bpmn:correlationPropertyRetrievalExpression messageRef="message_response">
-      <bpmn:formalExpression>from.name</bpmn:formalExpression>
+      <bpmn:messagePath>from.name</bpmn:messagePath>
     </bpmn:correlationPropertyRetrievalExpression>
   </bpmn:correlationProperty>
   <bpmn:process id="message_send_process" name="Message Send Process" isExecutable="true">
@@ -68,7 +68,7 @@
   </bpmn:process>
   <bpmn:correlationProperty id="correlation_property_one" name="Correlation Property One">
     <bpmn:correlationPropertyRetrievalExpression messageRef="message_send">
-      <bpmn:formalExpression>new</bpmn:formalExpression>
+      <bpmn:messagePath>new</bpmn:messagePath>
     </bpmn:correlationPropertyRetrievalExpression>
   </bpmn:correlationProperty>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">

--- a/bpmn-js-spiffworkflow/test/spec/bpmn/collaboration.bpmn
+++ b/bpmn-js-spiffworkflow/test/spec/bpmn/collaboration.bpmn
@@ -26,26 +26,26 @@
   <bpmn:message id="love_letter_response" name="Love Letter Response" />
   <bpmn:correlationProperty id="lover_instrument" name="Lover&#39;s Instrument">
     <bpmn:correlationPropertyRetrievalExpression messageRef="love_letter">
-      <bpmn:formalExpression>lover.instrument</bpmn:formalExpression>
+      <bpmn:messagePath>lover.instrument</bpmn:messagePath>
     </bpmn:correlationPropertyRetrievalExpression>
     <bpmn:correlationPropertyRetrievalExpression messageRef="love_letter_response">
-      <bpmn:formalExpression>from.instrument</bpmn:formalExpression>
+      <bpmn:messagePath>from.instrument</bpmn:messagePath>
     </bpmn:correlationPropertyRetrievalExpression>
   </bpmn:correlationProperty>
   <bpmn:correlationProperty id="lover_name" name="Lover&#39;s Name">
     <bpmn:correlationPropertyRetrievalExpression messageRef="love_letter">
-      <bpmn:formalExpression>lover.name</bpmn:formalExpression>
+      <bpmn:messagePath>lover.name</bpmn:messagePath>
     </bpmn:correlationPropertyRetrievalExpression>
     <bpmn:correlationPropertyRetrievalExpression messageRef="love_letter_response">
-      <bpmn:formalExpression>from.name</bpmn:formalExpression>
+      <bpmn:messagePath>from.name</bpmn:messagePath>
     </bpmn:correlationPropertyRetrievalExpression>
     <bpmn:correlationPropertyRetrievalExpression>
-      <bpmn:formalExpression>heartbreaker</bpmn:formalExpression>
+      <bpmn:messagePath>heartbreaker</bpmn:messagePath>
     </bpmn:correlationPropertyRetrievalExpression>
   </bpmn:correlationProperty>
   <bpmn:correlationProperty id="singer_name" name="Singer&#39;s Name">
     <bpmn:correlationPropertyRetrievalExpression messageRef="love_letter_response">
-      <bpmn:formalExpression>to.name</bpmn:formalExpression>
+      <bpmn:messagePath>to.name</bpmn:messagePath>
     </bpmn:correlationPropertyRetrievalExpression>
   </bpmn:correlationProperty>
   <bpmn:process id="process_buddy" name="Process Buddy" isExecutable="true">

--- a/bpmn-js-spiffworkflow/test/spec/bpmn/simple_collab.bpmn
+++ b/bpmn-js-spiffworkflow/test/spec/bpmn/simple_collab.bpmn
@@ -46,46 +46,46 @@
 
     <bpmn:correlationProperty id="invoice_id" name="Invoice ID">
         <bpmn:correlationPropertyRetrievalExpression messageRef="send_invoice">
-            <bpmn:formalExpression>invoice.invoice_id</bpmn:formalExpression>
+            <bpmn:messagePath>invoice.invoice_id</bpmn:messagePath>
         </bpmn:correlationPropertyRetrievalExpression>
         <bpmn:correlationPropertyRetrievalExpression messageRef="send_payment">
-            <bpmn:formalExpression>payment.invoice_id</bpmn:formalExpression>
+            <bpmn:messagePath>payment.invoice_id</bpmn:messagePath>
         </bpmn:correlationPropertyRetrievalExpression>
     </bpmn:correlationProperty>
 
     <bpmn:correlationProperty id="invoice_total" name="Invoice Total">
         <bpmn:correlationPropertyRetrievalExpression messageRef="send_invoice">
-            <bpmn:formalExpression>invoice.total</bpmn:formalExpression>
+            <bpmn:messagePath>invoice.total</bpmn:messagePath>
         </bpmn:correlationPropertyRetrievalExpression>
         <bpmn:correlationPropertyRetrievalExpression messageRef="send_payment">
-            <bpmn:formalExpression>payment.invoice_amount</bpmn:formalExpression>
+            <bpmn:messagePath>payment.invoice_amount</bpmn:messagePath>
         </bpmn:correlationPropertyRetrievalExpression>
     </bpmn:correlationProperty>
 
     <bpmn:correlationProperty id="invoice_date" name="Invoice Date">
         <bpmn:correlationPropertyRetrievalExpression messageRef="send_invoice">
-            <bpmn:formalExpression>invoice.date</bpmn:formalExpression>
+            <bpmn:messagePath>invoice.date</bpmn:messagePath>
         </bpmn:correlationPropertyRetrievalExpression>
         <bpmn:correlationPropertyRetrievalExpression messageRef="send_payment">
-            <bpmn:formalExpression>payment.invoice_date</bpmn:formalExpression>
+            <bpmn:messagePath>payment.invoice_date</bpmn:messagePath>
         </bpmn:correlationPropertyRetrievalExpression>
     </bpmn:correlationProperty>
 
     <bpmn:correlationProperty id="payment_date" name="Payment Date">
         <bpmn:correlationPropertyRetrievalExpression messageRef="send_payment">
-            <bpmn:formalExpression>payment.date</bpmn:formalExpression>
+            <bpmn:messagePath>payment.date</bpmn:messagePath>
         </bpmn:correlationPropertyRetrievalExpression>
     </bpmn:correlationProperty>
 
     <bpmn:correlationProperty id="payment_total" name="Payment Total">
         <bpmn:correlationPropertyRetrievalExpression messageRef="send_payment">
-            <bpmn:formalExpression>payment.total</bpmn:formalExpression>
+            <bpmn:messagePath>payment.total</bpmn:messagePath>
         </bpmn:correlationPropertyRetrievalExpression>
     </bpmn:correlationProperty>
 
     <bpmn:correlationProperty id="payment_id" name="Payment ID">
         <bpmn:correlationPropertyRetrievalExpression messageRef="send_payment">
-            <bpmn:formalExpression>payment.id</bpmn:formalExpression>
+            <bpmn:messagePath>payment.id</bpmn:messagePath>
         </bpmn:correlationPropertyRetrievalExpression>
     </bpmn:correlationProperty>
 


### PR DESCRIPTION
Based off validation errors we encountered in Spiff Workflow, these fixes should assure we generate XML that will validate against he officially published BPMN schemas.

* For Correlation Properties, should use messagePath and not formalEx…pression for the name.
* When all data input and outputs are removed, the ioSpecification should be removed as well
* If an ioSpecification is present, then there shoud be a at least one dataInputset and at least one dataoutputset.