### PR TITLE
Navigate to my task

### DIFF
--- a/spiffworkflow-frontend/src/routes/ProcessModelShow.tsx
+++ b/spiffworkflow-frontend/src/routes/ProcessModelShow.tsx
@@ -132,20 +132,11 @@ export default function ProcessModelShow() {
 
   const processInstanceResultTag = () => {
     if (processModel && processInstanceResult) {
-      let takeMeToMyTaskBlurb = null;
       // FIXME: ensure that the task is actually for the current user as well
       const processInstanceId = (processInstanceResult as any).id;
       const nextTask = (processInstanceResult as any).next_task;
       if (nextTask && nextTask.state === 'READY') {
-        takeMeToMyTaskBlurb = (
-          <span>
-            You have a task to complete. Go to{' '}
-            <Link to={`/tasks/${processInstanceId}/${nextTask.id}`}>
-              my task
-            </Link>
-            .
-          </span>
-        );
+        navigate(`/tasks/${processInstanceId}/${nextTask.id}`);
       }
       return (
         <div className="alert alert-success" role="alert">
@@ -157,7 +148,7 @@ export default function ProcessModelShow() {
             >
               view
             </Link>
-            ). {takeMeToMyTaskBlurb}
+            ).
           </p>
         </div>
       );


### PR DESCRIPTION
If you run a process, navigate to the form instead of giving a link to `my task`. Been some talk about wanting this and thought it would be a small step in the direction of what an async flow from the frontend would look like.