### PR TITLE
Send filters used in process_instance_list to the front end

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
@@ -439,6 +439,12 @@ paths:
         description: For filtering - not_started, user_input_required, waiting, complete, error, or suspended
         schema:
           type: string
+      - name: user_filter
+        in: query
+        required: false
+        description: For filtering - indicates the user has manually entered a query
+        schema:
+          type: boolean
     # process_instance_list
     get:
       operationId: spiffworkflow_backend.routes.process_api_blueprint.process_instance_list

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
@@ -73,8 +73,10 @@ from spiffworkflow_backend.services.process_instance_processor import (
     ProcessInstanceProcessor,
 )
 from spiffworkflow_backend.services.process_instance_report_service import (
-    ProcessInstanceReportService,
     ProcessInstanceReportFilter,
+)
+from spiffworkflow_backend.services.process_instance_report_service import (
+    ProcessInstanceReportService,
 )
 from spiffworkflow_backend.services.process_instance_service import (
     ProcessInstanceService,
@@ -750,14 +752,16 @@ def process_instance_list(
             process_status.split(",") if process_status else None,
         )
     else:
-        report_filter = ProcessInstanceReportService.filter_from_metadata_with_overrides(
-            process_instance_report,
-            process_model_identifier,
-            start_from,
-            start_to,
-            end_from,
-            end_to,
-            process_status,
+        report_filter = (
+            ProcessInstanceReportService.filter_from_metadata_with_overrides(
+                process_instance_report,
+                process_model_identifier,
+                start_from,
+                start_to,
+                end_from,
+                end_to,
+                process_status,
+            )
         )
 
     # process_model_identifier = un_modify_modified_process_model_id(modified_process_model_identifier)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
@@ -747,7 +747,7 @@ def process_instance_list(
             start_to,
             end_from,
             end_to,
-            process_status,
+            process_status.split(",") if process_status else None,
         )
     else:
         report_filter = ProcessInstanceReportService.filter_from_metadata_with_overrides(

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
@@ -74,6 +74,7 @@ from spiffworkflow_backend.services.process_instance_processor import (
 )
 from spiffworkflow_backend.services.process_instance_report_service import (
     ProcessInstanceReportService,
+    ProcessInstanceReportFilter,
 )
 from spiffworkflow_backend.services.process_instance_service import (
     ProcessInstanceService,
@@ -732,18 +733,32 @@ def process_instance_list(
     end_from: Optional[int] = None,
     end_to: Optional[int] = None,
     process_status: Optional[str] = None,
+    user_filter: Optional[bool] = False,
 ) -> flask.wrappers.Response:
     """Process_instance_list."""
     process_instance_report = ProcessInstanceReportModel.default_report(g.user)
-    report_filter = ProcessInstanceReportService.filter_from_metadata_with_overrides(
-        process_instance_report,
-        process_model_identifier,
-        start_from,
-        start_to,
-        end_from,
-        end_to,
-        process_status,
-    )
+
+    print(f"user_filter: {user_filter}")
+
+    if user_filter:
+        report_filter = ProcessInstanceReportFilter(
+            process_model_identifier,
+            start_from,
+            start_to,
+            end_from,
+            end_to,
+            process_status,
+        )
+    else:
+        report_filter = ProcessInstanceReportService.filter_from_metadata_with_overrides(
+            process_instance_report,
+            process_model_identifier,
+            start_from,
+            start_to,
+            end_from,
+            end_to,
+            process_status,
+        )
 
     # process_model_identifier = un_modify_modified_process_model_id(modified_process_model_identifier)
     process_instance_query = ProcessInstanceModel.query

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
@@ -805,6 +805,7 @@ def process_instance_list(
     response_json = {
         "report_metadata": report_metadata,
         "results": results,
+        "filters": report_filter.to_dict(),
         "pagination": {
             "count": len(results),
             "total": process_instances.total,

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
@@ -740,8 +740,6 @@ def process_instance_list(
     """Process_instance_list."""
     process_instance_report = ProcessInstanceReportModel.default_report(g.user)
 
-    print(f"user_filter: {user_filter}")
-
     if user_filter:
         report_filter = ProcessInstanceReportFilter(
             process_model_identifier,

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_report_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_report_service.py
@@ -18,6 +18,25 @@ class ProcessInstanceReportFilter:
     end_to: Optional[int] = None
     process_status: Optional[list[str]] = None
 
+    def to_dict(self) -> dict[str, str]:
+        """to_dict."""
+        d = {}
+
+        if self.process_model_identifier is not None:
+            d["process_model_identifier"] = self.process_model_identifier
+        if self.start_from is not None:
+            d["start_from"] = str(self.start_from)
+        if self.start_to is not None:
+            d["start_to"] = str(self.start_to)
+        if self.end_from is not None:
+            d["end_from"] = str(self.end_from)
+        if self.end_to is not None:
+            d["end_to"] = str(self.end_to)
+        if self.process_status is not None:
+            d["process_status"] = ",".join(self.process_status)
+
+        return d
+
 
 class ProcessInstanceReportService:
     """ProcessInstanceReportService."""

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_report_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_report_service.py
@@ -19,7 +19,7 @@ class ProcessInstanceReportFilter:
     process_status: Optional[list[str]] = None
 
     def to_dict(self) -> dict[str, str]:
-        """to_dict."""
+        """To_dict."""
         d = {}
 
         if self.process_model_identifier is not None:

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_report_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_report_service.py
@@ -13,8 +13,88 @@ from spiffworkflow_backend.services.process_instance_report_service import (
     ProcessInstanceReportFilter,
 )
 from spiffworkflow_backend.services.process_instance_report_service import (
+    ProcessInstanceReportFilter,
     ProcessInstanceReportService,
 )
+
+
+class TestProcessInstanceReportFilter(BaseTest):
+    """TestProcessInstanceReportFilter."""
+    def test_empty_filter_to_dict(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        d = ProcessInstanceReportFilter().to_dict()
+
+        assert d == {}
+
+    def test_string_value_filter_to_dict(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        d = ProcessInstanceReportFilter(
+            process_model_identifier="bob"
+        ).to_dict()
+
+        assert d == {"process_model_identifier": "bob"}
+
+    def test_int_value_filter_to_dict(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        d = ProcessInstanceReportFilter(
+            start_from=1,
+            start_to=2,
+            end_from=3,
+            end_to=4,
+        ).to_dict()
+
+        assert d == {
+            "start_from": "1",
+            "start_to": "2",
+            "end_from": "3",
+            "end_to": "4",
+        }
+
+    def test_list_single_value_filter_to_dict(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        d = ProcessInstanceReportFilter(
+            process_status=["bob"]
+        ).to_dict()
+
+        assert d == {"process_status": "bob"}
+
+    def test_list_multiple_value_filter_to_dict(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        """Docstring."""
+        d = ProcessInstanceReportFilter(
+            process_status=["joe", "bob", "sue"]
+        ).to_dict()
+
+        assert d == {"process_status": "joe,bob,sue"}
 
 
 class TestProcessInstanceReportService(BaseTest):

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_report_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_report_service.py
@@ -13,13 +13,13 @@ from spiffworkflow_backend.services.process_instance_report_service import (
     ProcessInstanceReportFilter,
 )
 from spiffworkflow_backend.services.process_instance_report_service import (
-    ProcessInstanceReportFilter,
     ProcessInstanceReportService,
 )
 
 
 class TestProcessInstanceReportFilter(BaseTest):
     """TestProcessInstanceReportFilter."""
+
     def test_empty_filter_to_dict(
         self,
         app: Flask,
@@ -40,9 +40,7 @@ class TestProcessInstanceReportFilter(BaseTest):
         with_super_admin_user: UserModel,
     ) -> None:
         """Docstring."""
-        d = ProcessInstanceReportFilter(
-            process_model_identifier="bob"
-        ).to_dict()
+        d = ProcessInstanceReportFilter(process_model_identifier="bob").to_dict()
 
         assert d == {"process_model_identifier": "bob"}
 
@@ -76,9 +74,7 @@ class TestProcessInstanceReportFilter(BaseTest):
         with_super_admin_user: UserModel,
     ) -> None:
         """Docstring."""
-        d = ProcessInstanceReportFilter(
-            process_status=["bob"]
-        ).to_dict()
+        d = ProcessInstanceReportFilter(process_status=["bob"]).to_dict()
 
         assert d == {"process_status": "bob"}
 
@@ -90,9 +86,7 @@ class TestProcessInstanceReportFilter(BaseTest):
         with_super_admin_user: UserModel,
     ) -> None:
         """Docstring."""
-        d = ProcessInstanceReportFilter(
-            process_status=["joe", "bob", "sue"]
-        ).to_dict()
+        d = ProcessInstanceReportFilter(process_status=["joe", "bob", "sue"]).to_dict()
 
         assert d == {"process_status": "joe,bob,sue"}
 

--- a/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
+++ b/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
@@ -215,7 +215,6 @@ export default function ProcessInstanceListTable({
   ]);
 
   useEffect(() => {
-    console.log(processInstanceFilters);
     const filters = processInstanceFilters as any;
     Object.keys(parametersToAlwaysFilterBy).forEach((paramName: string) => {
       // @ts-expect-error TS(7053) FIXME:
@@ -232,9 +231,13 @@ export default function ProcessInstanceListTable({
       (paramName: string) => {
         if (
           paramName === 'process_model_identifier' &&
-          processModelFullIdentifier
+          typeof filters.process_model_identifier === 'string'
         ) {
-          // queryParamString += `&process_model_identifier=${processModelFullIdentifier}`;
+          processModelAvailableItems.forEach((item: any) => {
+            if (item.id === filters.process_model_identifier) {
+              setProcessModelSelection(item);
+            }
+          });
         } else if (
           paramName === 'process_status' &&
           typeof filters.process_status === 'string'
@@ -251,7 +254,12 @@ export default function ProcessInstanceListTable({
         }
       }
     );
-  }, [processInstanceFilters]);
+  }, [
+    processInstanceFilters,
+    parametersToAlwaysFilterBy,
+    parametersToGetFromSearchParams,
+    processModelAvailableItems,
+  ]);
 
   // does the comparison, but also returns false if either argument
   // is not truthy and therefore not comparable.

--- a/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
+++ b/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
@@ -225,6 +225,7 @@ export default function ProcessInstanceListTable({
       // @ts-expect-error TS(7053) FIXME:
       const functionToCall = parametersToAlwaysFilterBy[paramName];
       const paramValue = filters[paramName];
+      functionToCall('');
       if (paramValue) {
         const dateString = convertSecondsToFormattedDate(paramValue as any);
         functionToCall(dateString);
@@ -234,20 +235,19 @@ export default function ProcessInstanceListTable({
 
     Object.keys(parametersToGetFromSearchParams).forEach(
       (paramName: string) => {
-        if (
-          paramName === 'process_model_identifier' &&
-          typeof filters.process_model_identifier === 'string'
-        ) {
+        if (paramName === 'process_model_identifier') {
+          setProcessModelSelection(null);
           processModelAvailableItems.forEach((item: any) => {
             if (item.id === filters.process_model_identifier) {
               setProcessModelSelection(item);
             }
           });
-        } else if (
-          paramName === 'process_status' &&
-          typeof filters.process_status === 'string'
-        ) {
+        } else if (paramName === 'process_status') {
           const processStatusSelectedArray: string[] = [];
+          setProcessStatusSelection(processStatusSelectedArray);
+          if (!filters.process_status) {
+            return;
+          }
           PROCESS_STATUSES.forEach((processStatusOption: any) => {
             const regex = new RegExp(`\\b${processStatusOption}\\b`);
             if (filters.process_status.match(regex)) {

--- a/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
+++ b/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
@@ -125,6 +125,11 @@ export default function ProcessInstanceListTable({
       }
       let queryParamString = `per_page=${perPage}&page=${page}`;
 
+      const userAppliedFilter = searchParams.get('user_filter');
+      if (userAppliedFilter) {
+        queryParamString += `&user_filter=${userAppliedFilter}`;
+      }
+
       Object.keys(parametersToAlwaysFilterBy).forEach((paramName: string) => {
         // @ts-expect-error TS(7053) FIXME:
         const functionToCall = parametersToAlwaysFilterBy[paramName];
@@ -286,7 +291,7 @@ export default function ProcessInstanceListTable({
       undefined,
       paginationQueryParamPrefix
     );
-    let queryParamString = `per_page=${perPage}&page=${page}`;
+    let queryParamString = `per_page=${perPage}&page=${page}&user_filter=true`;
 
     const startFromSeconds = convertDateStringToSeconds(startFrom);
     const endFromSeconds = convertDateStringToSeconds(endFrom);
@@ -338,6 +343,7 @@ export default function ProcessInstanceListTable({
     }
 
     setErrorMessage(null);
+    console.log(queryParamString);
     navigate(`/admin/process-instances?${queryParamString}`);
   };
 

--- a/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
+++ b/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
@@ -233,32 +233,24 @@ export default function ProcessInstanceListTable({
       }
     });
 
-    Object.keys(parametersToGetFromSearchParams).forEach(
-      (paramName: string) => {
-        if (paramName === 'process_model_identifier') {
-          setProcessModelSelection(null);
-          processModelAvailableItems.forEach((item: any) => {
-            if (item.id === filters.process_model_identifier) {
-              setProcessModelSelection(item);
-            }
-          });
-        } else if (paramName === 'process_status') {
-          const processStatusSelectedArray: string[] = [];
-          setProcessStatusSelection(processStatusSelectedArray);
-          if (!filters.process_status) {
-            return;
-          }
-          PROCESS_STATUSES.forEach((processStatusOption: any) => {
-            const regex = new RegExp(`\\b${processStatusOption}\\b`);
-            if (filters.process_status.match(regex)) {
-              processStatusSelectedArray.push(processStatusOption);
-            }
-          });
-          setProcessStatusSelection(processStatusSelectedArray);
-          setShowFilterOptions(true);
-        }
+    setProcessModelSelection(null);
+    processModelAvailableItems.forEach((item: any) => {
+      if (item.id === filters.process_model_identifier) {
+        setProcessModelSelection(item);
       }
-    );
+    });
+
+    const processStatusSelectedArray: string[] = [];
+    if (filters.process_status) {
+      PROCESS_STATUSES.forEach((processStatusOption: any) => {
+        const regex = new RegExp(`\\b${processStatusOption}\\b`);
+        if (filters.process_status.match(regex)) {
+          processStatusSelectedArray.push(processStatusOption);
+        }
+      });
+      setShowFilterOptions(true);
+    }
+    setProcessStatusSelection(processStatusSelectedArray);
   }, [
     processInstanceFilters,
     parametersToAlwaysFilterBy,

--- a/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
+++ b/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
@@ -335,7 +335,6 @@ export default function ProcessInstanceListTable({
     }
 
     setErrorMessage(null);
-    console.log(queryParamString);
     navigate(`/admin/process-instances?${queryParamString}`);
   };
 

--- a/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
+++ b/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
@@ -235,12 +235,18 @@ export default function ProcessInstanceListTable({
           processModelFullIdentifier
         ) {
           // queryParamString += `&process_model_identifier=${processModelFullIdentifier}`;
-        } else if (filters[paramName]) {
-          // @ts-expect-error TS(7053) FIXME:
-          const functionToCall = parametersToGetFromSearchParams[paramName];
-          if (functionToCall !== null) {
-            functionToCall(searchParams.get(paramName) || '');
-          }
+        } else if (
+          paramName === 'process_status' &&
+          typeof filters.process_status === 'string'
+        ) {
+          const processStatusSelectedArray: string[] = [];
+          PROCESS_STATUSES.forEach((processStatusOption: any) => {
+            const regex = new RegExp(`\\b${processStatusOption}\\b`);
+            if (filters.process_status.match(regex)) {
+              processStatusSelectedArray.push(processStatusOption);
+            }
+          });
+          setProcessStatusSelection(processStatusSelectedArray);
           setShowFilterOptions(true);
         }
       }


### PR DESCRIPTION
Allows the filters configured in the current report, if any, to be populated in the filter UI on the process instance list. I ended up having to add a flag to the api call that is set when the user hits filter - else we couldn't distinguish between a clear of part or all of the filter and no filter options being specified. WIthout that, clearing a filter when a report is in play just reset the filter back to whatever the report had specified. Seems to work as expected now.