### PR TITLE
Fix opening DMN Tables with "Launch Editor" button

### DIFF
--- a/spiffworkflow-frontend/src/interfaces.ts
+++ b/spiffworkflow-frontend/src/interfaces.ts
@@ -12,9 +12,8 @@ export interface RecentProcessModel {
 }
 
 export interface ProcessReference {
-  id: string; // The unique id of the process or decision table.
   name: string; // The process or decision Display name.
-  identifier: string;
+  identifier: string; // The unique id of the process
   display_name: string;
   process_group_id: string;
   process_model_id: string;

--- a/spiffworkflow-frontend/src/routes/ProcessModelEditDiagram.tsx
+++ b/spiffworkflow-frontend/src/routes/ProcessModelEditDiagram.tsx
@@ -735,7 +735,7 @@ export default function ProcessModelEditDiagram() {
     if (processModel) {
       const files = processModel.files.filter((f) => f.type === type);
       files.some((file) => {
-        if (file.references.some((ref) => ref.id === id)) {
+        if (file.references.some((ref) => ref.identifier === id)) {
           matchFile = file;
           return true;
         }


### PR DESCRIPTION
Use the identifier, not the id when locating a process model or dmn table.