### PR TITLE
add simple refresh capability

### DIFF
--- a/spiffworkflow-frontend/src/helpers.tsx
+++ b/spiffworkflow-frontend/src/helpers.tsx
@@ -197,3 +197,16 @@ export const getGroupFromModifiedModelId = (modifiedId: string) => {
 export const splitProcessModelId = (processModelId: string) => {
   return processModelId.split('/');
 };
+
+export const refreshAtInterval = (
+  interval: number,
+  timeout: number,
+  func: Function
+) => {
+  const intervalRef = setInterval(() => func(), interval * 1000);
+  const timeoutRef = setTimeout(
+    () => clearInterval(intervalRef),
+    timeout * 1000
+  );
+  return [intervalRef, timeoutRef];
+};


### PR DESCRIPTION
After adding the timer, I had to look at a DMN issue and by the time I got back to this, the page had refreshed thousands of times so I added a timeout too.  I think this would be useful on the log page for running processes, but in that scenario there should probably be a button to stop the updates.