### PR TITLE
backend: log oauth payload on invalid_token error

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/user.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/user.py
@@ -264,6 +264,7 @@ def login_return(code: str, state: str, session_state: str = "") -> Optional[Res
         )
 
     else:
+        current_app.logger.error(f"id_token not found in payload from provider: {auth_token_object}")
         raise ApiError(
             error_code="invalid_token",
             message="Login failed. Please try again",


### PR DESCRIPTION
Because otherwise you have to manually edit the file to see the actual error, for example:
```python
{'error': 'unauthorized_client', 'error_description': 'Invalid client or Invalid client credentials'}
```