### PR TITLE
Balance lock with unlock

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_instances_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_instances_controller.py
@@ -117,10 +117,10 @@ def process_instance_run(
         )
 
     processor = ProcessInstanceProcessor(process_instance)
-    processor.lock_process_instance("Web")
 
     if do_engine_steps:
         try:
+            processor.lock_process_instance("Web")
             processor.do_engine_steps(save=True)
         except ApiError as e:
             ErrorHandlingService().handle_error(processor, e)


### PR DESCRIPTION
Not sure when this happens in practice, but if `process_instance_run` was called with do_engine_steps = False, the process instance would remain locked.