### PR TITLE
Safe asserts

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/assertion_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/assertion_service.py
@@ -1,0 +1,16 @@
+"""Assertion_service."""
+
+import contextlib
+import sentry_sdk
+from flask import current_app
+
+@contextlib.contextmanager
+def safe_assertion(condition: bool) -> None:
+    try:
+        yield
+    except AssertionError as e:
+        if not condition:
+            sentry_sdk.capture_exception(e)
+            current_app.logger.exception(e)
+            if current_app.config["ENV_IDENTIFIER"] == "local_development":
+                raise e

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/assertion_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/assertion_service.py
@@ -1,13 +1,15 @@
 """Assertion_service."""
-
 import contextlib
+from typing import Generator
+
 import sentry_sdk
 from flask import current_app
 
+
 @contextlib.contextmanager
-def safe_assertion(condition: bool) -> None:
+def safe_assertion(condition: bool) -> Generator[bool, None, None]:
     try:
-        yield
+        yield True
     except AssertionError as e:
         if not condition:
             sentry_sdk.capture_exception(e)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -103,9 +103,6 @@ from spiffworkflow_backend.services.workflow_execution_service import (
     execution_strategy_named,
 )
 from spiffworkflow_backend.services.workflow_execution_service import (
-    StepDetailLoggingDelegate,
-)
-from spiffworkflow_backend.services.workflow_execution_service import (
     TaskModelSavingDelegate,
 )
 from spiffworkflow_backend.services.workflow_execution_service import (
@@ -1617,7 +1614,6 @@ class ProcessInstanceProcessor:
         execution_strategy_name: Optional[str] = None,
     ) -> None:
         """Do_engine_steps."""
-
         # NOTE: Commenting out to test how this changes performance:
         # def spiff_step_details_mapping_builder(
         #     task: SpiffTask, start: float, end: float

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
@@ -291,7 +291,7 @@ class WorkflowExecutionService:
     def do_engine_steps(self, exit_at: None = None, save: bool = False) -> None:
         """Do_engine_steps."""
         with safe_assertion(
-            not ProcessInstanceLockService.has_lock(self.process_instance_model.id)
+            ProcessInstanceLockService.has_lock(self.process_instance_model.id)
         ) as tripped:
             if tripped:
                 raise AssertionError(


### PR DESCRIPTION
The implementation of this is not as beautiful as it would be in languages with macros, but still achieves the end goal of allowing assertions in code that pass `./bin/run_pyl` that hit during local development but result in logging/sentry notifications in other environments. This would allow for extra debugging information of assumptions that don't hold in non dev environments - especially when trying to debug issues in the background worker, etc.

The assertion error is reported at the call site and would occur event if assertions are disabled. Example [link](https://sartography.sentry.io/issues/4005529436/?environment=local_development&project=4503966086529024&query=AssertionError&referrer=issue-stream&statsPeriod=14d).

Logs show:

```
AssertionError: The current thread has not obtained a lock for this process instance (54).
Traceback (most recent call last):
  File "/app/src/spiffworkflow_backend/routes/process_instances_controller.py", line 131, in process_instance_run
    processor.do_engine_steps(save=True)
  File "/app/src/spiffworkflow_backend/services/process_instance_processor.py", line 1649, in do_engine_steps
    execution_service.do_engine_steps(exit_at, save)
  File "/app/src/spiffworkflow_backend/services/workflow_execution_service.py", line 297, in do_engine_steps
    raise AssertionError(
AssertionError: The current thread has not obtained a lock for this process instance (54).


```