### PR TITLE
backend/git_service: check repo URLs from webhook

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/git_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/git_service.py
@@ -197,13 +197,15 @@ class GitService:
                 f" body: {webhook}"
             )
 
-        config_clone_url = current_app.config["SPIFFWORKFLOW_BACKEND_GIT_PUBLISH_CLONE_URL"]
+        config_clone_url = current_app.config[
+            "SPIFFWORKFLOW_BACKEND_GIT_PUBLISH_CLONE_URL"
+        ]
         repo = webhook["repository"]
         valid_clone_urls = [repo["clone_url"], repo["git_url"], repo["ssh_url"]]
         if config_clone_url not in valid_clone_urls:
             raise GitCloneUrlMismatchError(
-                "Configured clone url does not match the repo URLs from webhook: %s =/= %s"
-                % (config_clone_url, valid_clone_urls)
+                "Configured clone url does not match the repo URLs from webhook: %s"
+                " =/= %s" % (config_clone_url, valid_clone_urls)
             )
 
         # Test webhook requests have a zen koan and hook info.

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/git_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/git_service.py
@@ -206,6 +206,10 @@ class GitService:
                 % (config_clone_url, valid_clone_urls)
             )
 
+        # Test webhook requests have a zen koan and hook info.
+        if "zen" in webhook or "hook_id" in webhook:
+            return False
+
         if "ref" not in webhook:
             raise InvalidGitWebhookBodyError(
                 f"Could not find the 'ref' arg in the webhook boy: {webhook}"

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/git_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/git_service.py
@@ -197,14 +197,13 @@ class GitService:
                 f" body: {webhook}"
             )
 
-        clone_url = webhook["repository"]["clone_url"]
-        if (
-            clone_url
-            != current_app.config["SPIFFWORKFLOW_BACKEND_GIT_PUBLISH_CLONE_URL"]
-        ):
+        config_clone_url = current_app.config["SPIFFWORKFLOW_BACKEND_GIT_PUBLISH_CLONE_URL"]
+        repo = webhook["repository"]
+        valid_clone_urls = [repo["clone_url"], repo["git_url"], repo["ssh_url"]]
+        if config_clone_url not in valid_clone_urls:
             raise GitCloneUrlMismatchError(
-                "Configured clone url does not match clone url from webhook:"
-                f" {clone_url}"
+                "Configured clone url does not match the repo URLs from webhook: %s =/= %s"
+                % (config_clone_url, valid_clone_urls)
             )
 
         if "ref" not in webhook:


### PR DESCRIPTION
Since we are cloning a private repo we are using `ssh_url` in our case.

Also fix handling test requests sent at webhook creation time.
https://docs.github.com/en/webhooks-and-events/webhooks/testing-webhooks