### PR TITLE
ci: add deploy tag to commit to avoid race conditions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,8 +63,9 @@ pipeline {
     stage('Build') {
       steps { script {
         dir("spiffworkflow-${params.COMPONENT}") {
+          /* Tag and Commit is combined to avoid clashes of parallel builds. */
           image = docker.build(
-            "${params.DOCKER_NAME}:${env.GIT_COMMIT.take(8)}",
+            "${params.DOCKER_NAME}:${params.DOCKER_TAG}-${env.GIT_COMMIT.take(8)}",
             "--label=commit='${env.GIT_COMMIT.take(8)}' ."
           )
         }


### PR DESCRIPTION
When parallel builds for different environments run on the same host at the same time then the one that finishes last overwrites the Docker image that was built first, since the commit will be the same.

>"So the last shall be first, and the first last: for many be called, but few chosen."
> – Matthew 20:16, King James Bible