### PR TITLE
Don't die trying to remove correlation properties

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/data_setup_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/data_setup_service.py
@@ -29,7 +29,7 @@ class DataSetupService:
         process_models = ProcessModelService().get_process_models()
         for process_model in process_models:
             current_app.logger.debug(f"Process Model: {process_model.display_name}")
-
+            SpecFileService.clear_caches()
             try:
                 refs = SpecFileService.get_references_for_process(process_model)
                 for ref in refs:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/spec_file_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/spec_file_service.py
@@ -253,9 +253,7 @@ class SpecFileService(FileSystemService):
     def clear_caches() -> None:
         """Clear_caches."""
         db.session.query(SpecReferenceCache).delete()
-        db.session.query(MessageCorrelationPropertyModel).delete()
-        db.session.query(MessageTriggerableProcessModel).delete()
-        db.session.query(MessageModel).delete()
+        # fixme:  likely the other caches should be cleared as well, but we don't have a clean way to do so yet.
 
     @staticmethod
     def update_process_cache(ref: SpecReference) -> None:


### PR DESCRIPTION
It's good to clear out he cache, but we can't do that with correlation properties due to foreign key constraints that are built up over time.  So we'll just leave bad messages and correlations in the database for now -- we aren't doing a lot with messages yet anyway.