### PR TITLE
Rename Save as draft to Close, add tooltip

### DIFF
--- a/spiffworkflow-frontend/cypress/pilot/NDR_PP1/initiaterequest.cy.js
+++ b/spiffworkflow-frontend/cypress/pilot/NDR_PP1/initiaterequest.cy.js
@@ -405,7 +405,7 @@ describe('Initiate a Request - Without Files', () => {
                 cy.get('#root_item_1_unit_price').type('4500');
 
                 cy.get('button')
-                    .contains(/^Save as draft$/)
+                    .contains(/^Close$/)
                     .click();
 
                 //cy.get('button')
@@ -505,7 +505,7 @@ describe('Initiate a Request - Without Files', () => {
                 cy.get('.cds--text-area__wrapper').find('#root').type('2021 Newest HP 17.3 inch FHD Laptop, AMD Ryzen 5 5500U 6core(Beat i7-1160G7, up to 4.0GHz),16GB RAM, 1TB PCIe SSD, Bluetooth 4.2, WiFi, HDMI, USB-A&C, Windows 10 S, w/Ghost Manta Accessories, Silver\nhttps://www.amazon.com/HP-i7-11G7-Bluetooth-Windows');
 
                 cy.get('button')
-                    .contains(/^Save as draft$/)
+                    .contains(/^Close$/)
                     .click();
 
                // cy.get('button')

--- a/spiffworkflow-frontend/src/routes/TaskShow.tsx
+++ b/spiffworkflow-frontend/src/routes/TaskShow.tsx
@@ -347,20 +347,21 @@ export default function TaskShow() {
 
     if (task.state === 'READY') {
       let submitButtonText = 'Submit';
-      let saveAsDraftButton = null;
+      let closeButton = null;
       if (task.typename === 'ManualTask') {
         submitButtonText = 'Continue';
       } else if (task.typename === 'UserTask') {
-        saveAsDraftButton = (
+        closeButton = (
           <Button
-            id="save-as-draft-button"
+            id="close-button"
             disabled={disabled}
             kind="secondary"
+            title="Save changes without submitting."
             onClick={() =>
               handleFormSubmit(currentFormObject, null, FormSubmitType.Draft)
             }
           >
-            Save as draft
+            Close
           </Button>
         );
       }
@@ -369,7 +370,7 @@ export default function TaskShow() {
           <Button type="submit" id="submit-button" disabled={disabled}>
             {submitButtonText}
           </Button>
-          {saveAsDraftButton}
+          {closeButton}
           <>
             {task.signal_buttons.map((signal) => (
               <Button


### PR DESCRIPTION
Renames the `Save as draft` button to `Close` and adds the tooltip `Save changes without submitting.` per ticket `8db276d473cd40c39697913b48aa8b12`.