### PR TITLE
Optimistically skip some timers

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
@@ -2,7 +2,8 @@
 import base64
 import hashlib
 import time
-from datetime import datetime, timezone
+from datetime import datetime
+from datetime import timezone
 from typing import Any
 from typing import Dict
 from typing import Generator
@@ -102,7 +103,7 @@ class ProcessInstanceService:
             event_value = waiting_event.get("value")
             if event_value is not None:
                 event_datetime = TimerEventDefinition.get_datetime(event_value)
-                return event_datetime > now_in_utc
+                return event_datetime > now_in_utc  # type: ignore
         return False
 
     @classmethod

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_debug_controller.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_debug_controller.py
@@ -4,7 +4,6 @@ from tests.spiffworkflow_backend.helpers.base_test import BaseTest
 
 
 class TestDebugController(BaseTest):
-
     def test_test_raise_error(
         self,
         app: Flask,

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_service.py
@@ -1,5 +1,6 @@
 """Test_process_instance_processor."""
-from datetime import datetime, timezone
+from datetime import datetime
+from datetime import timezone
 from typing import Optional
 
 from flask.app import Flask
@@ -215,26 +216,32 @@ class TestProcessInstanceService(BaseTest):
         self._check_sample_file_data_model("File", 0, models[0])
         self._check_sample_file_data_model("File", 1, models[1])
 
-    def test_does_not_skip_events_it_does_not_know_about(self):
-        assert ProcessInstanceService.waiting_event_can_be_skipped(
-            {'event_type': 'Unknown', 'name': None, 'value': '2023-04-27T20:15:10.626656+00:00'},
-            datetime.now(timezone.utc)
-        ) == False
-
-    def test_does_skip_duration_timer_events_for_the_future(self):
-        assert ProcessInstanceService.waiting_event_can_be_skipped(
-            {'event_type': 'Duration Timer', 'name': None, 'value': '2023-04-27T20:15:10.626656+00:00'},
-            datetime.fromisoformat('2023-04-26T20:15:10.626656+00:00')
+    def test_does_not_skip_events_it_does_not_know_about(self) -> None:
+        assert not (
+            ProcessInstanceService.waiting_event_can_be_skipped(
+                {"event_type": "Unknown", "name": None, "value": "2023-04-27T20:15:10.626656+00:00"},
+                datetime.now(timezone.utc),
+            )
         )
 
-    def test_does_not_skip_duration_timer_events_for_the_past(self):
+    def test_does_skip_duration_timer_events_for_the_future(self) -> None:
         assert ProcessInstanceService.waiting_event_can_be_skipped(
-            {'event_type': 'Duration Timer', 'name': None, 'value': '2023-04-27T20:15:10.626656+00:00'},
-            datetime.fromisoformat('2023-04-28T20:15:10.626656+00:00')
-        ) == False
+            {"event_type": "Duration Timer", "name": None, "value": "2023-04-27T20:15:10.626656+00:00"},
+            datetime.fromisoformat("2023-04-26T20:15:10.626656+00:00"),
+        )
 
-    def test_does_not_skip_duration_timer_events_for_now(self):
-        assert ProcessInstanceService.waiting_event_can_be_skipped(
-            {'event_type': 'Duration Timer', 'name': None, 'value': '2023-04-27T20:15:10.626656+00:00'},
-            datetime.fromisoformat('2023-04-27T20:15:10.626656+00:00')
-        ) == False
+    def test_does_not_skip_duration_timer_events_for_the_past(self) -> None:
+        assert not (
+            ProcessInstanceService.waiting_event_can_be_skipped(
+                {"event_type": "Duration Timer", "name": None, "value": "2023-04-27T20:15:10.626656+00:00"},
+                datetime.fromisoformat("2023-04-28T20:15:10.626656+00:00"),
+            )
+        )
+
+    def test_does_not_skip_duration_timer_events_for_now(self) -> None:
+        assert not (
+            ProcessInstanceService.waiting_event_can_be_skipped(
+                {"event_type": "Duration Timer", "name": None, "value": "2023-04-27T20:15:10.626656+00:00"},
+                datetime.fromisoformat("2023-04-27T20:15:10.626656+00:00"),
+            )
+        )


### PR DESCRIPTION
In the background processor, if a `user_input_required` instance has an associated timer, and that timer is understood to happen in the future - optimistically skip it. This should further reduce the times a `user_input_required` instance is locked to check a timer. Currently only `Duration Timer` event types are handled.

Marking as draft until after the status demo.