### PR TITLE
Provide more details in process instance locking errors

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_instances_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_instances_controller.py
@@ -55,14 +55,20 @@ from spiffworkflow_backend.services.error_handling_service import ErrorHandlingS
 from spiffworkflow_backend.services.git_service import GitCommandError
 from spiffworkflow_backend.services.git_service import GitService
 from spiffworkflow_backend.services.message_service import MessageService
-from spiffworkflow_backend.services.process_instance_lock_service import ProcessInstanceLockService
+from spiffworkflow_backend.services.process_instance_lock_service import (
+    ProcessInstanceLockService,
+)
 from spiffworkflow_backend.services.process_instance_processor import (
     ProcessInstanceProcessor,
 )
 from spiffworkflow_backend.services.process_instance_queue_service import (
-    ProcessInstanceQueueService,
-    ProcessInstanceIsNotEnqueuedError,
     ProcessInstanceIsAlreadyLockedError,
+)
+from spiffworkflow_backend.services.process_instance_queue_service import (
+    ProcessInstanceIsNotEnqueuedError,
+)
+from spiffworkflow_backend.services.process_instance_queue_service import (
+    ProcessInstanceQueueService,
 )
 from spiffworkflow_backend.services.process_instance_report_service import (
     ProcessInstanceReportFilter,
@@ -132,7 +138,11 @@ def process_instance_run(
         try:
             processor.lock_process_instance("Web")
             processor.do_engine_steps(save=True)
-        except (ApiError, ProcessInstanceIsNotEnqueuedError, ProcessInstanceIsAlreadyLockedError) as e:
+        except (
+            ApiError,
+            ProcessInstanceIsNotEnqueuedError,
+            ProcessInstanceIsAlreadyLockedError,
+        ) as e:
             ErrorHandlingService().handle_error(processor, e)
             raise e
         except Exception as e:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_instances_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_instances_controller.py
@@ -55,11 +55,14 @@ from spiffworkflow_backend.services.error_handling_service import ErrorHandlingS
 from spiffworkflow_backend.services.git_service import GitCommandError
 from spiffworkflow_backend.services.git_service import GitService
 from spiffworkflow_backend.services.message_service import MessageService
+from spiffworkflow_backend.services.process_instance_lock_service import ProcessInstanceLockService
 from spiffworkflow_backend.services.process_instance_processor import (
     ProcessInstanceProcessor,
 )
 from spiffworkflow_backend.services.process_instance_queue_service import (
     ProcessInstanceQueueService,
+    ProcessInstanceIsNotEnqueuedError,
+    ProcessInstanceIsAlreadyLockedError,
 )
 from spiffworkflow_backend.services.process_instance_report_service import (
     ProcessInstanceReportFilter,
@@ -129,7 +132,7 @@ def process_instance_run(
         try:
             processor.lock_process_instance("Web")
             processor.do_engine_steps(save=True)
-        except ApiError as e:
+        except (ApiError, ProcessInstanceIsNotEnqueuedError, ProcessInstanceIsAlreadyLockedError) as e:
             ErrorHandlingService().handle_error(processor, e)
             raise e
         except Exception as e:
@@ -143,7 +146,8 @@ def process_instance_run(
                 task=task,
             ) from e
         finally:
-            processor.unlock_process_instance("Web")
+            if ProcessInstanceLockService.has_lock(process_instance.id):
+                processor.unlock_process_instance("Web")
 
         if not current_app.config["SPIFFWORKFLOW_BACKEND_RUN_BACKGROUND_SCHEDULER"]:
             MessageService.correlate_all_message_instances()

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_queue_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_queue_service.py
@@ -17,6 +17,7 @@ from spiffworkflow_backend.services.process_instance_lock_service import (
 class ProcessInstanceIsNotEnqueuedError(Exception):
     pass
 
+
 class ProcessInstanceIsAlreadyLockedError(Exception):
     pass
 
@@ -71,7 +72,8 @@ class ProcessInstanceQueueService:
 
         if queue_entry is None:
             raise ProcessInstanceIsNotEnqueuedError(
-                f"{locked_by} cannot lock process instance {process_instance.id}. It has not been enqueued."
+                f"{locked_by} cannot lock process instance {process_instance.id}. It"
+                " has not been enqueued."
             )
 
         if queue_entry.locked_by != locked_by:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_queue_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_queue_service.py
@@ -14,6 +14,9 @@ from spiffworkflow_backend.services.process_instance_lock_service import (
 )
 
 
+class ProcessInstanceIsNotEnqueuedError(Exception):
+    pass
+
 class ProcessInstanceIsAlreadyLockedError(Exception):
     pass
 
@@ -62,15 +65,19 @@ class ProcessInstanceQueueService:
             db.session.query(ProcessInstanceQueueModel)
             .filter(
                 ProcessInstanceQueueModel.process_instance_id == process_instance.id,
-                ProcessInstanceQueueModel.locked_by == locked_by,
             )
             .first()
         )
 
         if queue_entry is None:
+            raise ProcessInstanceIsNotEnqueuedError(
+                f"{locked_by} cannot lock process instance {process_instance.id}. It has not been enqueued."
+            )
+
+        if queue_entry.locked_by != locked_by:
             raise ProcessInstanceIsAlreadyLockedError(
-                f"Cannot lock process instance {process_instance.id}. "
-                "It has already been locked or has not been enqueued."
+                f"{locked_by} cannot lock process instance {process_instance.id}. "
+                f"It has already been locked by {queue_entry.locked_by}."
             )
 
         ProcessInstanceLockService.lock(process_instance.id, queue_entry)


### PR DESCRIPTION
The existing errors during enqueue/dequeue combined not enqueued and already dequeued into one error so couldn't tell what the scenario was without looking in the db. Also putting who is trying to lock and who already has the lock in the already locked error. Lastly in run don't try to unlock if an exception resulting in the lock not being obtained, else the locking error is showed with a unique constraint error.