### PR TITLE
Fix endpoints for script task unit tests

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
@@ -610,15 +610,9 @@ paths:
                 items:
                   $ref: "#/components/schemas/Workflow"
 
-  /process-models/{process_group_id}/{process_model_id}/script-unit-tests:
+  /process-models/{modified_process_model_identifier}/script-unit-tests:
     parameters:
-      - name: process_group_id
-        in: path
-        required: true
-        description: The unique id of an existing process group
-        schema:
-          type: string
-      - name: process_model_id
+      - name: modified_process_model_identifier
         in: path
         required: true
         description: The unique id of an existing process model.
@@ -637,15 +631,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/Workflow"
 
-  /process-models/{process_group_id}/{process_model_id}/script-unit-tests/run:
+  /process-models/{modified_process_model_identifier}/script-unit-tests/run:
     parameters:
-      - name: process_group_id
-        in: path
-        required: true
-        description: The unique id of an existing process group
-        schema:
-          type: string
-      - name: process_model_id
+      - name: modified_process_model_identifier
         in: path
         required: true
         description: The unique id of an existing process model.

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
@@ -1613,7 +1613,7 @@ def task_submit(
 
 
 def script_unit_test_create(
-    process_group_id: str, process_model_id: str, body: Dict[str, Union[str, bool, int]]
+    modified_process_model_identifier: str, body: Dict[str, Union[str, bool, int]]
 ) -> flask.wrappers.Response:
     """Script_unit_test_create."""
     bpmn_task_identifier = _get_required_parameter_or_raise(
@@ -1624,7 +1624,7 @@ def script_unit_test_create(
         "expected_output_json", body
     )
 
-    process_model_identifier = f"{process_group_id}/{process_model_id}"
+    process_model_identifier = modified_process_model_identifier.replace(":", "/")
     process_model = get_process_model(process_model_identifier)
     file = SpecFileService.get_files(process_model, process_model.primary_file_name)[0]
     if file is None:
@@ -1702,7 +1702,7 @@ def script_unit_test_create(
 
 
 def script_unit_test_run(
-    process_group_id: str, process_model_id: str, body: Dict[str, Union[str, bool, int]]
+    modified_process_model_identifier: str, body: Dict[str, Union[str, bool, int]]
 ) -> flask.wrappers.Response:
     """Script_unit_test_run."""
     # FIXME: We should probably clear this somewhere else but this works

--- a/spiffworkflow-frontend/package-lock.json
+++ b/spiffworkflow-frontend/package-lock.json
@@ -48174,7 +48174,7 @@
         "@csstools/postcss-text-decoration-shorthand": "^1.0.0",
         "@csstools/postcss-trigonometric-functions": "^1.0.2",
         "@csstools/postcss-unset-value": "^1.0.2",
-        "autoprefixer": "10.4.8",
+        "autoprefixer": "10.4.5",
         "browserslist": "^4.21.3",
         "css-blank-pseudo": "^3.0.3",
         "css-has-pseudo": "^3.0.4",
@@ -48212,7 +48212,8 @@
       },
       "dependencies": {
         "autoprefixer": {
-          "version": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.5.tgz",
+          "version": "10.4.5",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.5.tgz",
           "integrity": "sha512-Fvd8yCoA7lNX/OUllvS+aS1I7WRBclGXsepbvT8ZaPgrH24rgXpZzF0/6Hh3ZEkwg+0AES/Osd196VZmYoEFtw==",
           "requires": {
             "browserslist": "^4.20.2",

--- a/spiffworkflow-frontend/package-lock.json
+++ b/spiffworkflow-frontend/package-lock.json
@@ -48174,7 +48174,7 @@
         "@csstools/postcss-text-decoration-shorthand": "^1.0.0",
         "@csstools/postcss-trigonometric-functions": "^1.0.2",
         "@csstools/postcss-unset-value": "^1.0.2",
-        "autoprefixer": "10.4.5",
+        "autoprefixer": "10.4.8",
         "browserslist": "^4.21.3",
         "css-blank-pseudo": "^3.0.3",
         "css-has-pseudo": "^3.0.4",
@@ -48212,8 +48212,7 @@
       },
       "dependencies": {
         "autoprefixer": {
-          "version": "10.4.5",
-          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.5.tgz",
+          "version": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.5.tgz",
           "integrity": "sha512-Fvd8yCoA7lNX/OUllvS+aS1I7WRBclGXsepbvT8ZaPgrH24rgXpZzF0/6Hh3ZEkwg+0AES/Osd196VZmYoEFtw==",
           "requires": {
             "browserslist": "^4.20.2",


### PR DESCRIPTION
Ran into this when working with @danfunk - this updates the endpoints for the script task unit tests to use `modified_process_model_identifier`.