### PR TITLE
frontend: avoid redundant steps in Dockerfile

### DIFF
--- a/spiffworkflow-frontend/Dockerfile
+++ b/spiffworkflow-frontend/Dockerfile
@@ -1,5 +1,5 @@
-### STAGE 1: Build ###
-FROM quay.io/sartography/node:latest
+# Base image to share ENV vars that activate VENV.
+FROM quay.io/sartography/node:latest AS base
 
 RUN mkdir /app
 WORKDIR /app
@@ -7,8 +7,10 @@ WORKDIR /app
 # this matches total memory on spiffworkflow-demo
 ENV NODE_OPTIONS=--max_old_space_size=2048
 
-ADD package.json /app/
-ADD package-lock.json /app/
+# Setup image for installing JS dependencies.
+FROM base AS setup
+
+COPY . /app/
 
 # npm ci because it respects the lock file.
 # --ignore-scripts because authors can do bad things in postinstall scripts.
@@ -16,8 +18,17 @@ ADD package-lock.json /app/
 # npx can-i-ignore-scripts can check that it's safe to ignore scripts.
 RUN npm ci --ignore-scripts
 
-COPY . /app/
-
 RUN npm run build
+
+# Final image without setup dependencies.
+FROM base AS final
+
+LABEL source="https://github.com/sartography/spiff-arena"
+LABEL description="Software development platform for building, running, and monitoring executable diagrams"
+
+# WARNING: On localhost frontend assumes backend is one port lowe.
+ENV PORT0=7001
+
+COPY --from=setup /app/build /app/build
 
 ENTRYPOINT ["/app/bin/boot_server_in_docker"]


### PR DESCRIPTION
Use separate base, setup and final to avoid redundat steps.
Also add default value for `PORT0` as `7001`.
