### PR TITLE
If the form object is undefined, navigate to tasks

### DIFF
--- a/spiffworkflow-frontend/src/routes/TaskShow.tsx
+++ b/spiffworkflow-frontend/src/routes/TaskShow.tsx
@@ -176,6 +176,9 @@ export default function TaskShow() {
     if (disabled) {
       return;
     }
+    if (!formObject) {
+      navigate(`/tasks`);
+    }
     let queryParams = '';
     if (submitType === FormSubmitType.Draft) {
       queryParams = '?save_as_draft=true';


### PR DESCRIPTION
I can't properly reproduce this locally, but judging by the stack trace in `8db276d473cd40c39697913b48aa8b12` this is an optimistic fix. I set `formObject` to undefined locally and did get the same exception that this fixed.