### PR TITLE
Fix for updating xero token in the background

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/secret_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/secret_service.py
@@ -65,7 +65,7 @@ class SecretService:
     def update_secret(
         key: str,
         value: str,
-        user_id: int,
+        user_id: Optional[int] = None,
         create_if_not_exists: Optional[bool] = False,
     ) -> None:
         """Does this pass pre commit?"""
@@ -79,6 +79,12 @@ class SecretService:
                 db.session.rollback()
                 raise e
         elif create_if_not_exists:
+            if user_id is None:
+                raise ApiError(
+                    error_code="update_secret_error_no_user_id",
+                    message=f"Cannot update secret with key: {key}. Missing user id.",
+                    status_code=404,
+                )
             SecretService.add_secret(key=key, value=value, user_id=user_id)
         else:
             raise ApiError(

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/service_task_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/service_task_service.py
@@ -8,6 +8,7 @@ from flask import g
 
 from spiffworkflow_backend.services.file_system_service import FileSystemService
 from spiffworkflow_backend.services.secret_service import SecretService
+from spiffworkflow_backend.services.user_service import UserService
 
 
 class ConnectorProxyError(Exception):
@@ -65,7 +66,8 @@ class ServiceTaskDelegate:
 
         secret_key = parsed_response["auth"]
         refreshed_token_set = json.dumps(parsed_response["refreshed_token_set"])
-        SecretService().update_secret(secret_key, refreshed_token_set, g.user.id)
+        user_id = g.user.id if UserService.has_user() else None
+        SecretService().update_secret(secret_key, refreshed_token_set, user_id)
 
         return json.dumps(parsed_response["api_response"])
 


### PR DESCRIPTION
Locally this resolves the issue with xero/createInvoice service tasks failing when behind a timer. The issue was the lack of `g.user.id` when in the background, which caused an unreported exception to occur. Made the user_id optional in update_secret since it is not used in this flow.