### PR TITLE
Support reporting on task data

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
@@ -811,18 +811,7 @@ def process_instance_list(
         ProcessInstanceModel.start_in_seconds.desc(), ProcessInstanceModel.id.desc()  # type: ignore
     ).paginate(page=page, per_page=per_page, error_out=False)
 
-    # TODO need to look into test failures when the results from result_dict is
-    # used instead of the process instances
-
-    # substitution_variables = request.args.to_dict()
-    # result_dict = process_instance_report.generate_report(
-    #    process_instances.items, substitution_variables
-    # )
-
-    # results = result_dict["results"]
-    # report_metadata = result_dict["report_metadata"]
-
-    results = process_instances.items
+    results = list(map(ProcessInstanceService.serialize_flat_with_task_data, process_instances.items))
     report_metadata = process_instance_report.report_metadata
 
     response_json = {

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
@@ -811,7 +811,12 @@ def process_instance_list(
         ProcessInstanceModel.start_in_seconds.desc(), ProcessInstanceModel.id.desc()  # type: ignore
     ).paginate(page=page, per_page=per_page, error_out=False)
 
-    results = list(map(ProcessInstanceService.serialize_flat_with_task_data, process_instances.items))
+    results = list(
+        map(
+            ProcessInstanceService.serialize_flat_with_task_data,
+            process_instances.items,
+        )
+    )
     report_metadata = process_instance_report.report_metadata
 
     response_json = {

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
@@ -318,8 +318,8 @@ class ProcessInstanceService:
 
     @staticmethod
     def serialize_flat_with_task_data(
-        process_instance: ProcessInstanceModel
-    ) -> dict[str, any]:
+        process_instance: ProcessInstanceModel,
+    ) -> dict[str, Any]:
         """serialize_flat_with_task_data."""
         results = {}
         try:
@@ -327,8 +327,8 @@ class ProcessInstanceService:
             processor = ProcessInstanceProcessor(process_instance)
             process_instance.data = processor.get_current_data()
             results = process_instance.serialized_flat
-            # this process seems to mutate the status of the process_instance which 
-            # can result in different results than expected from process_instance_list, 
+            # this process seems to mutate the status of the process_instance which
+            # can result in different results than expected from process_instance_list,
             # so set the status back to the expected value
             results["status"] = original_status
         except ApiError:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
@@ -315,3 +315,17 @@ class ProcessInstanceService:
         )
 
         return task
+
+    @staticmethod
+    def serialize_flat_with_task_data(
+        process_instance: ProcessInstanceModel
+    ) -> dict[str, any]:
+        """serialize_flat_with_task_data."""
+        results = {}
+        try:
+            processor = ProcessInstanceProcessor(process_instance)
+            process_instance.data = processor.get_current_data()
+            results = process_instance.serialized_flat
+        except ApiError:
+            results = process_instance.serialized
+        return results

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
@@ -323,9 +323,14 @@ class ProcessInstanceService:
         """serialize_flat_with_task_data."""
         results = {}
         try:
+            original_status = process_instance.status
             processor = ProcessInstanceProcessor(process_instance)
             process_instance.data = processor.get_current_data()
             results = process_instance.serialized_flat
+            # this process seems to mutate the status of the process_instance which 
+            # can result in different results than expected from process_instance_list, 
+            # so set the status back to the expected value
+            results["status"] = original_status
         except ApiError:
             results = process_instance.serialized
         return results


### PR DESCRIPTION
Adds the task data back into the process_instance_list api response when possible. Loading up the process model (hope that is the right way to say this) triggers validation which could fail. In this case we skip merging in the task data so the process instance list table is not bricked in case of a bad bpmn/dmn file. Task data is returned at the root along with the process instance information and can be added to the report columns.