### PR TITLE
Strategy based engine step execution

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -1674,7 +1674,12 @@ class ProcessInstanceProcessor:
         current_app.config["THREAD_LOCAL_DATA"].spiff_step = spiff_step
         db.session.add(self.process_instance_model)
 
-    def do_engine_steps(self, exit_at: None = None, save: bool = False, execution_strategy_name: str = "greedy") -> None:
+    def do_engine_steps(
+        self,
+        exit_at: None = None,
+        save: bool = False,
+        execution_strategy_name: str = "greedy",
+    ) -> None:
         """Do_engine_steps."""
 
         def spiff_step_details_mapping_builder(
@@ -1686,7 +1691,9 @@ class ProcessInstanceProcessor:
         step_delegate = StepDetailLoggingDelegate(
             self.increment_spiff_step, spiff_step_details_mapping_builder
         )
-        execution_strategy = execution_strategy_named(execution_strategy_name, step_delegate)
+        execution_strategy = execution_strategy_named(
+            execution_strategy_name, step_delegate
+        )
         execution_service = WorkflowExecutionService(
             self.bpmn_process_instance,
             self.process_instance_model,

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -1680,6 +1680,7 @@ class ProcessInstanceProcessor:
             return self.spiff_step_details_mapping(task, start, end)
 
         step_delegate = StepDetailLoggingDelegate(self.increment_spiff_step, spiff_step_details_mapping_builder)
+        # TODO: make this configurable
         execution_strategy = GreedyExecutionStrategy(step_delegate)
         execution_service = WorkflowExecutionService(
             self.bpmn_process_instance,
@@ -1689,36 +1690,6 @@ class ProcessInstanceProcessor:
             self.save,
         )
         execution_service.do_engine_steps(exit_at, save)
-
-#        try:
-#            self.bpmn_process_instance.refresh_waiting_tasks()
-#
-#            self.bpmn_process_instance.do_engine_steps(
-#                exit_at=exit_at,
-#                will_complete_task=step_delegate.will_complete_task,
-#                did_complete_task=step_delegate.did_complete_task,
-#            )
-#
-#            if self.bpmn_process_instance.is_completed():
-#                self._script_engine.environment.finalize_result(
-#                    self.bpmn_process_instance
-#                )
-#
-#            self.process_bpmn_messages()
-#            self.queue_waiting_receive_messages()
-#        except SpiffWorkflowException as swe:
-#            raise ApiError.from_workflow_exception("task_error", str(swe), swe) from swe
-#
-#        finally:
-#            step_delegate.save()
-#            spiff_logger = logging.getLogger("spiff")
-#            for handler in spiff_logger.handlers:
-#                if hasattr(handler, "bulk_insert_logs"):
-#                    handler.bulk_insert_logs()  # type: ignore
-#            db.session.commit()
-#
-#            if save:
-#                self.save()
 
     # log the spiff step details so we know what is processing the process
     # instance when a human task has a timer event.

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -44,8 +44,7 @@ from SpiffWorkflow.bpmn.specs.SubWorkflowTask import SubWorkflowTask  # type: ig
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow  # type: ignore
 from SpiffWorkflow.dmn.parser.BpmnDmnParser import BpmnDmnParser  # type: ignore
 from SpiffWorkflow.dmn.serializer.task_spec import BusinessRuleTaskConverter  # type: ignore
-from SpiffWorkflow.exceptions import SpiffWorkflowException  # type: ignore
-from SpiffWorkflow.exceptions import WorkflowException
+from SpiffWorkflow.exceptions import WorkflowException  # type: ignore
 from SpiffWorkflow.exceptions import WorkflowTaskException
 from SpiffWorkflow.serializer.exceptions import MissingSpecError  # type: ignore
 from SpiffWorkflow.spiff.serializer.config import SPIFF_SPEC_CONFIG  # type: ignore

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -95,7 +95,7 @@ from spiffworkflow_backend.services.service_task_service import ServiceTaskDeleg
 from spiffworkflow_backend.services.spec_file_service import SpecFileService
 from spiffworkflow_backend.services.user_service import UserService
 from spiffworkflow_backend.services.workflow_execution_service import (
-    GreedyExecutionStrategy,
+    execution_strategy_named,
 )
 from spiffworkflow_backend.services.workflow_execution_service import (
     StepDetailLoggingDelegate,
@@ -1674,7 +1674,7 @@ class ProcessInstanceProcessor:
         current_app.config["THREAD_LOCAL_DATA"].spiff_step = spiff_step
         db.session.add(self.process_instance_model)
 
-    def do_engine_steps(self, exit_at: None = None, save: bool = False) -> None:
+    def do_engine_steps(self, exit_at: None = None, save: bool = False, execution_strategy_name: str = "greedy") -> None:
         """Do_engine_steps."""
 
         def spiff_step_details_mapping_builder(
@@ -1686,8 +1686,7 @@ class ProcessInstanceProcessor:
         step_delegate = StepDetailLoggingDelegate(
             self.increment_spiff_step, spiff_step_details_mapping_builder
         )
-        # TODO: make this configurable
-        execution_strategy = GreedyExecutionStrategy(step_delegate)
+        execution_strategy = execution_strategy_named(execution_strategy_name, step_delegate)
         execution_service = WorkflowExecutionService(
             self.bpmn_process_instance,
             self.process_instance_model,

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -95,11 +95,13 @@ from spiffworkflow_backend.services.process_model_service import ProcessModelSer
 from spiffworkflow_backend.services.service_task_service import ServiceTaskDelegate
 from spiffworkflow_backend.services.spec_file_service import SpecFileService
 from spiffworkflow_backend.services.user_service import UserService
-
 from spiffworkflow_backend.services.workflow_execution_service import (
-    EngineStepDelegate,
     GreedyExecutionStrategy,
+)
+from spiffworkflow_backend.services.workflow_execution_service import (
     StepDetailLoggingDelegate,
+)
+from spiffworkflow_backend.services.workflow_execution_service import (
     WorkflowExecutionService,
 )
 
@@ -1675,11 +1677,16 @@ class ProcessInstanceProcessor:
 
     def do_engine_steps(self, exit_at: None = None, save: bool = False) -> None:
         """Do_engine_steps."""
-        def spiff_step_details_mapping_builder(task: SpiffTask, start: float, end: float) -> dict:
+
+        def spiff_step_details_mapping_builder(
+            task: SpiffTask, start: float, end: float
+        ) -> dict:
             self._script_engine.environment.revise_state_with_task_data(task)
             return self.spiff_step_details_mapping(task, start, end)
 
-        step_delegate = StepDetailLoggingDelegate(self.increment_spiff_step, spiff_step_details_mapping_builder)
+        step_delegate = StepDetailLoggingDelegate(
+            self.increment_spiff_step, spiff_step_details_mapping_builder
+        )
         # TODO: make this configurable
         execution_strategy = GreedyExecutionStrategy(step_delegate)
         execution_service = WorkflowExecutionService(

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -1,4 +1,4 @@
-"""Process_instance_processor."""
+"user_service""Process_instance_processor."""
 import _strptime  # type: ignore
 import decimal
 import json
@@ -95,7 +95,12 @@ from spiffworkflow_backend.services.process_model_service import ProcessModelSer
 from spiffworkflow_backend.services.service_task_service import ServiceTaskDelegate
 from spiffworkflow_backend.services.spec_file_service import SpecFileService
 from spiffworkflow_backend.services.user_service import UserService
-from spiffworkflow_backend.services.workflow_execution_service import WorkflowExecutionService
+from spiffworkflow_backend.services.workflow_execution_service import (
+    EngineStepDelegate,
+    GreedyExecutionStrategy,
+    StepDetailLoggingEngineStepDelegate,
+    WorkflowExecutionService,
+)
 
 SPIFF_SPEC_CONFIG["task_specs"].append(BusinessRuleTaskConverter)
 
@@ -1626,79 +1631,98 @@ class ProcessInstanceProcessor:
             self._do_engine_steps(exit_at=exit_at, save=save)
         pr.print_stats(sort=SortKey.CUMULATIVE)
 
+    def engine_step_delegate(self) -> EngineStepDelegate:
+        def mapping_builder(task: SpiffTask, start: float, end: float) -> dict:
+            self._script_engine.environment.revise_state_with_task_data(task)
+            return self.spiff_step_details_mapping(task, start, end)
+
+        return StepDetailLoggingEngineStepDelegate(self.increment_spiff_step, mapping_builder)
+
     def do_engine_steps(self, exit_at: None = None, save: bool = False) -> None:
         """Do_engine_steps."""
-        step_details = []
 
-        tasks_to_log = {
-            "BPMN Task",
-            "Script Task",
-            "Service Task",
-            "Default Start Event",
-            "Exclusive Gateway",
-            "Call Activity",
-            # "End Join",
-            "End Event",
-            "Default Throwing Event",
-            "Subprocess",
-            "Transactional Subprocess",
-        }
+        # TODO: allow different strategy to be passed in
+        execution_strategy = GreedyExecutionStrategy(self.engine_step_delegate())
+        execution_service = WorkflowExecutionService(
+            self.bpmn_process_instance,
+            self.process_instance_model,
+            execution_strategy,
+            self._script_engine.environment.finalize_result,
+            self.save,
+        )
+        execution_service.do_engine_steps(exit_at, save)
 
-        # making a dictionary to ensure we are not shadowing variables in the other methods
-        current_task_start_in_seconds = {}
-
-        def should_log(task: SpiffTask) -> bool:
-            if (
-                task.task_spec.spec_type in tasks_to_log
-                and not task.task_spec.name.endswith(".EndJoin")
-            ):
-                return True
-            return False
-
-        def will_complete_task(task: SpiffTask) -> None:
-            if should_log(task):
-                current_task_start_in_seconds["time"] = time.time()
-                self.increment_spiff_step()
-
-        def did_complete_task(task: SpiffTask) -> None:
-            if should_log(task):
-                self._script_engine.environment.revise_state_with_task_data(task)
-                step_details.append(
-                    self.spiff_step_details_mapping(
-                        task, current_task_start_in_seconds["time"], time.time()
-                    )
-                )
-
-        try:
-            self.bpmn_process_instance.refresh_waiting_tasks()
-
-            self.bpmn_process_instance.do_engine_steps(
-                exit_at=exit_at,
-                will_complete_task=will_complete_task,
-                did_complete_task=did_complete_task,
-            )
-
-            if self.bpmn_process_instance.is_completed():
-                self._script_engine.environment.finalize_result(
-                    self.bpmn_process_instance
-                )
-
-            self.process_bpmn_messages()
-            self.queue_waiting_receive_messages()
-        except SpiffWorkflowException as swe:
-            raise ApiError.from_workflow_exception("task_error", str(swe), swe) from swe
-
-        finally:
-            # self.log_spiff_step_details(step_details)
-            db.session.bulk_insert_mappings(SpiffStepDetailsModel, step_details)
-            spiff_logger = logging.getLogger("spiff")
-            for handler in spiff_logger.handlers:
-                if hasattr(handler, "bulk_insert_logs"):
-                    handler.bulk_insert_logs()  # type: ignore
-            db.session.commit()
-
-            if save:
-                self.save()
+#        step_details = []
+#
+#        tasks_to_log = {
+#            "BPMN Task",
+#            "Script Task",
+#            "Service Task",
+#            "Default Start Event",
+#            "Exclusive Gateway",
+#            "Call Activity",
+#            # "End Join",
+#            "End Event",
+#            "Default Throwing Event",
+#            "Subprocess",
+#            "Transactional Subprocess",
+#        }
+#
+#        # making a dictionary to ensure we are not shadowing variables in the other methods
+#        current_task_start_in_seconds = {}
+#
+#        def should_log(task: SpiffTask) -> bool:
+#            if (
+#                task.task_spec.spec_type in tasks_to_log
+#                and not task.task_spec.name.endswith(".EndJoin")
+#            ):
+#                return True
+#            return False
+#
+#        def will_complete_task(task: SpiffTask) -> None:
+#            if should_log(task):
+#                current_task_start_in_seconds["time"] = time.time()
+#                self.increment_spiff_step()
+#
+#        def did_complete_task(task: SpiffTask) -> None:
+#            if should_log(task):
+#                self._script_engine.environment.revise_state_with_task_data(task)
+#                step_details.append(
+#                    self.spiff_step_details_mapping(
+#                        task, current_task_start_in_seconds["time"], time.time()
+#                    )
+#                )
+#
+#        try:
+#            self.bpmn_process_instance.refresh_waiting_tasks()
+#
+#            self.bpmn_process_instance.do_engine_steps(
+#                exit_at=exit_at,
+#                will_complete_task=will_complete_task,
+#                did_complete_task=did_complete_task,
+#            )
+#
+#            if self.bpmn_process_instance.is_completed():
+#                self._script_engine.environment.finalize_result(
+#                    self.bpmn_process_instance
+#                )
+#
+#            self.process_bpmn_messages()
+#            self.queue_waiting_receive_messages()
+#        except SpiffWorkflowException as swe:
+#            raise ApiError.from_workflow_exception("task_error", str(swe), swe) from swe
+#
+#        finally:
+#            # self.log_spiff_step_details(step_details)
+#            db.session.bulk_insert_mappings(SpiffStepDetailsModel, step_details)
+#            spiff_logger = logging.getLogger("spiff")
+#            for handler in spiff_logger.handlers:
+#                if hasattr(handler, "bulk_insert_logs"):
+#                    handler.bulk_insert_logs()  # type: ignore
+#            db.session.commit()
+#
+#            if save:
+#                self.save()
 
     # log the spiff step details so we know what is processing the process
     # instance when a human task has a timer event.

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
@@ -122,7 +122,7 @@ class RunUntilServiceTaskExecutionStrategy(ExecutionStrategy):
     """For illustration purposes, not currently integrated.
 
     Would allow the `run` from the UI to execute until a service task then
-    return (to an interstitial page). The background processor when then take over.
+    return (to an interstitial page). The background processor would then take over.
     """
 
     def do_engine_steps(

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
@@ -1,6 +1,7 @@
 import logging
 import time
 from typing import Callable
+from typing import List
 
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow  # type: ignore
 from SpiffWorkflow.exceptions import SpiffWorkflowException  # type: ignore
@@ -41,9 +42,10 @@ class StepDetailLoggingDelegate(EngineStepDelegate):
         increment_spiff_step: SpiffStepIncrementer,
         spiff_step_details_mapping: SpiffStepDetailsMappingBuilder,
     ):
+        """__init__."""
         self.increment_spiff_step = increment_spiff_step
         self.spiff_step_details_mapping = spiff_step_details_mapping
-        self.step_details = []
+        self.step_details: List[dict] = []
         self.current_task_start_in_seconds = 0.0
         self.tasks_to_log = {
             "BPMN Task",
@@ -87,6 +89,7 @@ class ExecutionStrategy:
     """TODO: comment."""
 
     def __init__(self, delegate: EngineStepDelegate):
+        """__init__."""
         self.delegate = delegate
 
     def do_engine_steps(
@@ -126,6 +129,7 @@ class WorkflowExecutionService:
         process_instance_completer: ProcessInstanceCompleter,
         process_instance_saver: ProcessInstanceSaver,
     ):
+        """__init__."""
         self.bpmn_process_instance = bpmn_process_instance
         self.process_instance_model = process_instance_model
         self.execution_strategy = execution_strategy
@@ -134,7 +138,6 @@ class WorkflowExecutionService:
 
     def do_engine_steps(self, exit_at: None = None, save: bool = False) -> None:
         """Do_engine_steps."""
-
         try:
             self.bpmn_process_instance.refresh_waiting_tasks()
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
@@ -113,6 +113,13 @@ class GreedyExecutionStrategy(ExecutionStrategy):
             did_complete_task=self.delegate.did_complete_task,
         )
 
+def execution_strategy_named(name: str, delegate: EngineStepDelegate) -> ExecutionStrategy:
+    cls = {
+        "greedy": GreedyExecutionStrategy,
+    }[name]
+    
+    return cls(delegate)
+
 
 ProcessInstanceCompleter = Callable[[BpmnWorkflow], None]
 ProcessInstanceSaver = Callable[[], None]

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
@@ -1,0 +1,185 @@
+from SpiffWorkflow.task import Task as SpiffTask  # type: ignore
+from SpiffWorkflow.bpmn.workflow import BpmnWorkflow  # type: ignore
+from spiffworkflow_backend.models.db import db
+from spiffworkflow_backend.models.process_instance import ProcessInstanceModel
+
+from typing import Callable, Optional
+
+class EngineStepDelegate:
+    """TODO: comment."""
+    def will_complete_task(task: SpiffTask) -> None:
+        pass
+
+    def did_complete_task(task: SpiffTask) -> None:
+        pass
+
+    def save() -> None:
+        pass
+
+SpiffStepIncrementer = Callable[[], None]
+SpiffStepDetailsMappingBuilder = Callable[[SpiffTask, float, float], dict]
+
+class StepDetailLoggingEngineStepDelegate(EngineStepDelegate):
+    """TODO: comment."""
+    def __init__(self,
+        increment_spiff_step: SpiffStepIncrementer,
+        spiff_step_details_mapping: SpiffStepDetailsMappingBuilder,
+    ):
+        self.increment_spiff_step = increment_spiff_step
+        self.spiff_step_details_mapping = spiff_step_details_mapping
+        self.step_details = []
+        self.current_task_start_in_seconds = 0.0
+        self.tasks_to_log = {
+            "BPMN Task",
+            "Script Task",
+            "Service Task",
+            "Default Start Event",
+            "Exclusive Gateway",
+            "Call Activity",
+            # "End Join",
+            "End Event",
+            "Default Throwing Event",
+            "Subprocess",
+            "Transactional Subprocess",
+        }
+
+        def should_log(task: SpiffTask) -> bool:
+            return (
+                task.task_spec.spec_type in self.tasks_to_log
+                and not task.task_spec.name.endswith(".EndJoin")
+            )
+
+        def will_complete_task(task: SpiffTask) -> None:
+            if should_log(task):
+                self.current_task_start_in_seconds = time.time()
+                self.increment_spiff_step()
+
+        def did_complete_task(task: SpiffTask) -> None:
+            if should_log(task):
+                step_details.append(
+                    self.spiff_step_details_mapping(
+                        task, self.current_task_start_in_seconds, time.time()
+                    )
+                )
+
+    def save() -> None:
+        db.session.bulk_insert_mappings(SpiffStepDetailsModel, step_details)
+        db.session.commit()
+
+class ExecutionStrategy:
+    """TODO: comment."""
+    def __init__(self, bpmn_process_instance: BpmnWorkflow, delegate: EngineStepDelegate):
+        self.bpmn_process_instance = bpmn_process_instance
+        self.delegate = delegate
+
+    def do_engine_steps(self, exit_at: None = None) -> None:
+        pass
+    
+    def save() -> None:
+        self.delegate.save()
+
+class GreedyExecutionStrategy(ExecutionStrategy):
+    """TODO: comment."""
+    def do_engine_steps(self, exit_at: None = None) -> None:
+        self.bpmn_process_instance.do_engine_steps(
+            exit_at=exit_at,
+            will_complete_task=will_complete_task,
+            did_complete_task=did_complete_task,
+        )
+
+ProcessInstanceCompleter = Callable[[BpmnWorkflow], None]
+SaveHandler = Callable[[], None]
+
+class WorkflowExecutionService:
+    """TODO: comment."""
+    def __init__(self,
+        bpmn_process_instance: BpmnWorkflow,
+        process_instance_model: ProcessInstanceModel,
+        execution_strategy: ExecutionStrategy, 
+        process_instance_completer: ProcessInstanceCompleter,
+        save_handler: SaveHandler,
+    ):
+        self.bpmn_process_instance = bpmn_process_instance
+        self.process_instance_model = process_instance_model
+        self.execution_strategy = execution_strategy
+        self.process_instance_completer = process_instance_completer
+        self.save_handler = save_handler
+    
+    def do_engine_steps(self, exit_at: None = None, save: bool = False) -> None:
+        """Do_engine_steps."""
+
+        try:
+            self.bpmn_process_instance.refresh_waiting_tasks()
+
+            self.execution_strategy.do_engine_steps(exit_at)
+
+            if self.bpmn_process_instance.is_completed():
+                self.process_instance_completer(self.bpmn_process_instance)
+
+            self.process_bpmn_messages()
+            self.queue_waiting_receive_messages()
+        except SpiffWorkflowException as swe:
+            raise ApiError.from_workflow_exception("task_error", str(swe), swe) from swe
+
+        finally:
+            self.execution_strategy.save()
+            spiff_logger = logging.getLogger("spiff")
+            for handler in spiff_logger.handlers:
+                if hasattr(handler, "bulk_insert_logs"):
+                    handler.bulk_insert_logs()  # type: ignore
+            db.session.commit()
+
+            if save:
+                self.save_handler()
+
+    def process_bpmn_messages(self) -> None:
+        """Process_bpmn_messages."""
+        bpmn_messages = self.bpmn_process_instance.get_bpmn_messages()
+        for bpmn_message in bpmn_messages:
+            message_instance = MessageInstanceModel(
+                process_instance_id=self.process_instance_model.id,
+                user_id=self.process_instance_model.process_initiator_id,  # TODO: use the correct swimlane user when that is set up
+                message_type="send",
+                name=bpmn_message.name,
+                payload=bpmn_message.payload,
+                correlation_keys=self.bpmn_process_instance.correlations,
+            )
+            db.session.add(message_instance)
+            db.session.commit()
+
+    def queue_waiting_receive_messages(self) -> None:
+        """Queue_waiting_receive_messages."""
+        waiting_events = self.bpmn_process_instance.waiting_events()
+        waiting_message_events = filter(
+            lambda e: e["event_type"] == "Message", waiting_events
+        )
+
+        for event in waiting_message_events:
+            # Ensure we are only creating one message instance for each waiting message
+            if (
+                MessageInstanceModel.query.filter_by(
+                    process_instance_id=self.process_instance_model.id,
+                    message_type="receive",
+                    name=event["name"],
+                ).count()
+                > 0
+            ):
+                continue
+
+            # Create a new Message Instance
+            message_instance = MessageInstanceModel(
+                process_instance_id=self.process_instance_model.id,
+                user_id=self.process_instance_model.process_initiator_id,
+                message_type="receive",
+                name=event["name"],
+                correlation_keys=self.bpmn_process_instance.correlations,
+            )
+            for correlation_property in event["value"]:
+                message_correlation = MessageInstanceCorrelationRuleModel(
+                    message_instance_id=message_instance.id,
+                    name=correlation_property.name,
+                    retrieval_expression=correlation_property.retrieval_expression,
+                )
+                message_instance.correlation_rules.append(message_correlation)
+            db.session.add(message_instance)
+            db.session.commit()


### PR DESCRIPTION
In preparation for the interstitial page and the background processor handling engine steps differently, this breaks out the `do_engine_step` logic from `ProcessInstanceProcessor` and into a new `WorkflowExecutionService`. A delegate/callback pattern is used to prevent circular imports.

The logging of spiff step details is also decoupled from the driver code and the execution strategy. When implementing a new step execution strategy you don't have to ensure your steps are logged properly. Likewise if you want to improve (or omit) step logging you don't have to concern yourself with how steps are being executed.

The current step execution logic is preserved via the default `GreedyExecutionStrategy`. The old code to profile has been moved untested to a new `ProfiledWorkflowExecutionService`.

An example `RunUntilServiceTaskExecutionStrategy` is there largely for illustrative purposes. The idea is that `process_instance_run` could pass that strategy in so the `Run` button only executed until a service task and navigate to the interstitial page. Then the background processor would kick in and run with the greedy (or whatever) strategy until complete or a human task. Repeat with the appropriate mix of strategies.

Any number of strategies could be deployed - for instance one that queries all previous runs of the process model to see many tasks it should run before returning, or one that only does one task, one that only runs script tasks, one that runs for at most 5 seconds, etc, etc.