### PR TITLE
Bug/more fun with admin tools

### DIFF
--- a/spiffworkflow-backend/poetry.lock
+++ b/spiffworkflow-backend/poetry.lock
@@ -3089,7 +3089,7 @@ lxml = "*"
 type = "git"
 url = "https://github.com/sartography/SpiffWorkflow"
 reference = "main"
-resolved_reference = "a68dec77ebb0960dd8097341df7575a34e435501"
+resolved_reference = "340e9983b5afd2e6e71df883e74f7dc20d4474dd"
 
 [[package]]
 name = "sqlalchemy"

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
@@ -438,14 +438,6 @@ def _interstitial_stream(process_instance: ProcessInstanceModel) -> Generator[st
                     )
                     yield render_data("error", api_error)
                     return
-                except Exception as e:
-                    api_error = ApiError(
-                        error_code="engine_steps_error",
-                        message=f"Failed to complete an automated task. Error was: {str(e)}",
-                        status_code=400,
-                    )
-                    yield render_data("error", api_error)
-                    return
         processor.refresh_waiting_tasks()
         ready_engine_task_count = get_ready_engine_step_count(processor.bpmn_process_instance)
         tasks = get_reportable_tasks()


### PR DESCRIPTION
I'm yanking the general exception catching because it made it impossible to debug a problem we ran into - and it results in roughly the same error message presented to the end user.  Updating SpiffWorkflow which will now handle the situation where a task does not have a parent task.  Which was causing the error in 