### PR TITLE
workflow.catch() was nice, in that it is where we could send events a…

### DIFF
--- a/SpiffWorkflow/SpiffWorkflow/bpmn/specs/events/event_definitions.py
+++ b/SpiffWorkflow/SpiffWorkflow/bpmn/specs/events/event_definitions.py
@@ -221,6 +221,20 @@ class MessageEventDefinition(NamedEventDefinition):
                     raise we
         return correlation_keys
 
+    def conversation(self):
+        """An event may have many correlation properties, this figures out
+        which conversation exists across all of them, or return None if they
+        do not share a topic. """
+        conversation = None
+        if len(self.correlation_properties) > 0:
+            for prop in self.correlation_properties:
+                for key in prop.correlation_keys:
+                    conversation = key
+                    for prop in self.correlation_properties:
+                        if conversation not in prop.correlation_keys:
+                            break
+                    return conversation
+        return None
 
 
 class NoneEventDefinition(EventDefinition):

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/example.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/example.yml
@@ -30,6 +30,12 @@ groups:
         admin@spiffworkflow.org,
         nelson@spiffworkflow.org
       ]
+  approvers:
+    users:
+      [
+        malala@spiffworkflow.org,
+        oskar@spiffworkflow.org
+      ]
 
 permissions:
   # Admins have access to everything.

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -350,7 +350,9 @@ class CustomBpmnScriptEngine(PythonScriptEngine):  # type: ignore
         external_methods: Optional[Dict[str, Any]] = None,
     ) -> Any:
         """_evaluate."""
-        methods = self.__get_augment_methods(task)
+        methods = {}
+        if task:
+            methods = self.__get_augment_methods(task)
         if external_methods:
             methods.update(external_methods)
 


### PR DESCRIPTION
workflow.catch() was nice, in that it is where we could send events and messages.  With this change sending an event to catch will behave incorrectly for BPMN Messages. Only sending it to the right method will create the desired result.  It also adds a lot of additional code.   Would love a careful review of this, and any optimizations anyone can think of.