### PR TITLE
Enables nginx https to proxy SpiffWorkflow Backend running on http

### DIFF
--- a/spiffworkflow-backend/wsgi.py
+++ b/spiffworkflow-backend/wsgi.py
@@ -7,6 +7,9 @@ from spiffworkflow_backend.services.acceptance_test_fixtures import (
 )
 
 app = create_app()
+if os.environ.get("SPIFFWORKFLOW_BACKEND_USE_WERKZEUG_MIDDLEWARE_PROXY_FIX") == "true":
+    from werkzeug.middleware.proxy_fix import ProxyFix
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1)
 
 # this is in here because when we put it in the create_app function,
 # it also loaded when we were running migrations, which resulted in a chicken/egg thing.


### PR DESCRIPTION
The patch adds the ProxyFix to Flask running SpiffWorkflow Backend on http by processing the 'X-Forwarded-Proto' header to make SpiffWorkflow aware that it should return https for the server urls etc rather than http.

This patch is enabled by setting environment variable: SPIFFWORKFLOW_BACKEND_USE_WERKZEUG_MIDDLEWARE_PROXY_FIX to true