### PR TITLE
move away from using the auth_token from the open id server as a token between the front end and backend.

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/user.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/user.py
@@ -255,7 +255,7 @@ def parse_id_token(token: str) -> Any:
     return json.loads(decoded)
 
 
-def login_return(code: str, state: str, session_state: str = None) -> Optional[Response]:
+def login_return(code: str, state: str, session_state: str = "") -> Optional[Response]:
     """Login_return."""
     state_dict = ast.literal_eval(base64.b64decode(state).decode("utf-8"))
     state_redirect_url = state_dict["redirect_url"]

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/user.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/user.py
@@ -96,7 +96,7 @@ def verify_token(
                             )
                             if auth_token and "error" not in auth_token:
                                 tld = current_app.config["THREAD_LOCAL_DATA"]
-                                tld.new_access_token = auth_token["access_token"]
+                                tld.new_access_token = auth_token["id_token"]
                                 tld.new_id_token = auth_token["id_token"]
                                 # We have the user, but this code is a bit convoluted, and will later demand
                                 # a user_info object so it can look up the user.  Sorry to leave this crap here.
@@ -186,6 +186,7 @@ def set_new_access_token_in_cookie(
     ):
         domain_for_frontend_cookie = None
 
+    # fixme - we should not be passing the access token back to the client
     if hasattr(tld, "new_access_token") and tld.new_access_token:
         response.set_cookie(
             "access_token", tld.new_access_token, domain=domain_for_frontend_cookie
@@ -254,7 +255,7 @@ def parse_id_token(token: str) -> Any:
     return json.loads(decoded)
 
 
-def login_return(code: str, state: str, session_state: str) -> Optional[Response]:
+def login_return(code: str, state: str, session_state: str = None) -> Optional[Response]:
     """Login_return."""
     state_dict = ast.literal_eval(base64.b64decode(state).decode("utf-8"))
     state_redirect_url = state_dict["redirect_url"]
@@ -269,12 +270,13 @@ def login_return(code: str, state: str, session_state: str) -> Optional[Response
                 user_model = AuthorizationService.create_user_from_sign_in(user_info)
                 g.user = user_model.id
                 g.token = auth_token_object["id_token"]
-                AuthenticationService.store_refresh_token(
-                    user_model.id, auth_token_object["refresh_token"]
-                )
+                if "refresh_token" in auth_token_object:
+                    AuthenticationService.store_refresh_token(
+                        user_model.id, auth_token_object["refresh_token"]
+                    )
                 redirect_url = state_redirect_url
                 tld = current_app.config["THREAD_LOCAL_DATA"]
-                tld.new_access_token = auth_token_object["access_token"]
+                tld.new_access_token = auth_token_object["id_token"]
                 tld.new_id_token = auth_token_object["id_token"]
                 return redirect(redirect_url)
 


### PR DESCRIPTION
Use the id_token, not the auth_token from the open id server for authentication with the front end.  The auth_token should be kept safe, and not guranteeded to be a json token.