### PR TITLE
Only save tasks portion of the bpmn_json with each spiff_step

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
@@ -1296,7 +1296,9 @@ def process_instance_task_list(
             .first()
         )
         if step_detail is not None:
-            process_instance.bpmn_json = json.dumps(step_detail.task_json)
+            bpmn_json = json.loads(process_instance.bpmn_json)
+            bpmn_json["tasks"] = step_detail.task_json
+            process_instance.bpmn_json = json.dumps(bpmn_json)
 
     processor = ProcessInstanceProcessor(process_instance)
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
@@ -1295,7 +1295,7 @@ def process_instance_task_list(
             )
             .first()
         )
-        if step_detail is not None:
+        if step_detail is not None and process_instance.bpmn_json is not None:
             bpmn_json = json.loads(process_instance.bpmn_json)
             bpmn_json["tasks"] = step_detail.task_json
             process_instance.bpmn_json = json.dumps(bpmn_json)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -542,13 +542,8 @@ class ProcessInstanceProcessor:
         """SaveSpiffStepDetails."""
         bpmn_json = self.serialize()
         wf_json = json.loads(bpmn_json)
-        task_json = "{}"
-        if "tasks" in wf_json:
-            task_json = json.dumps(wf_json["tasks"])
+        task_json = wf_json["tasks"]
 
-        # TODO want to just save the tasks, something wasn't immediately working
-        # so after the flow works with the full wf_json revisit this
-        task_json = wf_json
         return {
             "process_instance_id": self.process_instance_model.id,
             "spiff_step": self.process_instance_model.spiff_step or 1,


### PR DESCRIPTION
Lightly tested but seems to work as expected with a simple manual->script task and my test timer->xero service task workflows. This should reduce the amount of data stored with each spiff_step, exactly how much depends on the workflow. This a breaking change, so will need a db wipe or old processes won't have their historic step by step execution displayed properly.