### PR TITLE
Feature/view button

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
@@ -388,7 +388,6 @@ def _render_instructions_for_end_user(task_model: TaskModel, extensions: Optiona
 
 
 def _interstitial_stream(process_instance: ProcessInstanceModel) -> Generator[str, Optional[str], None]:
-
     def get_reportable_tasks() -> Any:
         return processor.bpmn_process_instance.get_tasks(
             TaskState.WAITING | TaskState.STARTED | TaskState.READY | TaskState.ERROR
@@ -404,10 +403,6 @@ def _interstitial_stream(process_instance: ProcessInstanceModel) -> Generator[st
         return_hash[return_type] = entity
         return f"data: {current_app.json.dumps(return_hash)} \n\n"
 
-    # do not do any processing if the instance is not currently active
-    if process_instance.status not in ProcessInstanceModel.active_statuses():
-        yield render_data("unrunnable_instance", process_instance)
-        return
 
     processor = ProcessInstanceProcessor(process_instance)
     reported_ids = []  # A list of all the ids reported by this endpoint so far.
@@ -430,6 +425,10 @@ def _interstitial_stream(process_instance: ProcessInstanceModel) -> Generator[st
                 yield render_data("task", task)
                 reported_ids.append(spiff_task.id)
             if spiff_task.state == TaskState.READY:
+                # do not do any processing if the instance is not currently active
+                if process_instance.status not in ProcessInstanceModel.active_statuses():
+                    yield render_data("unrunnable_instance", process_instance)
+                    return
                 try:
                     processor.do_engine_steps(execution_strategy_name="one_at_a_time")
                     processor.do_engine_steps(execution_strategy_name="run_until_user_message")

--- a/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
+++ b/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
@@ -1602,7 +1602,7 @@ export default function ProcessInstanceListTable({
         }
 
         buttonElement = (
-          <Button kind='secondary' href={interstitialUrl}>
+          <Button kind="secondary" href={interstitialUrl}>
             {buttonText}
           </Button>
         );

--- a/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
+++ b/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
@@ -1597,22 +1597,27 @@ export default function ProcessInstanceListTable({
         }
 
         let buttonText = 'View';
-        let buttonKind = 'ghost';
-        if (
-          processInstance.status !== 'suspended' &&
-          hasAccessToCompleteTask &&
-          processInstance.task_id
-        ) {
+        if (hasAccessToCompleteTask && processInstance.task_id) {
           buttonText = 'Go';
-          buttonKind = 'secondary';
         }
 
         buttonElement = (
-          <Button kind={buttonKind} href={interstitialUrl}>
+          <Button kind='secondary' href={interstitialUrl}>
             {buttonText}
           </Button>
         );
-        currentRow.push(<td>{buttonElement}</td>);
+
+        console.log(processInstance.status);
+        if (
+          processInstance.status === 'not_started' ||
+          processInstance.status === 'user_input_required' ||
+          processInstance.status === 'waiting' ||
+          processInstance.status === 'complete'
+        ) {
+          currentRow.push(<td>{buttonElement}</td>);
+        } else {
+          currentRow.push(<td />);
+        }
       }
 
       const rowStyle = { cursor: 'pointer' };

--- a/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
+++ b/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
@@ -1607,7 +1607,6 @@ export default function ProcessInstanceListTable({
           </Button>
         );
 
-        console.log(processInstance.status);
         if (
           processInstance.status === 'not_started' ||
           processInstance.status === 'user_input_required' ||


### PR DESCRIPTION
Don't show the view button for Suspended, terminated, or Errored Processes when there is nothing to see.
On the interstitial page, if the process is not runnable, return out of the process, don't keep looping forever.