### PR TITLE
Check the End Event to fix the failing test

### DIFF
--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_api.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_api.py
@@ -2766,7 +2766,7 @@ class TestProcessApi(BaseTest):
             headers=self.logged_in_headers(with_super_admin_user),
         )
         assert response.status_code == 200
-        end = next(task for task in response.json if task["name"] == "End")
+        end = next(task for task in response.json if task["type"] == "End Event")
         assert end["data"]["result"] == {"message": "message 1"}
 
     def test_manual_complete_task(


### PR DESCRIPTION
This task has a spiff step, and thusly the merged task data and python environment. Also checked in app to make sure the message events still work as expected. Believe they do given my little knowledge.