### PR TITLE
Refresh process_instance after obtaining the background lock

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
@@ -25,7 +25,6 @@ from spiffworkflow_backend.models.process_instance_file_data import (
 from spiffworkflow_backend.models.process_model import ProcessModelInfo
 from spiffworkflow_backend.models.task import Task
 from spiffworkflow_backend.models.user import UserModel
-from spiffworkflow_backend.services.assertion_service import safe_assertion
 from spiffworkflow_backend.services.authorization_service import AuthorizationService
 from spiffworkflow_backend.services.git_service import GitCommandError
 from spiffworkflow_backend.services.git_service import GitService


### PR DESCRIPTION
Was able to reproduce this locally a few times before this change and not after, however same sizes are very low. Issue was the status of a process instance could have changed in between the times that we query in the background processor after peeking at the locks but before the process instance was locked. Fix is the lock the process instance and refresh it, then check that the status is the desired one before doing engine steps.

Still want to go back and make @jasquat's suggestions to not have the locking calls take the whole process instance model, will do those changes post UAT.