### PR TITLE
View button styled the same as the go button.

### DIFF
--- a/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
+++ b/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
@@ -1597,22 +1597,27 @@ export default function ProcessInstanceListTable({
         }
 
         let buttonText = 'View';
-        let buttonKind = 'ghost';
-        if (
-          processInstance.status !== 'suspended' &&
-          hasAccessToCompleteTask &&
-          processInstance.task_id
-        ) {
+        if (hasAccessToCompleteTask && processInstance.task_id) {
           buttonText = 'Go';
-          buttonKind = 'secondary';
         }
 
         buttonElement = (
-          <Button kind={buttonKind} href={interstitialUrl}>
+          <Button kind='secondary' href={interstitialUrl}>
             {buttonText}
           </Button>
         );
-        currentRow.push(<td>{buttonElement}</td>);
+
+        console.log(processInstance.status);
+        if (
+          processInstance.status === 'not_started' ||
+          processInstance.status === 'user_input_required' ||
+          processInstance.status === 'waiting' ||
+          processInstance.status === 'complete'
+        ) {
+          currentRow.push(<td>{buttonElement}</td>);
+        } else {
+          currentRow.push(<td />);
+        }
       }
 
       const rowStyle = { cursor: 'pointer' };


### PR DESCRIPTION
Don't show the view button for Suspended, terminated, or Errored Processes when there is nothing to see. On the interstitial page, if the process is not runnable, return out of the process, don't keep looping forever.