### PR TITLE
Accept report_identifier to specify system reports

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
@@ -445,6 +445,12 @@ paths:
         description: For filtering - indicates the user has manually entered a query
         schema:
           type: boolean
+      - name: report_identifier
+        in: query
+        required: false
+        description: Specifies the identifier of a report to use, if any
+        schema:
+          type: string
     get:
       operationId: spiffworkflow_backend.routes.process_api_blueprint.process_instance_list
       summary: Returns a list of process instances for a given process model

--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/process_instance_report.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/process_instance_report.py
@@ -79,6 +79,7 @@ class ProcessInstanceReportModel(SpiffworkflowBaseDBModel):
             identifier=identifier, created_by_id=user.id
         ).first()
 
+        # TODO replace with system report that is loaded on launch (or similar)
         if process_instance_report is None:
             report_metadata = {
                 "columns": [

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
@@ -736,10 +736,12 @@ def process_instance_list(
     end_to: Optional[int] = None,
     process_status: Optional[str] = None,
     user_filter: Optional[bool] = False,
-    report_identifier: Optional[str] = None
+    report_identifier: Optional[str] = None,
 ) -> flask.wrappers.Response:
     """Process_instance_list."""
-    process_instance_report = ProcessInstanceReportService.report_with_identifier(g.user, report_identifier)
+    process_instance_report = ProcessInstanceReportService.report_with_identifier(
+        g.user, report_identifier
+    )
 
     if user_filter:
         report_filter = ProcessInstanceReportFilter(

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
@@ -739,7 +739,7 @@ def process_instance_list(
     report_identifier: Optional[str] = None
 ) -> flask.wrappers.Response:
     """Process_instance_list."""
-    process_instance_report = ProcessInstanceReportModel.default_report(g.user)
+    process_instance_report = ProcessInstanceReportService.report_with_identifier(g.user, report_identifier)
 
     if user_filter:
         report_filter = ProcessInstanceReportFilter(

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
@@ -736,6 +736,7 @@ def process_instance_list(
     end_to: Optional[int] = None,
     process_status: Optional[str] = None,
     user_filter: Optional[bool] = False,
+    report_identifier: Optional[str] = None
 ) -> flask.wrappers.Response:
     """Process_instance_list."""
     process_instance_report = ProcessInstanceReportModel.default_report(g.user)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_report_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_report_service.py
@@ -54,12 +54,12 @@ class ProcessInstanceReportService:
         temp_system_metadata_map = {
             "system_report_instances_initiated_by_me": {
                 "columns": [
-                    {"Header": "id", "accessor": "id"},
                     {
                         "Header": "process_model_identifier",
                         "accessor": "process_model_identifier",
                     },
                     {"Header": "start_in_seconds", "accessor": "start_in_seconds"},
+                    {"Header": "id", "accessor": "id"},
                     {"Header": "end_in_seconds", "accessor": "end_in_seconds"},
                     {"Header": "status", "accessor": "status"},
                 ],

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_report_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_report_service.py
@@ -5,6 +5,7 @@ from typing import Optional
 from spiffworkflow_backend.models.process_instance_report import (
     ProcessInstanceReportModel,
 )
+from spiffworkflow_backend.models.user import UserModel
 
 
 @dataclass
@@ -40,6 +41,63 @@ class ProcessInstanceReportFilter:
 
 class ProcessInstanceReportService:
     """ProcessInstanceReportService."""
+
+    @classmethod
+    def report_with_identifier(
+        cls,
+        user: UserModel,
+        report_identifier: Optional[str] = None
+    ) -> ProcessInstanceReportModel:
+        if report_identifier is None:
+            return ProcessInstanceReportModel.default_report(user)
+
+        # TODO replace with system reports that are loaded on launch (or similar)
+        temp_system_metdata_map = {
+            "system_report_instances_initiated_by_me": {
+                "columns": [
+                    {"Header": "id", "accessor": "id"},
+                    {
+                        "Header": "process_model_identifier",
+                        "accessor": "process_model_identifier",
+                    },
+                    {"Header": "start_in_seconds", "accessor": "start_in_seconds"},
+                    {"Header": "end_in_seconds", "accessor": "end_in_seconds"},
+                    {"Header": "status", "accessor": "status"},
+                ],
+            },
+            "system_report_instances_with_tasks_completed_by_me": {
+                "columns": [
+                    {"Header": "start_in_seconds", "accessor": "start_in_seconds"},
+                    {"Header": "end_in_seconds", "accessor": "end_in_seconds"},
+                    {"Header": "status", "accessor": "status"},
+                    {"Header": "id", "accessor": "id"},
+                    {
+                        "Header": "process_model_identifier",
+                        "accessor": "process_model_identifier",
+                    },
+                ],
+            },
+            "system_report_instances_with_tasks_completed_by_my_groups": {
+                "columns": [
+                    {
+                        "Header": "process_model_identifier",
+                        "accessor": "process_model_identifier",
+                    },
+                    {"Header": "start_in_seconds", "accessor": "start_in_seconds"},
+                    {"Header": "end_in_seconds", "accessor": "end_in_seconds"},
+                    {"Header": "status", "accessor": "status"},
+                    {"Header": "id", "accessor": "id"},
+                ],
+            },
+        }
+
+        process_instance_report = cls(
+            identifier=identifier,
+            created_by_id=user.id,
+            report_metadata=temp_system_metadata_map[report_identifier],
+        )
+
+        return process_instance_report
 
     @classmethod
     def filter_by_to_dict(

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_report_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_report_service.py
@@ -44,15 +44,14 @@ class ProcessInstanceReportService:
 
     @classmethod
     def report_with_identifier(
-        cls,
-        user: UserModel,
-        report_identifier: Optional[str] = None
+        cls, user: UserModel, report_identifier: Optional[str] = None
     ) -> ProcessInstanceReportModel:
+        """Report_with_filter."""
         if report_identifier is None:
             return ProcessInstanceReportModel.default_report(user)
 
         # TODO replace with system reports that are loaded on launch (or similar)
-        temp_system_metdata_map = {
+        temp_system_metadata_map = {
             "system_report_instances_initiated_by_me": {
                 "columns": [
                     {"Header": "id", "accessor": "id"},
@@ -91,8 +90,8 @@ class ProcessInstanceReportService:
             },
         }
 
-        process_instance_report = cls(
-            identifier=identifier,
+        process_instance_report = ProcessInstanceReportModel(
+            identifier=report_identifier,
             created_by_id=user.id,
             report_metadata=temp_system_metadata_map[report_identifier],
         )


### PR DESCRIPTION
The `process_instance_list` api now accepts an optional `report_identifier` parameter that when specified allows loading one of the three system reports specified in slack. This does not currently support loading user created reports - need to refactor the default logic there a bit but wanted to get this in to unblock further development for list table/filter joins.