### PR TITLE
Fix FutureWarning in SpiffWorkflow

### DIFF
--- a/SpiffWorkflow/SpiffWorkflow/bpmn/parser/node_parser.py
+++ b/SpiffWorkflow/SpiffWorkflow/bpmn/parser/node_parser.py
@@ -35,7 +35,8 @@ class NodeParser:
         return expression.text if expression is not None else None
 
     def parse_documentation(self, sequence_flow=None):
-        documentation_node = first(self._xpath(sequence_flow or self.node, './/bpmn:documentation'))
+        node = sequence_flow if sequence_flow is not None else self.node
+        documentation_node = first(self._xpath(node, './/bpmn:documentation'))
         return None if documentation_node is None else documentation_node.text
 
     def parse_incoming_data_references(self):


### PR DESCRIPTION
When running SpiffWorkflow there is a warning produced, believe from lxml:

```
spiff-arena/SpiffWorkflow/SpiffWorkflow/bpmn/parser/node_parser.py:39: FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.
  documentation_node = first(self._xpath(sequence_flow or self.node, './/bpmn:documentation'))
```

Went with the `elem is not None` option for the fix.