### PR TITLE
Change steps when viewing a process instance model

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/process_instance.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/process_instance.py
@@ -112,6 +112,7 @@ class ProcessInstanceModel(SpiffworkflowBaseDBModel):
             "end_in_seconds": self.end_in_seconds,
             "process_initiator_id": self.process_initiator_id,
             "bpmn_xml_file_contents": local_bpmn_xml_file_contents,
+            "spiff_step": self.spiff_step,
         }
 
     @property

--- a/spiffworkflow-frontend/src/routes/ProcessInstanceShow.tsx
+++ b/spiffworkflow-frontend/src/routes/ProcessInstanceShow.tsx
@@ -233,8 +233,23 @@ export default function ProcessInstanceShow() {
     }
   };
 
+  const currentSpiffStep = (processInstanceToUse: any) => {
+    if (typeof params.spiff_step === 'undefined') {
+      return processInstanceToUse.spiff_step;
+    }
+
+    return params.spiff_step;
+  };
+
+  const showingLastSpiffStep = () => {
+    const processInstanceToUse: any = processInstance;
+    return (
+      currentSpiffStep(processInstanceToUse) === processInstanceToUse.spiff_step
+    );
+  };
+
   const canEditTaskData = (task: any) => {
-    return task.state === 'READY';
+    return task.state === 'READY' && showingLastSpiffStep();
   };
 
   const cancelEditingTaskData = () => {

--- a/spiffworkflow-frontend/src/routes/ProcessInstanceShow.tsx
+++ b/spiffworkflow-frontend/src/routes/ProcessInstanceShow.tsx
@@ -96,6 +96,61 @@ export default function ProcessInstanceShow() {
     return taskIds;
   };
 
+  const currentSpiffStep = (processInstanceToUse: any) => {
+    if (typeof params.spiff_step === 'undefined') {
+      return processInstanceToUse.spiff_step;
+    }
+
+    return Number(params.spiff_step);
+  };
+
+  const showingFirstSpiffStep = (processInstanceToUse: any) => {
+    return currentSpiffStep(processInstanceToUse) === 1;
+  };
+
+  const showingLastSpiffStep = (processInstanceToUse: any) => {
+    return (
+      currentSpiffStep(processInstanceToUse) === processInstanceToUse.spiff_step
+    );
+  };
+
+  const spiffStepLink = (
+    processInstanceToUse: any,
+    label: string,
+    distance: number
+  ) => {
+    return (
+      <li>
+        <Link
+          data-qa="process-instance-prev-step-link"
+          to={`/admin/process-models/${params.process_group_id}/${
+            params.process_model_id
+          }/process-instances/${params.process_instance_id}/${
+            currentSpiffStep(processInstanceToUse) + distance
+          }`}
+        >
+          {label}
+        </Link>
+      </li>
+    );
+  };
+
+  const previousStepLink = (processInstanceToUse: any) => {
+    if (showingFirstSpiffStep(processInstanceToUse)) {
+      return null;
+    }
+
+    return spiffStepLink(processInstanceToUse, 'Previous Step', -1);
+  };
+
+  const nextStepLink = (processInstanceToUse: any) => {
+    if (showingLastSpiffStep(processInstanceToUse)) {
+      return null;
+    }
+
+    return spiffStepLink(processInstanceToUse, 'Next Step', 1);
+  };
+
   const getInfoTag = (processInstanceToUse: any) => {
     const currentEndDate = convertSecondsToFormattedDate(
       processInstanceToUse.end_in_seconds
@@ -135,6 +190,12 @@ export default function ProcessInstanceShow() {
             Messages
           </Link>
         </li>
+        <li>
+          Step {currentSpiffStep(processInstanceToUse)} of{' '}
+          {processInstanceToUse.spiff_step}
+        </li>
+        {previousStepLink(processInstanceToUse)}
+        {nextStepLink(processInstanceToUse)}
       </ul>
     );
   };
@@ -233,23 +294,10 @@ export default function ProcessInstanceShow() {
     }
   };
 
-  const currentSpiffStep = (processInstanceToUse: any) => {
-    if (typeof params.spiff_step === 'undefined') {
-      return processInstanceToUse.spiff_step;
-    }
-
-    return params.spiff_step;
-  };
-
-  const showingLastSpiffStep = () => {
-    const processInstanceToUse: any = processInstance;
-    return (
-      currentSpiffStep(processInstanceToUse) === processInstanceToUse.spiff_step
-    );
-  };
-
   const canEditTaskData = (task: any) => {
-    return task.state === 'READY' && showingLastSpiffStep();
+    return (
+      task.state === 'READY' && showingLastSpiffStep(processInstance as any)
+    );
   };
 
   const cancelEditingTaskData = () => {

--- a/spiffworkflow-frontend/src/routes/ProcessInstanceShow.tsx
+++ b/spiffworkflow-frontend/src/routes/ProcessInstanceShow.tsx
@@ -122,7 +122,8 @@ export default function ProcessInstanceShow() {
     return (
       <li>
         <Link
-          data-qa="process-instance-prev-step-link"
+          reloadDocument
+          data-qa="process-instance-step-link"
           to={`/admin/process-models/${params.process_group_id}/${
             params.process_model_id
           }/process-instances/${params.process_instance_id}/${


### PR DESCRIPTION
Provides a quick and dirty UI to move to previous/next steps of the spiff execution when viewing a process instance model. Not pretending this should be the final UI, but functionality is there. Also fixes the bug @essweine mentioned in standup about being able to edit task data for previous steps. Now only ready tasks on the current step have the edit button, instead of any ready task at any step.