### PR TITLE
Fix the sometimes wrong yellow task

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_instances_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_instances_controller.py
@@ -621,7 +621,7 @@ def process_instance_task_list(
     spiff_task = processor.__class__.get_task_by_bpmn_identifier(
         step_details[-1].bpmn_task_identifier, processor.bpmn_process_instance
     )
-    if spiff_task is not None:
+    if spiff_task is not None and spiff_task.state != TaskState.READY:
         spiff_task.complete()
 
     spiff_tasks = None


### PR DESCRIPTION
If a process instance was on a user task or a task that was in error, don't mark it as complete to try to compute the next yellow task. This fixes the issue reported where a script task after a user task would be yellow, even though the user task was still waiting on user input. Also fixes tasks in error, they are now yellow instead of the next task.