### PR TITLE
Feature/bug fix human tasks

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
@@ -457,6 +457,7 @@ class AuthorizationService:
         human_task = HumanTaskModel.query.filter_by(
             task_name=spiff_task.task_spec.name,
             process_instance_id=process_instance_id,
+            completed=False
         ).first()
         if human_task is None:
             raise HumanTaskNotFoundError(

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
@@ -457,7 +457,7 @@ class AuthorizationService:
         human_task = HumanTaskModel.query.filter_by(
             task_name=spiff_task.task_spec.name,
             process_instance_id=process_instance_id,
-            completed=False
+            completed=False,
         ).first()
         if human_task is None:
             raise HumanTaskNotFoundError(

--- a/spiffworkflow-frontend/src/routes/TaskShow.tsx
+++ b/spiffworkflow-frontend/src/routes/TaskShow.tsx
@@ -42,9 +42,12 @@ export default function TaskShow() {
       HttpService.makeCallToBackend({
         path: url,
         successCallback: (tasks: any) => {
+          setDisabled(false);
           setUserTasks(tasks);
         },
-        onUnauthorized: () => {},
+        onUnauthorized: () => {
+          setDisabled(false);
+        },
         failureCallback: (error: any) => {
           addError(error);
         },
@@ -61,7 +64,6 @@ export default function TaskShow() {
 
   const processSubmitResult = (result: any) => {
     removeError();
-    setDisabled(false);
     if (result.ok) {
       navigate(`/tasks`);
     } else if (result.process_instance_id) {


### PR DESCRIPTION
When searching for human tasks to determine if the current user can complete it, filter on the "completed" flag.

Front-end -- enable the form if you receive an onUnathorized error because the thing you are unauthorized to do might have nothing to do with whether you can submit the form.