### PR TITLE
Merge process_instance_list query filters with report filters

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
@@ -70,7 +70,9 @@ from spiffworkflow_backend.services.message_service import MessageService
 from spiffworkflow_backend.services.process_instance_processor import (
     ProcessInstanceProcessor,
 )
-from spiffworkflow_backend.services.process_instance_report_service import ProcessInstanceReportService
+from spiffworkflow_backend.services.process_instance_report_service import (
+    ProcessInstanceReportService,
+)
 from spiffworkflow_backend.services.process_instance_service import (
     ProcessInstanceService,
 )
@@ -723,7 +725,7 @@ def process_instance_list(
         start_to,
         end_from,
         end_to,
-        process_status
+        process_status,
     )
 
     # process_model_identifier = un_modify_modified_process_model_id(modified_process_model_identifier)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
@@ -70,6 +70,7 @@ from spiffworkflow_backend.services.message_service import MessageService
 from spiffworkflow_backend.services.process_instance_processor import (
     ProcessInstanceProcessor,
 )
+from spiffworkflow_backend.services.process_instance_report_service import ProcessInstanceReportService
 from spiffworkflow_backend.services.process_instance_service import (
     ProcessInstanceService,
 )
@@ -715,12 +716,21 @@ def process_instance_list(
 ) -> flask.wrappers.Response:
     """Process_instance_list."""
     process_instance_report = ProcessInstanceReportModel.default_report(g.user)
+    report_filter = ProcessInstanceReportService.filter_from_metadata_with_overrides(
+        process_instance_report,
+        process_model_identifier,
+        start_from,
+        start_to,
+        end_from,
+        end_to,
+        process_status
+    )
 
     # process_model_identifier = un_modify_modified_process_model_id(modified_process_model_identifier)
     process_instance_query = ProcessInstanceModel.query
-    if process_model_identifier is not None:
+    if report_filter.process_model_identifier is not None:
         process_model = get_process_model(
-            f"{process_model_identifier}",
+            f"{report_filter.process_model_identifier}",
         )
 
         process_instance_query = process_instance_query.filter_by(
@@ -740,34 +750,31 @@ def process_instance_list(
             )
         )
 
-    if start_from is not None:
+    if report_filter.start_from is not None:
         process_instance_query = process_instance_query.filter(
-            ProcessInstanceModel.start_in_seconds >= start_from
+            ProcessInstanceModel.start_in_seconds >= report_filter.start_from
         )
-    if start_to is not None:
+    if report_filter.start_to is not None:
         process_instance_query = process_instance_query.filter(
-            ProcessInstanceModel.start_in_seconds <= start_to
+            ProcessInstanceModel.start_in_seconds <= report_filter.start_to
         )
-    if end_from is not None:
+    if report_filter.end_from is not None:
         process_instance_query = process_instance_query.filter(
-            ProcessInstanceModel.end_in_seconds >= end_from
+            ProcessInstanceModel.end_in_seconds >= report_filter.end_from
         )
-    if end_to is not None:
+    if report_filter.end_to is not None:
         process_instance_query = process_instance_query.filter(
-            ProcessInstanceModel.end_in_seconds <= end_to
+            ProcessInstanceModel.end_in_seconds <= report_filter.end_to
         )
-    if process_status is not None:
-        process_status_array = process_status.split(",")
+    if report_filter.process_status is not None:
         process_instance_query = process_instance_query.filter(
-            ProcessInstanceModel.status.in_(process_status_array)  # type: ignore
+            ProcessInstanceModel.status.in_(report_filter.process_status)  # type: ignore
         )
 
     process_instances = process_instance_query.order_by(
         ProcessInstanceModel.start_in_seconds.desc(), ProcessInstanceModel.id.desc()  # type: ignore
     ).paginate(page=page, per_page=per_page, error_out=False)
 
-    # TODO need to look into this more - how the filter here interacts with the
-    # one defined in the report.
     # TODO need to look into test failures when the results from result_dict is
     # used instead of the process instances
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
@@ -714,6 +714,8 @@ def process_instance_list(
     process_status: Optional[str] = None,
 ) -> flask.wrappers.Response:
     """Process_instance_list."""
+    process_instance_report = ProcessInstanceReportModel.default_report(g.user)
+
     # process_model_identifier = un_modify_modified_process_model_id(modified_process_model_identifier)
     process_instance_query = ProcessInstanceModel.query
     if process_model_identifier is not None:
@@ -763,8 +765,6 @@ def process_instance_list(
     process_instances = process_instance_query.order_by(
         ProcessInstanceModel.start_in_seconds.desc(), ProcessInstanceModel.id.desc()  # type: ignore
     ).paginate(page=page, per_page=per_page, error_out=False)
-
-    process_instance_report = ProcessInstanceReportModel.default_report(g.user)
 
     # TODO need to look into this more - how the filter here interacts with the
     # one defined in the report.

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_report_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_report_service.py
@@ -1,4 +1,4 @@
-"""process_instance_report_service."""
+"""Process_instance_report_service."""
 from dataclasses import dataclass
 from typing import Optional
 
@@ -21,13 +21,19 @@ class ProcessInstanceReportFilter:
 
 class ProcessInstanceReportService:
     """ProcessInstanceReportService."""
+
     @classmethod
     def filter_by_to_dict(
         cls, process_instance_report: ProcessInstanceReportModel
-    ) -> dict[str,str]:
+    ) -> dict[str, str]:
+        """Filter_by_to_dict."""
         metadata = process_instance_report.report_metadata
         filter_by = metadata.get("filter_by", [])
-        filters = {d["field_name"]: d["field_value"] for d in filter_by if "field_name" in d and "field_value" in d}
+        filters = {
+            d["field_name"]: d["field_value"]
+            for d in filter_by
+            if "field_name" in d and "field_value" in d
+        }
         return filters
 
     @classmethod
@@ -38,9 +44,11 @@ class ProcessInstanceReportService:
         filters = cls.filter_by_to_dict(process_instance_report)
 
         def int_value(key: str) -> Optional[int]:
+            """Int_value."""
             return int(filters[key]) if key in filters else None
 
         def list_value(key: str) -> Optional[list[str]]:
+            """List_value."""
             return filters[key].split(",") if key in filters else None
 
         process_model_identifier = filters.get("process_model_identifier")

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_report_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_report_service.py
@@ -21,22 +21,34 @@ class ProcessInstanceReportFilter:
 
 class ProcessInstanceReportService:
     """ProcessInstanceReportService."""
+    @classmethod
+    def filter_by_to_dict(
+        cls, process_instance_report: ProcessInstanceReportModel
+    ) -> dict[str,str]:
+        metadata = process_instance_report.report_metadata
+        filter_by = metadata.get("filter_by", [])
+        filters = {d["field_name"]: d["field_value"] for d in filter_by if "field_name" in d and "field_value" in d}
+        return filters
 
     @classmethod
     def filter_from_metadata(
         cls, process_instance_report: ProcessInstanceReportModel
     ) -> ProcessInstanceReportFilter:
         """Filter_from_metadata."""
-        process_model_identifier: Optional[str] = None
-        start_from: Optional[int] = None
-        start_to: Optional[int] = None
-        end_from: Optional[int] = None
-        end_to: Optional[int] = None
-        process_status: Optional[list[str]] = None
+        filters = cls.filter_by_to_dict(process_instance_report)
 
-        metadata = process_instance_report.report_metadata
-        filter_by = metadata.get("filter_by", [])
-        filters = {k: v for filter_dict in filter_by for k, v in filter_dict.items()}
+        def int_value(key: str) -> Optional[int]:
+            return int(filters[key]) if key in filters else None
+
+        def list_value(key: str) -> Optional[list[str]]:
+            return filters[key].split(",") if key in filters else None
+
+        process_model_identifier = filters.get("process_model_identifier")
+        start_from = int_value("start_from")
+        start_to = int_value("start_to")
+        end_from = int_value("end_from")
+        end_to = int_value("end_to")
+        process_status = list_value("process_status")
 
         process_instance_report_filter = ProcessInstanceReportFilter(
             process_model_identifier,
@@ -48,20 +60,3 @@ class ProcessInstanceReportService:
         )
 
         return process_instance_report_filter
-
-    # def passes_filter(
-    #    self, process_instance_dict: dict, substitution_variables: dict
-    # ) -> bool:
-    #    """Passes_filter."""
-    #    if "filter_by" in self.report_metadata:
-    #        for filter_by in self.report_metadata["filter_by"]:
-    #            field_name = filter_by["field_name"]
-    #            operator = filter_by["operator"]
-    #            field_value = self.with_substitutions(
-    #                filter_by["field_value"], substitution_variables
-    #            )
-    #            if operator == "equals":
-    # if str(process_instance_dict.get(field_name)) != str(field_value):
-    #                    return False
-    #
-    #    return True

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_report_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_report_service.py
@@ -71,7 +71,7 @@ class ProcessInstanceReportService:
 
     @classmethod
     def filter_from_metadata_with_overrides(
-        cls, 
+        cls,
         process_instance_report: ProcessInstanceReportModel,
         process_model_identifier: Optional[str] = None,
         start_from: Optional[int] = None,
@@ -84,16 +84,16 @@ class ProcessInstanceReportService:
         report_filter = cls.filter_from_metadata(process_instance_report)
 
         if process_model_identifier is not None:
-            report_filter.process_model_identifier = process_model_identifier 
+            report_filter.process_model_identifier = process_model_identifier
         if start_from is not None:
-            report_filter.start_from = start_from 
+            report_filter.start_from = start_from
         if start_to is not None:
-            report_filter.start_to = start_to 
+            report_filter.start_to = start_to
         if end_from is not None:
-            report_filter.end_from = end_from 
+            report_filter.end_from = end_from
         if end_to is not None:
-            report_filter.end_to = end_to 
+            report_filter.end_to = end_to
         if process_status is not None:
-            report_filter.process_status = process_status.split(",") 
+            report_filter.process_status = process_status.split(",")
 
         return report_filter

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_report_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_report_service.py
@@ -58,7 +58,7 @@ class ProcessInstanceReportService:
         end_to = int_value("end_to")
         process_status = list_value("process_status")
 
-        process_instance_report_filter = ProcessInstanceReportFilter(
+        report_filter = ProcessInstanceReportFilter(
             process_model_identifier,
             start_from,
             start_to,
@@ -67,4 +67,33 @@ class ProcessInstanceReportService:
             process_status,
         )
 
-        return process_instance_report_filter
+        return report_filter
+
+    @classmethod
+    def filter_from_metadata_with_overrides(
+        cls, 
+        process_instance_report: ProcessInstanceReportModel,
+        process_model_identifier: Optional[str] = None,
+        start_from: Optional[int] = None,
+        start_to: Optional[int] = None,
+        end_from: Optional[int] = None,
+        end_to: Optional[int] = None,
+        process_status: Optional[str] = None,
+    ) -> ProcessInstanceReportFilter:
+        """Filter_from_metadata_with_overrides."""
+        report_filter = cls.filter_from_metadata(process_instance_report)
+
+        if process_model_identifier is not None:
+            report_filter.process_model_identifier = process_model_identifier 
+        if start_from is not None:
+            report_filter.start_from = start_from 
+        if start_to is not None:
+            report_filter.start_to = start_to 
+        if end_from is not None:
+            report_filter.end_from = end_from 
+        if end_to is not None:
+            report_filter.end_to = end_to 
+        if process_status is not None:
+            report_filter.process_status = process_status.split(",") 
+
+        return report_filter

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_report_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_report_service.py
@@ -1,0 +1,56 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from spiffworkflow_backend.models.process_instance_report import ProcessInstanceReportModel
+
+@dataclass
+class ProcessInstanceReportFilter:
+    process_model_identifier: Optional[str] = None
+    start_from: Optional[int] = None
+    start_to: Optional[int] = None
+    end_from: Optional[int] = None
+    end_to: Optional[int] = None
+    process_status: Optional[list[str]] = None
+
+class ProcessInstanceReportService:
+    """ProcessInstanceReportService."""
+    @classmethod
+    def filter_from_metadata(cls, process_instance_report: ProcessInstanceReportModel) -> ProcessInstanceReportFilter:
+        process_model_identifier: Optional[str] = None
+        start_from: Optional[int] = None
+        start_to: Optional[int] = None
+        end_from: Optional[int] = None
+        end_to: Optional[int] = None
+        process_status: Optional[list[str]] = None
+
+        metadata = process_instance_report.report_metadata
+        if "filter_by" in metadata:
+            pass
+
+        process_instance_report_filter = ProcessInstanceReportFilter(
+            process_model_identifier,
+            start_from,
+            start_to,
+            end_from,
+            end_to,
+            process_status,
+        )
+        
+        return process_instance_report_filter
+
+    #def passes_filter(
+    #    self, process_instance_dict: dict, substitution_variables: dict
+    #) -> bool:
+    #    """Passes_filter."""
+    #    if "filter_by" in self.report_metadata:
+    #        for filter_by in self.report_metadata["filter_by"]:
+    #            field_name = filter_by["field_name"]
+    #            operator = filter_by["operator"]
+    #            field_value = self.with_substitutions(
+    #                filter_by["field_value"], substitution_variables
+    #            )
+    #            if operator == "equals":
+    ##                if str(process_instance_dict.get(field_name)) != str(field_value):
+    #                    return False
+    #
+    #    return True

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_report_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_report_service.py
@@ -1,10 +1,16 @@
+"""process_instance_report_service."""
 from dataclasses import dataclass
 from typing import Optional
 
-from spiffworkflow_backend.models.process_instance_report import ProcessInstanceReportModel
+from spiffworkflow_backend.models.process_instance_report import (
+    ProcessInstanceReportModel,
+)
+
 
 @dataclass
 class ProcessInstanceReportFilter:
+    """ProcessInstanceReportFilter."""
+
     process_model_identifier: Optional[str] = None
     start_from: Optional[int] = None
     start_to: Optional[int] = None
@@ -12,10 +18,15 @@ class ProcessInstanceReportFilter:
     end_to: Optional[int] = None
     process_status: Optional[list[str]] = None
 
+
 class ProcessInstanceReportService:
     """ProcessInstanceReportService."""
+
     @classmethod
-    def filter_from_metadata(cls, process_instance_report: ProcessInstanceReportModel) -> ProcessInstanceReportFilter:
+    def filter_from_metadata(
+        cls, process_instance_report: ProcessInstanceReportModel
+    ) -> ProcessInstanceReportFilter:
+        """Filter_from_metadata."""
         process_model_identifier: Optional[str] = None
         start_from: Optional[int] = None
         start_to: Optional[int] = None
@@ -24,8 +35,8 @@ class ProcessInstanceReportService:
         process_status: Optional[list[str]] = None
 
         metadata = process_instance_report.report_metadata
-        if "filter_by" in metadata:
-            pass
+        filter_by = metadata.get("filter_by", [])
+        filters = {k: v for filter_dict in filter_by for k, v in filter_dict.items()}
 
         process_instance_report_filter = ProcessInstanceReportFilter(
             process_model_identifier,
@@ -35,12 +46,12 @@ class ProcessInstanceReportService:
             end_to,
             process_status,
         )
-        
+
         return process_instance_report_filter
 
-    #def passes_filter(
+    # def passes_filter(
     #    self, process_instance_dict: dict, substitution_variables: dict
-    #) -> bool:
+    # ) -> bool:
     #    """Passes_filter."""
     #    if "filter_by" in self.report_metadata:
     #        for filter_by in self.report_metadata["filter_by"]:
@@ -50,7 +61,7 @@ class ProcessInstanceReportService:
     #                filter_by["field_value"], substitution_variables
     #            )
     #            if operator == "equals":
-    ##                if str(process_instance_dict.get(field_name)) != str(field_value):
+    # if str(process_instance_dict.get(field_name)) != str(field_value):
     #                    return False
     #
     #    return True

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_report_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_report_service.py
@@ -1,7 +1,8 @@
 """Test_process_instance_report_service."""
+from typing import Optional
+
 from flask import Flask
 from flask.testing import FlaskClient
-from typing import Optional
 from tests.spiffworkflow_backend.helpers.base_test import BaseTest
 
 from spiffworkflow_backend.models.process_instance_report import (
@@ -31,7 +32,7 @@ class TestProcessInstanceReportService(BaseTest):
         return ProcessInstanceReportService.filter_from_metadata(report)
 
     def _filter_from_metadata_with_overrides(
-        self, 
+        self,
         report_metadata: dict,
         process_model_identifier: Optional[str] = None,
         start_from: Optional[int] = None,
@@ -46,13 +47,15 @@ class TestProcessInstanceReportService(BaseTest):
             created_by_id=1,
             report_metadata=report_metadata,
         )
-        return ProcessInstanceReportService.filter_from_metadata_with_overrides(report,
+        return ProcessInstanceReportService.filter_from_metadata_with_overrides(
+            report,
             process_model_identifier,
             start_from,
             start_to,
             end_from,
             end_to,
-            process_status)
+            process_status,
+        )
 
     def _filter_by_dict_from_metadata(self, report_metadata: dict) -> dict[str, str]:
         """Docstring."""
@@ -461,7 +464,9 @@ class TestProcessInstanceReportService(BaseTest):
         report_filter = self._filter_from_metadata_with_overrides(
             {
                 "columns": [],
-                "filter_by": [{"field_name": "process_model_identifier", "field_value": "bob"}]
+                "filter_by": [
+                    {"field_name": "process_model_identifier", "field_value": "bob"}
+                ],
             },
             process_model_identifier="joe",
         )
@@ -484,7 +489,7 @@ class TestProcessInstanceReportService(BaseTest):
         report_filter = self._filter_from_metadata_with_overrides(
             {
                 "columns": [],
-                "filter_by": [{"field_name": "start_from", "field_value": "123"}]
+                "filter_by": [{"field_name": "start_from", "field_value": "123"}],
             },
             start_from=321,
         )
@@ -507,7 +512,7 @@ class TestProcessInstanceReportService(BaseTest):
         report_filter = self._filter_from_metadata_with_overrides(
             {
                 "columns": [],
-                "filter_by": [{"field_name": "start_to", "field_value": "123"}]
+                "filter_by": [{"field_name": "start_to", "field_value": "123"}],
             },
             start_to=321,
         )
@@ -530,7 +535,7 @@ class TestProcessInstanceReportService(BaseTest):
         report_filter = self._filter_from_metadata_with_overrides(
             {
                 "columns": [],
-                "filter_by": [{"field_name": "end_from", "field_value": "123"}]
+                "filter_by": [{"field_name": "end_from", "field_value": "123"}],
             },
             end_from=321,
         )
@@ -553,7 +558,7 @@ class TestProcessInstanceReportService(BaseTest):
         report_filter = self._filter_from_metadata_with_overrides(
             {
                 "columns": [],
-                "filter_by": [{"field_name": "end_to", "field_value": "123"}]
+                "filter_by": [{"field_name": "end_to", "field_value": "123"}],
             },
             end_to=321,
         )
@@ -576,7 +581,9 @@ class TestProcessInstanceReportService(BaseTest):
         report_filter = self._filter_from_metadata_with_overrides(
             {
                 "columns": [],
-                "filter_by": [{"field_name": "process_status", "field_value": "joe,bob"}]
+                "filter_by": [
+                    {"field_name": "process_status", "field_value": "joe,bob"}
+                ],
             },
             process_status="sue",
         )
@@ -599,7 +606,7 @@ class TestProcessInstanceReportService(BaseTest):
         report_filter = self._filter_from_metadata_with_overrides(
             {
                 "columns": [],
-                "filter_by": [{"field_name": "process_status", "field_value": "sue"}]
+                "filter_by": [{"field_name": "process_status", "field_value": "sue"}],
             },
             process_status="joe,bob",
         )

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_report_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_report_service.py
@@ -3,23 +3,31 @@ from flask import Flask
 from flask.testing import FlaskClient
 from tests.spiffworkflow_backend.helpers.base_test import BaseTest
 
-from spiffworkflow_backend.models.process_instance_report import ProcessInstanceReportModel
+from spiffworkflow_backend.models.process_instance_report import (
+    ProcessInstanceReportModel,
+)
 from spiffworkflow_backend.models.user import UserModel
-from spiffworkflow_backend.services.process_instance_report_service import ProcessInstanceReportFilter
-from spiffworkflow_backend.services.process_instance_report_service import ProcessInstanceReportService
+from spiffworkflow_backend.services.process_instance_report_service import (
+    ProcessInstanceReportFilter,
+)
+from spiffworkflow_backend.services.process_instance_report_service import (
+    ProcessInstanceReportService,
+)
 
 
 class TestProcessInstanceReportService(BaseTest):
     """TestProcessInstanceReportService."""
 
-    def _filter_from_metadata(self, report_metadata: dict) -> ProcessInstanceReportFilter:
+    def _filter_from_metadata(
+        self, report_metadata: dict
+    ) -> ProcessInstanceReportFilter:
+        """_filter_from_metadata."""
         report = ProcessInstanceReportModel(
             identifier="test",
             created_by_id=1,
             report_metadata=report_metadata,
         )
         return ProcessInstanceReportService.filter_from_metadata(report)
-
 
     def test_report_with_no_filter(
         self,
@@ -29,9 +37,11 @@ class TestProcessInstanceReportService(BaseTest):
         with_super_admin_user: UserModel,
     ) -> None:
         """Docstring."""
-        report_filter = self._filter_from_metadata({
-            "columns": [],
-        })
+        report_filter = self._filter_from_metadata(
+            {
+                "columns": [],
+            }
+        )
 
         assert report_filter.process_model_identifier is None
         assert report_filter.start_from is None
@@ -48,10 +58,12 @@ class TestProcessInstanceReportService(BaseTest):
         with_super_admin_user: UserModel,
     ) -> None:
         """Docstring."""
-        report_filter = self._filter_from_metadata({
-            "columns": [],
-            "filter_by": [],
-        })
+        report_filter = self._filter_from_metadata(
+            {
+                "columns": [],
+                "filter_by": [],
+            }
+        )
 
         assert report_filter.process_model_identifier is None
         assert report_filter.start_from is None
@@ -68,10 +80,12 @@ class TestProcessInstanceReportService(BaseTest):
         with_super_admin_user: UserModel,
     ) -> None:
         """Docstring."""
-        report_filter = self._filter_from_metadata({
-            "columns": [],
-            "filter_by": [{"field_name": "bob", "field_value": "joe"}],
-        })
+        report_filter = self._filter_from_metadata(
+            {
+                "columns": [],
+                "filter_by": [{"field_name": "bob", "field_value": "joe"}],
+            }
+        )
 
         assert report_filter.process_model_identifier is None
         assert report_filter.start_from is None
@@ -88,10 +102,12 @@ class TestProcessInstanceReportService(BaseTest):
         with_super_admin_user: UserModel,
     ) -> None:
         """Docstring."""
-        report_filter = self._filter_from_metadata({
-            "columns": [],
-            "filter_by": [{"_name": "bob", "_value": "joe"}],
-        })
+        report_filter = self._filter_from_metadata(
+            {
+                "columns": [],
+                "filter_by": [{"_name": "bob", "_value": "joe"}],
+            }
+        )
 
         assert report_filter.process_model_identifier is None
         assert report_filter.start_from is None
@@ -108,10 +124,14 @@ class TestProcessInstanceReportService(BaseTest):
         with_super_admin_user: UserModel,
     ) -> None:
         """Docstring."""
-        report_filter = self._filter_from_metadata({
-            "columns": [],
-            "filter_by": [{"field_name": "process_model_identifier", "field_value": "bob"}],
-        })
+        report_filter = self._filter_from_metadata(
+            {
+                "columns": [],
+                "filter_by": [
+                    {"field_name": "process_model_identifier", "field_value": "bob"}
+                ],
+            }
+        )
 
         assert report_filter.process_model_identifier == "bob"
         assert report_filter.start_from is None
@@ -128,10 +148,12 @@ class TestProcessInstanceReportService(BaseTest):
         with_super_admin_user: UserModel,
     ) -> None:
         """Docstring."""
-        report_filter = self._filter_from_metadata({
-            "columns": [],
-            "filter_by": [{"field_name": "start_from", "field_value": "1234"}],
-        })
+        report_filter = self._filter_from_metadata(
+            {
+                "columns": [],
+                "filter_by": [{"field_name": "start_from", "field_value": "1234"}],
+            }
+        )
 
         assert report_filter.process_model_identifier is None
         assert report_filter.start_from == 1234
@@ -148,10 +170,12 @@ class TestProcessInstanceReportService(BaseTest):
         with_super_admin_user: UserModel,
     ) -> None:
         """Docstring."""
-        report_filter = self._filter_from_metadata({
-            "columns": [],
-            "filter_by": [{"field_name": "start_to", "field_value": "1234"}],
-        })
+        report_filter = self._filter_from_metadata(
+            {
+                "columns": [],
+                "filter_by": [{"field_name": "start_to", "field_value": "1234"}],
+            }
+        )
 
         assert report_filter.process_model_identifier is None
         assert report_filter.start_from is None
@@ -168,10 +192,12 @@ class TestProcessInstanceReportService(BaseTest):
         with_super_admin_user: UserModel,
     ) -> None:
         """Docstring."""
-        report_filter = self._filter_from_metadata({
-            "columns": [],
-            "filter_by": [{"field_name": "end_from", "field_value": "1234"}],
-        })
+        report_filter = self._filter_from_metadata(
+            {
+                "columns": [],
+                "filter_by": [{"field_name": "end_from", "field_value": "1234"}],
+            }
+        )
 
         assert report_filter.process_model_identifier is None
         assert report_filter.start_from is None
@@ -188,10 +214,12 @@ class TestProcessInstanceReportService(BaseTest):
         with_super_admin_user: UserModel,
     ) -> None:
         """Docstring."""
-        report_filter = self._filter_from_metadata({
-            "columns": [],
-            "filter_by": [{"field_name": "end_to", "field_value": "1234"}],
-        })
+        report_filter = self._filter_from_metadata(
+            {
+                "columns": [],
+                "filter_by": [{"field_name": "end_to", "field_value": "1234"}],
+            }
+        )
 
         assert report_filter.process_model_identifier is None
         assert report_filter.start_from is None
@@ -208,10 +236,12 @@ class TestProcessInstanceReportService(BaseTest):
         with_super_admin_user: UserModel,
     ) -> None:
         """Docstring."""
-        report_filter = self._filter_from_metadata({
-            "columns": [],
-            "filter_by": [{"field_name": "process_status", "field_value": "ready"}],
-        })
+        report_filter = self._filter_from_metadata(
+            {
+                "columns": [],
+                "filter_by": [{"field_name": "process_status", "field_value": "ready"}],
+            }
+        )
 
         assert report_filter.process_model_identifier is None
         assert report_filter.start_from is None
@@ -228,10 +258,17 @@ class TestProcessInstanceReportService(BaseTest):
         with_super_admin_user: UserModel,
     ) -> None:
         """Docstring."""
-        report_filter = self._filter_from_metadata({
-            "columns": [],
-            "filter_by": [{"field_name": "process_status", "field_value": "ready,completed,other"}],
-        })
+        report_filter = self._filter_from_metadata(
+            {
+                "columns": [],
+                "filter_by": [
+                    {
+                        "field_name": "process_status",
+                        "field_value": "ready,completed,other",
+                    }
+                ],
+            }
+        )
 
         assert report_filter.process_model_identifier is None
         assert report_filter.start_from is None
@@ -239,4 +276,3 @@ class TestProcessInstanceReportService(BaseTest):
         assert report_filter.end_from is None
         assert report_filter.end_to is None
         assert report_filter.process_status == ["ready", "completed", "other"]
-

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_report_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_report_service.py
@@ -28,7 +28,7 @@ class TestProcessInstanceReportService(BaseTest):
         with_db_and_bpmn_file_cleanup: None,
         with_super_admin_user: UserModel,
     ) -> None:
-        """Test_report_with_no_filter."""
+        """Docstring."""
         report_filter = self._filter_from_metadata({
             "columns": [],
         })
@@ -47,7 +47,7 @@ class TestProcessInstanceReportService(BaseTest):
         with_db_and_bpmn_file_cleanup: None,
         with_super_admin_user: UserModel,
     ) -> None:
-        """Test_report_with_no_filter."""
+        """Docstring."""
         report_filter = self._filter_from_metadata({
             "columns": [],
             "filter_by": [],
@@ -59,4 +59,184 @@ class TestProcessInstanceReportService(BaseTest):
         assert report_filter.end_from is None
         assert report_filter.end_to is None
         assert report_filter.process_status is None
+
+    def test_report_with_unknown_filter_field_name(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        report_filter = self._filter_from_metadata({
+            "columns": [],
+            "filter_by": [{"field_name": "bob", "field_value": "joe"}],
+        })
+
+        assert report_filter.process_model_identifier is None
+        assert report_filter.start_from is None
+        assert report_filter.start_to is None
+        assert report_filter.end_from is None
+        assert report_filter.end_to is None
+        assert report_filter.process_status is None
+
+    def test_report_with_unknown_filter_keys(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        report_filter = self._filter_from_metadata({
+            "columns": [],
+            "filter_by": [{"_name": "bob", "_value": "joe"}],
+        })
+
+        assert report_filter.process_model_identifier is None
+        assert report_filter.start_from is None
+        assert report_filter.start_to is None
+        assert report_filter.end_from is None
+        assert report_filter.end_to is None
+        assert report_filter.process_status is None
+
+    def test_report_with_process_model_identifier_filter(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        report_filter = self._filter_from_metadata({
+            "columns": [],
+            "filter_by": [{"field_name": "process_model_identifier", "field_value": "bob"}],
+        })
+
+        assert report_filter.process_model_identifier == "bob"
+        assert report_filter.start_from is None
+        assert report_filter.start_to is None
+        assert report_filter.end_from is None
+        assert report_filter.end_to is None
+        assert report_filter.process_status is None
+
+    def test_report_with_start_from_filter(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        report_filter = self._filter_from_metadata({
+            "columns": [],
+            "filter_by": [{"field_name": "start_from", "field_value": "1234"}],
+        })
+
+        assert report_filter.process_model_identifier is None
+        assert report_filter.start_from == 1234
+        assert report_filter.start_to is None
+        assert report_filter.end_from is None
+        assert report_filter.end_to is None
+        assert report_filter.process_status is None
+
+    def test_report_with_start_to_filter(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        report_filter = self._filter_from_metadata({
+            "columns": [],
+            "filter_by": [{"field_name": "start_to", "field_value": "1234"}],
+        })
+
+        assert report_filter.process_model_identifier is None
+        assert report_filter.start_from is None
+        assert report_filter.start_to == 1234
+        assert report_filter.end_from is None
+        assert report_filter.end_to is None
+        assert report_filter.process_status is None
+
+    def test_report_with_end_from_filter(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        report_filter = self._filter_from_metadata({
+            "columns": [],
+            "filter_by": [{"field_name": "end_from", "field_value": "1234"}],
+        })
+
+        assert report_filter.process_model_identifier is None
+        assert report_filter.start_from is None
+        assert report_filter.start_to is None
+        assert report_filter.end_from == 1234
+        assert report_filter.end_to is None
+        assert report_filter.process_status is None
+
+    def test_report_with_end_to_filter(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        report_filter = self._filter_from_metadata({
+            "columns": [],
+            "filter_by": [{"field_name": "end_to", "field_value": "1234"}],
+        })
+
+        assert report_filter.process_model_identifier is None
+        assert report_filter.start_from is None
+        assert report_filter.start_to is None
+        assert report_filter.end_from is None
+        assert report_filter.end_to == 1234
+        assert report_filter.process_status is None
+
+    def test_report_with_single_startus_filter(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        report_filter = self._filter_from_metadata({
+            "columns": [],
+            "filter_by": [{"field_name": "process_status", "field_value": "ready"}],
+        })
+
+        assert report_filter.process_model_identifier is None
+        assert report_filter.start_from is None
+        assert report_filter.start_to is None
+        assert report_filter.end_from is None
+        assert report_filter.end_to is None
+        assert report_filter.process_status == ["ready"]
+
+    def test_report_with_multiple_startus_filters(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        report_filter = self._filter_from_metadata({
+            "columns": [],
+            "filter_by": [{"field_name": "process_status", "field_value": "ready,completed,other"}],
+        })
+
+        assert report_filter.process_model_identifier is None
+        assert report_filter.start_from is None
+        assert report_filter.start_to is None
+        assert report_filter.end_from is None
+        assert report_filter.end_to is None
+        assert report_filter.process_status == ["ready", "completed", "other"]
 

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_report_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_report_service.py
@@ -21,13 +21,94 @@ class TestProcessInstanceReportService(BaseTest):
     def _filter_from_metadata(
         self, report_metadata: dict
     ) -> ProcessInstanceReportFilter:
-        """_filter_from_metadata."""
+        """Docstring."""
         report = ProcessInstanceReportModel(
             identifier="test",
             created_by_id=1,
             report_metadata=report_metadata,
         )
         return ProcessInstanceReportService.filter_from_metadata(report)
+
+    def _filter_by_dict_from_metadata(
+        self, report_metadata: dict
+    ) -> ProcessInstanceReportFilter:
+        """Docstring."""
+        report = ProcessInstanceReportModel(
+            identifier="test",
+            created_by_id=1,
+            report_metadata=report_metadata,
+        )
+        return ProcessInstanceReportService.filter_by_to_dict(report)
+
+    def test_filter_by_to_dict_no_filter_by(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        filters = self._filter_by_dict_from_metadata(
+            {
+                "columns": [],
+            }
+        )
+
+        assert filters == {}
+
+    def test_filter_by_to_dict_empty_filter_by(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        filters = self._filter_by_dict_from_metadata(
+            {
+                "columns": [],
+                "filter_by": [],
+            }
+        )
+
+        assert filters == {}
+
+    def test_filter_by_to_dict_single_filter_by(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        filters = self._filter_by_dict_from_metadata(
+            {
+                "columns": [],
+                "filter_by": [{"field_name": "end_to", "field_value": "1234"}],
+            }
+        )
+
+        assert filters == {"end_to": "1234"}
+
+    def test_filter_by_to_dict_mulitple_filter_by(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        filters = self._filter_by_dict_from_metadata(
+            {
+                "columns": [],
+                "filter_by": [
+                    {"field_name": "end_to", "field_value": "1234"},
+                    {"field_name": "end_from", "field_value": "4321"},
+                ],
+            }
+        )
+
+        assert filters == {"end_to": "1234", "end_from": "4321"}
 
     def test_report_with_no_filter(
         self,

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_report_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_report_service.py
@@ -1,6 +1,7 @@
 """Test_process_instance_report_service."""
 from flask import Flask
 from flask.testing import FlaskClient
+from typing import Optional
 from tests.spiffworkflow_backend.helpers.base_test import BaseTest
 
 from spiffworkflow_backend.models.process_instance_report import (
@@ -28,6 +29,30 @@ class TestProcessInstanceReportService(BaseTest):
             report_metadata=report_metadata,
         )
         return ProcessInstanceReportService.filter_from_metadata(report)
+
+    def _filter_from_metadata_with_overrides(
+        self, 
+        report_metadata: dict,
+        process_model_identifier: Optional[str] = None,
+        start_from: Optional[int] = None,
+        start_to: Optional[int] = None,
+        end_from: Optional[int] = None,
+        end_to: Optional[int] = None,
+        process_status: Optional[str] = None,
+    ) -> ProcessInstanceReportFilter:
+        """Docstring."""
+        report = ProcessInstanceReportModel(
+            identifier="test",
+            created_by_id=1,
+            report_metadata=report_metadata,
+        )
+        return ProcessInstanceReportService.filter_from_metadata_with_overrides(report,
+            process_model_identifier,
+            start_from,
+            start_to,
+            end_from,
+            end_to,
+            process_status)
 
     def _filter_by_dict_from_metadata(self, report_metadata: dict) -> dict[str, str]:
         """Docstring."""
@@ -355,3 +380,285 @@ class TestProcessInstanceReportService(BaseTest):
         assert report_filter.end_from is None
         assert report_filter.end_to is None
         assert report_filter.process_status == ["ready", "completed", "other"]
+
+    def test_report_with_multiple_filters(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        report_filter = self._filter_from_metadata(
+            {
+                "columns": [],
+                "filter_by": [
+                    {"field_name": "start_from", "field_value": "44"},
+                    {"field_name": "end_from", "field_value": "55"},
+                    {"field_name": "process_status", "field_value": "ready"},
+                ],
+            }
+        )
+
+        assert report_filter.process_model_identifier is None
+        assert report_filter.start_from == 44
+        assert report_filter.start_to is None
+        assert report_filter.end_from == 55
+        assert report_filter.end_to is None
+        assert report_filter.process_status == ["ready"]
+
+    def test_report_no_override_with_no_filter(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        report_filter = self._filter_from_metadata_with_overrides(
+            {
+                "columns": [],
+            },
+        )
+
+        assert report_filter.process_model_identifier is None
+        assert report_filter.start_from is None
+        assert report_filter.start_to is None
+        assert report_filter.end_from is None
+        assert report_filter.end_to is None
+        assert report_filter.process_status is None
+
+    def test_report_override_with_no_filter(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        report_filter = self._filter_from_metadata_with_overrides(
+            {
+                "columns": [],
+            },
+            end_to=54321,
+        )
+
+        assert report_filter.process_model_identifier is None
+        assert report_filter.start_from is None
+        assert report_filter.start_to is None
+        assert report_filter.end_from is None
+        assert report_filter.end_to == 54321
+        assert report_filter.process_status is None
+
+    def test_report_override_process_model_identifier_filter(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        report_filter = self._filter_from_metadata_with_overrides(
+            {
+                "columns": [],
+                "filter_by": [{"field_name": "process_model_identifier", "field_value": "bob"}]
+            },
+            process_model_identifier="joe",
+        )
+
+        assert report_filter.process_model_identifier == "joe"
+        assert report_filter.start_from is None
+        assert report_filter.start_to is None
+        assert report_filter.end_from is None
+        assert report_filter.end_to is None
+        assert report_filter.process_status is None
+
+    def test_report_override_start_from_filter(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        report_filter = self._filter_from_metadata_with_overrides(
+            {
+                "columns": [],
+                "filter_by": [{"field_name": "start_from", "field_value": "123"}]
+            },
+            start_from=321,
+        )
+
+        assert report_filter.process_model_identifier is None
+        assert report_filter.start_from == 321
+        assert report_filter.start_to is None
+        assert report_filter.end_from is None
+        assert report_filter.end_to is None
+        assert report_filter.process_status is None
+
+    def test_report_override_start_to_filter(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        report_filter = self._filter_from_metadata_with_overrides(
+            {
+                "columns": [],
+                "filter_by": [{"field_name": "start_to", "field_value": "123"}]
+            },
+            start_to=321,
+        )
+
+        assert report_filter.process_model_identifier is None
+        assert report_filter.start_from is None
+        assert report_filter.start_to == 321
+        assert report_filter.end_from is None
+        assert report_filter.end_to is None
+        assert report_filter.process_status is None
+
+    def test_report_override_end_from_filter(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        report_filter = self._filter_from_metadata_with_overrides(
+            {
+                "columns": [],
+                "filter_by": [{"field_name": "end_from", "field_value": "123"}]
+            },
+            end_from=321,
+        )
+
+        assert report_filter.process_model_identifier is None
+        assert report_filter.start_from is None
+        assert report_filter.start_to is None
+        assert report_filter.end_from == 321
+        assert report_filter.end_to is None
+        assert report_filter.process_status is None
+
+    def test_report_override_end_to_filter(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        report_filter = self._filter_from_metadata_with_overrides(
+            {
+                "columns": [],
+                "filter_by": [{"field_name": "end_to", "field_value": "123"}]
+            },
+            end_to=321,
+        )
+
+        assert report_filter.process_model_identifier is None
+        assert report_filter.start_from is None
+        assert report_filter.start_to is None
+        assert report_filter.end_from is None
+        assert report_filter.end_to == 321
+        assert report_filter.process_status is None
+
+    def test_report_override_process_status_filter(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        report_filter = self._filter_from_metadata_with_overrides(
+            {
+                "columns": [],
+                "filter_by": [{"field_name": "process_status", "field_value": "joe,bob"}]
+            },
+            process_status="sue",
+        )
+
+        assert report_filter.process_model_identifier is None
+        assert report_filter.start_from is None
+        assert report_filter.start_to is None
+        assert report_filter.end_from is None
+        assert report_filter.end_to is None
+        assert report_filter.process_status == ["sue"]
+
+    def test_report_override_mulitple_process_status_filter(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        report_filter = self._filter_from_metadata_with_overrides(
+            {
+                "columns": [],
+                "filter_by": [{"field_name": "process_status", "field_value": "sue"}]
+            },
+            process_status="joe,bob",
+        )
+
+        assert report_filter.process_model_identifier is None
+        assert report_filter.start_from is None
+        assert report_filter.start_to is None
+        assert report_filter.end_from is None
+        assert report_filter.end_to is None
+        assert report_filter.process_status == ["joe", "bob"]
+
+    def test_report_override_does_not_override_other_filters(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        report_filter = self._filter_from_metadata_with_overrides(
+            {
+                "columns": [],
+                "filter_by": [
+                    {"field_name": "process_model_identifier", "field_value": "sue"},
+                    {"field_name": "process_status", "field_value": "sue"},
+                ],
+            },
+            process_status="joe,bob",
+        )
+
+        assert report_filter.process_model_identifier == "sue"
+        assert report_filter.start_from is None
+        assert report_filter.start_to is None
+        assert report_filter.end_from is None
+        assert report_filter.end_to is None
+        assert report_filter.process_status == ["joe", "bob"]
+
+    def test_report_override_of_none_does_not_override_filter(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        report_filter = self._filter_from_metadata_with_overrides(
+            {
+                "columns": [],
+                "filter_by": [
+                    {"field_name": "process_model_identifier", "field_value": "sue"},
+                    {"field_name": "process_status", "field_value": "sue"},
+                ],
+            },
+            process_status=None,
+        )
+
+        assert report_filter.process_model_identifier == "sue"
+        assert report_filter.start_from is None
+        assert report_filter.start_to is None
+        assert report_filter.end_from is None
+        assert report_filter.end_to is None
+        assert report_filter.process_status == ["sue"]

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_report_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_report_service.py
@@ -29,9 +29,7 @@ class TestProcessInstanceReportService(BaseTest):
         )
         return ProcessInstanceReportService.filter_from_metadata(report)
 
-    def _filter_by_dict_from_metadata(
-        self, report_metadata: dict
-    ) -> ProcessInstanceReportFilter:
+    def _filter_by_dict_from_metadata(self, report_metadata: dict) -> dict[str, str]:
         """Docstring."""
         report = ProcessInstanceReportModel(
             identifier="test",

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_report_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_report_service.py
@@ -1,0 +1,62 @@
+"""Test_process_instance_report_service."""
+from flask import Flask
+from flask.testing import FlaskClient
+from tests.spiffworkflow_backend.helpers.base_test import BaseTest
+
+from spiffworkflow_backend.models.process_instance_report import ProcessInstanceReportModel
+from spiffworkflow_backend.models.user import UserModel
+from spiffworkflow_backend.services.process_instance_report_service import ProcessInstanceReportFilter
+from spiffworkflow_backend.services.process_instance_report_service import ProcessInstanceReportService
+
+
+class TestProcessInstanceReportService(BaseTest):
+    """TestProcessInstanceReportService."""
+
+    def _filter_from_metadata(self, report_metadata: dict) -> ProcessInstanceReportFilter:
+        report = ProcessInstanceReportModel(
+            identifier="test",
+            created_by_id=1,
+            report_metadata=report_metadata,
+        )
+        return ProcessInstanceReportService.filter_from_metadata(report)
+
+
+    def test_report_with_no_filter(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Test_report_with_no_filter."""
+        report_filter = self._filter_from_metadata({
+            "columns": [],
+        })
+
+        assert report_filter.process_model_identifier is None
+        assert report_filter.start_from is None
+        assert report_filter.start_to is None
+        assert report_filter.end_from is None
+        assert report_filter.end_to is None
+        assert report_filter.process_status is None
+
+    def test_report_with_empty_filter(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Test_report_with_no_filter."""
+        report_filter = self._filter_from_metadata({
+            "columns": [],
+            "filter_by": [],
+        })
+
+        assert report_filter.process_model_identifier is None
+        assert report_filter.start_from is None
+        assert report_filter.start_to is None
+        assert report_filter.end_from is None
+        assert report_filter.end_to is None
+        assert report_filter.process_status is None
+


### PR DESCRIPTION
This is a much more straightforward approach that what I was trying to do yesterday. If there is a default report, parse its `filter_by` and overlay the individual filter query params passed into `process_instance_list`. This also means report filtering is done in the db the same was as if you entered a filter manually in the UI. This does not currently support filtering on task data. I also dropped handling of the filter comparison since the `process_instance_list` query filters have an assumed comparison operator.

Next I'd like to serialize the combined filters and send that in the response so the UI can populate the filters appropriately if a report is in play.