### PR TITLE
Handle the multiple single file upload widget case

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
@@ -278,6 +278,15 @@ class ProcessInstanceService:
                 for list_index, list_value in enumerate(value):
                     if isinstance(list_value, str):
                         yield (identifier, list_value, list_index)
+                    if isinstance(list_value, dict) and len(list_value) == 1:
+                        # the form can contain multiple single file uploads. in this case the
+                        # list contains dictionaries with a single key. when this is detected
+                        # the single value will be promoted to the list, overwriting the
+                        # dictionary. this makes this style of multiple file uploads appear
+                        # the same as a single multi file upload widget, which simplifies
+                        # downstream script tasks/file linking.
+                        for value_to_promote in list_value.values():
+                            yield (identifier, value_to_promote, list_index)
 
     @classmethod
     def file_data_models_for_data(

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_service.py
@@ -89,7 +89,7 @@ class TestProcessInstanceService(BaseTest):
         self._check_sample_file_data_model("uploaded_files", 0, models[0])
         self._check_sample_file_data_model("uploaded_files", 1, models[1])
 
-    def test_can_create_file_data_models_for_fix_of_file_data_and_non_file_data_values(
+    def test_can_create_file_data_models_for_mix_of_file_data_and_non_file_data_values(
         self,
         app: Flask,
         with_db_and_bpmn_file_cleanup: None,
@@ -122,6 +122,8 @@ class TestProcessInstanceService(BaseTest):
     ) -> None:
         data = {
             "not_a_file": "just a value",
+            "also_no_files": ["not a file", "also not a file"],
+            "still_no_files": [{"key": "value"}],
         }
         models = ProcessInstanceService.file_data_models_for_data(data, 111)
 
@@ -189,3 +191,25 @@ class TestProcessInstanceService(BaseTest):
             ],
             "not_a_file3": "just a value3",
         }
+
+    def test_can_create_file_data_models_for_mulitple_single_file_data_values(
+        self,
+        app: Flask,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        data = {
+            "File": [
+                {
+                    "supporting_files": self.SAMPLE_FILE_DATA,
+                },
+                {
+                    "supporting_files": self.SAMPLE_FILE_DATA,
+                },
+            ],
+        }
+        models = ProcessInstanceService.file_data_models_for_data(data, 111)
+
+        assert len(models) == 2
+        self._check_sample_file_data_model("File", 0, models[0])
+        self._check_sample_file_data_model("File", 1, models[1])


### PR DESCRIPTION
In the case of the "multiple single file upload" widget, instead of being an array of data urls, it was an array of dictionaries with a single key and a data url. This caused the file content swapping not to occur. Fix is to detect this file upload style and make it appear as if it was a single multiple file upload (array of data urls). This takes the file contents out of task data as expected and simplifies the downstream code - especially the file linking.