### PR TITLE
Data size script

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/scripts/get_data_sizes.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/scripts/get_data_sizes.py
@@ -9,8 +9,6 @@ from spiffworkflow_backend.services.process_instance_processor import (
     ProcessInstanceProcessor,
 )
 
-# from spiffworkflow_backend.servces.process_instance_processor import ProcessInstanceProcessor
-
 
 class GetDataSizes(Script):
     """GetDataSizes."""

--- a/spiffworkflow-backend/src/spiffworkflow_backend/scripts/get_data_sizes.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/scripts/get_data_sizes.py
@@ -22,7 +22,8 @@ class GetDataSizes(Script):
 
     def get_description(self) -> str:
         """Get_description."""
-        return """Returns a dictionary of information about the size of task data and the python environment for the currently running process."""
+        return """Returns a dictionary of information about the size of task data and
+            the python environment for the currently running process."""
 
     def run(
         self,
@@ -32,11 +33,11 @@ class GetDataSizes(Script):
     ) -> Any:
         """Run."""
         task = script_attributes_context.task
+        cumulative_task_data_size = ProcessInstanceProcessor.get_task_data_size(
+            task.workflow
+        )
+        python_env_size = ProcessInstanceProcessor.get_python_env_size(task.workflow)
         return {
-            "cumulative_task_data_size": ProcessInstanceProcessor.get_task_data_size(
-                task.workflow
-            ),
-            "python_env_size": ProcessInstanceProcessor.get_python_env_size(
-                task.workflow
-            ),
+            "cumulative_task_data_size": cumulative_task_data_size,
+            "python_env_size": python_env_size,
         }

--- a/spiffworkflow-backend/src/spiffworkflow_backend/scripts/get_data_sizes.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/scripts/get_data_sizes.py
@@ -32,12 +32,17 @@ class GetDataSizes(Script):
         **kwargs: Any
     ) -> Any:
         """Run."""
-        task = script_attributes_context.task
-        cumulative_task_data_size = ProcessInstanceProcessor.get_task_data_size(
-            task.workflow
-        )
-        python_env_size = ProcessInstanceProcessor.get_python_env_size(task.workflow)
+        workflow = script_attributes_context.task.workflow
+        task_data_size = ProcessInstanceProcessor.get_task_data_size(workflow)
+        task_data_keys_by_task = {
+            t.task_spec.name: sorted(t.data.keys())
+            for t in ProcessInstanceProcessor.get_tasks_with_data(workflow)
+        }
+        python_env_size = ProcessInstanceProcessor.get_python_env_size(workflow)
+        python_env_keys = workflow.script_engine.environment.user_defined_state().keys()
         return {
-            "cumulative_task_data_size": cumulative_task_data_size,
             "python_env_size": python_env_size,
+            "python_env_keys": sorted(python_env_keys),
+            "task_data_size": task_data_size,
+            "task_data_keys_by_task": task_data_keys_by_task,
         }

--- a/spiffworkflow-backend/src/spiffworkflow_backend/scripts/get_data_sizes.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/scripts/get_data_sizes.py
@@ -33,5 +33,5 @@ class GetDataSizes(Script):
         task = script_attributes_context.task
         return {
             "cumulative_task_data_size": ProcessInstanceProcessor.get_task_data_size(task.workflow),
-            "python_env_size": 0,
+            "python_env_size": ProcessInstanceProcessor.get_python_env_size(task.workflow),
         }

--- a/spiffworkflow-backend/src/spiffworkflow_backend/scripts/get_data_sizes.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/scripts/get_data_sizes.py
@@ -1,0 +1,37 @@
+"""Get_data_sizes."""
+from typing import Any
+
+from spiffworkflow_backend.models.script_attributes_context import (
+    ScriptAttributesContext,
+)
+from spiffworkflow_backend.scripts.script import Script
+#from spiffworkflow_backend.servces.process_instance_processor import ProcessInstanceProcessor
+from spiffworkflow_backend.services.process_instance_processor import (
+    ProcessInstanceProcessor,
+)
+
+
+class GetDataSizes(Script):
+    """GetDataSizes."""
+
+    @staticmethod
+    def requires_privileged_permissions() -> bool:
+        """We have deemed this function safe to run without elevated permissions."""
+        return False
+
+    def get_description(self) -> str:
+        """Get_description."""
+        return """Returns a dictionary of information about the size of task data and the python environment for the currently running process."""
+
+    def run(
+        self,
+        script_attributes_context: ScriptAttributesContext,
+        *_args: Any,
+        **kwargs: Any
+    ) -> Any:
+        """Run."""
+        task = script_attributes_context.task
+        return {
+            "cumulative_task_data_size": ProcessInstanceProcessor.get_task_data_size(task.workflow),
+            "python_env_size": 0,
+        }

--- a/spiffworkflow-backend/src/spiffworkflow_backend/scripts/get_data_sizes.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/scripts/get_data_sizes.py
@@ -5,10 +5,11 @@ from spiffworkflow_backend.models.script_attributes_context import (
     ScriptAttributesContext,
 )
 from spiffworkflow_backend.scripts.script import Script
-#from spiffworkflow_backend.servces.process_instance_processor import ProcessInstanceProcessor
 from spiffworkflow_backend.services.process_instance_processor import (
     ProcessInstanceProcessor,
 )
+
+# from spiffworkflow_backend.servces.process_instance_processor import ProcessInstanceProcessor
 
 
 class GetDataSizes(Script):
@@ -32,6 +33,10 @@ class GetDataSizes(Script):
         """Run."""
         task = script_attributes_context.task
         return {
-            "cumulative_task_data_size": ProcessInstanceProcessor.get_task_data_size(task.workflow),
-            "python_env_size": ProcessInstanceProcessor.get_python_env_size(task.workflow),
+            "cumulative_task_data_size": ProcessInstanceProcessor.get_task_data_size(
+                task.workflow
+            ),
+            "python_env_size": ProcessInstanceProcessor.get_python_env_size(
+                task.workflow
+            ),
         }

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -1608,26 +1608,26 @@ class ProcessInstanceProcessor:
             raise ApiError.from_workflow_exception("task_error", str(we), we) from we
 
     @classmethod
-    def _get_data_size(cls, data: Dict[Any, Any]) -> int:
-        data_to_check = list(filter(len, data))
-
-        try:
-            return len(json.dumps(data_to_check))
-        except Exception:
-            return 0
-
-    @classmethod
     def get_task_data_size(cls, bpmn_process_instance: BpmnWorkflow) -> int:
         tasks_to_check = bpmn_process_instance.get_tasks(TaskState.FINISHED_MASK)
         task_data = [task.data for task in tasks_to_check]
-        return cls._get_data_size(task_data)
+        task_data_to_check = list(filter(len, task_data))
+
+        try:
+            return len(json.dumps(task_data_to_check))
+        except Exception:
+            return 0
 
     @classmethod
     def get_python_env_size(cls, bpmn_process_instance: BpmnWorkflow) -> int:
         user_defined_state = (
             bpmn_process_instance.script_engine.environment.user_defined_state()
         )
-        return cls._get_data_size(user_defined_state)
+
+        try:
+            return len(json.dumps(user_defined_state))
+        except Exception:
+            return 0
 
     def check_task_data_size(self) -> None:
         """CheckTaskDataSize."""

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -1608,13 +1608,20 @@ class ProcessInstanceProcessor:
             raise ApiError.from_workflow_exception("task_error", str(we), we) from we
 
     @classmethod
+    def get_tasks_with_data(cls, bpmn_process_instance: BpmnWorkflow) -> List[SpiffTask]:
+        return [
+            task
+            for task in bpmn_process_instance.get_tasks(TaskState.FINISHED_MASK)
+            if len(task.data) > 0
+        ]
+
+    @classmethod
     def get_task_data_size(cls, bpmn_process_instance: BpmnWorkflow) -> int:
-        tasks_to_check = bpmn_process_instance.get_tasks(TaskState.FINISHED_MASK)
-        task_data = [task.data for task in tasks_to_check]
-        task_data_to_check = list(filter(len, task_data))
+        tasks_with_data = cls.get_tasks_with_data(bpmn_process_instance)
+        all_task_data = [task.data for task in tasks_with_data]
 
         try:
-            return len(json.dumps(task_data_to_check))
+            return len(json.dumps(all_task_data))
         except Exception:
             return 0
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -1624,7 +1624,9 @@ class ProcessInstanceProcessor:
 
     @classmethod
     def get_python_env_size(cls, bpmn_process_instance: BpmnWorkflow) -> int:
-        user_defined_state = bpmn_process_instance.script_engine.environment.user_defined_state()
+        user_defined_state = (
+            bpmn_process_instance.script_engine.environment.user_defined_state()
+        )
         return cls._get_data_size(user_defined_state)
 
     def check_task_data_size(self) -> None:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -1608,7 +1608,9 @@ class ProcessInstanceProcessor:
             raise ApiError.from_workflow_exception("task_error", str(we), we) from we
 
     @classmethod
-    def get_tasks_with_data(cls, bpmn_process_instance: BpmnWorkflow) -> List[SpiffTask]:
+    def get_tasks_with_data(
+        cls, bpmn_process_instance: BpmnWorkflow
+    ) -> List[SpiffTask]:
         return [
             task
             for task in bpmn_process_instance.get_tasks(TaskState.FINISHED_MASK)


### PR DESCRIPTION
Adds a helper script to get a process instance's task data and python environment size. Also provides the keys that are associated with each task and the environment. Hoping this could help provide sanity checks about the storage of process instance data.

Example of a call at the beginning of a workflow:

```
"start_sizes": {
    "python_env_keys": [],
    "python_env_size": 2,
    "task_data_keys_by_task": {},
    "task_data_size": 2
  }
```

Example of a call at the end of a workflow:

```
"end_sizes": {
    "python_env_keys": [
      "spiff__Activity_0p3u6b2_result",
      "spiff__Activity_111tyd7_result",
      "start_sizes"
    ],
    "python_env_size": 3742,
    "task_data_keys_by_task": {
      "Activity_0nortte": [
        "spiff__Activity_0p3u6b2_result",
        "spiff__Activity_111tyd7_result",
        "start_sizes"
      ]
    },
    "task_data_size": 3744
  }
```