### PR TITLE
Allow viewing/editing xml of bpmn and dmn files

### DIFF
--- a/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
+++ b/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
@@ -52,6 +52,8 @@ import TouchModule from 'diagram-js/lib/navigation/touch';
 // @ts-expect-error TS(7016) FIXME
 import ZoomScrollModule from 'diagram-js/lib/navigation/zoomscroll';
 
+import { useNavigate } from 'react-router-dom';
+
 import { Can } from '@casl/react';
 import HttpService from '../services/HttpService';
 
@@ -119,6 +121,7 @@ export default function ReactDiagramEditor({
     [targetUris.processModelFileShowPath]: ['POST', 'GET', 'PUT', 'DELETE'],
   };
   const { ability } = usePermissionFetcher(permissionRequestData);
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (diagramModelerState) {
@@ -542,6 +545,10 @@ export default function ReactDiagramEditor({
       });
   };
 
+  const viewXmlFile = () => {
+    navigate(`/admin/process-models/${processModelId}/form/${fileName}`);
+  };
+
   const userActionOptions = () => {
     if (diagramType !== 'readonly') {
       return (
@@ -579,6 +586,13 @@ export default function ReactDiagramEditor({
             ability={ability}
           >
             <Button onClick={downloadXmlFile}>Download</Button>
+          </Can>
+          <Can
+            I="GET"
+            a={targetUris.processModelFileShowPath}
+            ability={ability}
+          >
+            <Button onClick={viewXmlFile}>View XML</Button>
           </Can>
         </>
       );

--- a/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
+++ b/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
@@ -545,9 +545,7 @@ export default function ReactDiagramEditor({
       });
   };
 
-  const viewXmlFile = () => {
-    navigate(`/admin/process-models/${processModelId}/form/${fileName}`);
-  };
+  const canViewXml = fileName !== undefined;
 
   const userActionOptions = () => {
     if (diagramType !== 'readonly') {
@@ -592,7 +590,17 @@ export default function ReactDiagramEditor({
             a={targetUris.processModelFileShowPath}
             ability={ability}
           >
-            <Button onClick={viewXmlFile}>View XML</Button>
+            {canViewXml && (
+              <Button
+                onClick={() => {
+                  navigate(
+                    `/admin/process-models/${processModelId}/form/${fileName}`
+                  );
+                }}
+              >
+                View XML
+              </Button>
+            )}
           </Can>
         </>
       );

--- a/spiffworkflow-frontend/src/routes/ReactFormEditor.tsx
+++ b/spiffworkflow-frontend/src/routes/ReactFormEditor.tsx
@@ -36,7 +36,20 @@ export default function ReactFormEditor() {
     return searchParams.get('file_ext') ?? 'json';
   })();
 
-  const editorDefaultLanguage = fileExtension === 'md' ? 'markdown' : 'json';
+  const hasDiagram = fileExtension === 'bpmn' || fileExtension === 'dmn';
+
+  const editorDefaultLanguage = (() => {
+    if (fileExtension === 'json') {
+      return 'json';
+    }
+    if (hasDiagram) {
+      return 'xml';
+    }
+    if (fileExtension === 'md') {
+      return 'markdown';
+    }
+    return 'text';
+  })();
 
   const modifiedProcessModelId = modifyProcessIdentifierForPathParam(
     `${params.process_model_id}`
@@ -192,6 +205,19 @@ export default function ReactFormEditor() {
             onConfirmation={deleteFile}
             buttonLabel="Delete"
           />
+        ) : null}
+        {hasDiagram ? (
+          <Button
+            onClick={() =>
+              navigate(
+                `/admin/process-models/${modifiedProcessModelId}/files/${params.file_name}`
+              )
+            }
+            variant="danger"
+            data-qa="form-builder-button"
+          >
+            View Diagram
+          </Button>
         ) : null}
         <Editor
           height={600}

--- a/spiffworkflow-frontend/src/routes/ReactFormEditor.tsx
+++ b/spiffworkflow-frontend/src/routes/ReactFormEditor.tsx
@@ -214,7 +214,7 @@ export default function ReactFormEditor() {
               )
             }
             variant="danger"
-            data-qa="form-builder-button"
+            data-qa="view-diagram-button"
           >
             View Diagram
           </Button>


### PR DESCRIPTION
For line 10 in the december spreadsheet - adds support for editing the xml of bpmn and dmn files. Not sure how far we want to take this one - right now you can only view the xml of a file that has been saved. Any changes to the xml need to be saved before switching between editing modes. The work to prompt on save should make this more obvious. 