### PR TITLE
Throw an exception if max task data length is exceeded

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -1278,10 +1278,11 @@ class ProcessInstanceProcessor:
         task_data = [self.user_defined_task_data(task.data) for task in tasks_to_check]
         task_data_to_check = list(filter(len, task_data))
 
-        if len(task_data_to_check) == 0:
-            return
+        try:
+            task_data_len = len(json.dumps(task_data_to_check))
+        except Exception:
+            task_data_len = 0
 
-        task_data_len = len(json.dumps(task_data_to_check))
         task_data_limit = 1024**2
 
         if task_data_len > task_data_limit:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -564,10 +564,25 @@ class ProcessInstanceProcessor:
             "lane_assignment_id": lane_assignment_id,
         }
 
+    def check_task_data_size(self, tasks_dict: dict) -> None:
+        """CheckTaskDataSize."""
+        task_data = [v["data"] for v in tasks_dict.values() if len(v["data"]) > 0]
+        task_data_len = len(json.dumps(task_data))
+        task_data_limit = 1024
+
+        if task_data_len > task_data_limit:
+            raise (
+                ApiError(
+                    error_code="task_data_size_exceeded",
+                    message=f"Maximum task data size of {task_data_limit} exceeded."
+                )
+            )
+
     def spiff_step_details_mapping(self) -> dict:
         """SaveSpiffStepDetails."""
         bpmn_json = self.serialize()
         wf_json = json.loads(bpmn_json)
+        self.check_task_data_size(wf_json["tasks"])
         task_json = {"tasks": wf_json["tasks"], "subprocesses": wf_json["subprocesses"]}
 
         return {

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -1282,7 +1282,7 @@ class ProcessInstanceProcessor:
             return
 
         task_data_len = len(json.dumps(task_data_to_check))
-        task_data_limit = 1024
+        task_data_limit = 1024**2
 
         if task_data_len > task_data_limit:
             raise (

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -1288,7 +1288,7 @@ class ProcessInstanceProcessor:
             raise (
                 ApiError(
                     error_code="task_data_size_exceeded",
-                    message=f"Maximum task data size of {task_data_limit} exceeded."
+                    message=f"Maximum task data size of {task_data_limit} exceeded.",
                 )
             )
 


### PR DESCRIPTION
If the dump of the task data for all completed tasks exceeds 1MB an exception is raised. The system defined key `current_user` is removed before the size check is done.