### PR TITLE
Editor compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ t
 version_info.json
 .coverage*
 UNKNOWN.egg-info/
+process_models/

--- a/bin/run_editor
+++ b/bin/run_editor
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 
-SPIFFWORKFLOW_BACKEND_URL_FOR_FRONTEND="${SPIFFWORKFLOW_BACKEND_URL_FOR_FRONTEND:-http://localhost:${SPIFFWORKFLOW_FRONTEND_PORT:-8001}}"
-
 docker compose -f editor.docker-compose.yml up -d
 
 echo ""
 echo "Spiff Editor is ready."
 echo ""
-echo "Please open ${SPIFFWORKFLOW_BACKEND_URL_FOR_FRONTEND}"
+echo "Please open ${SPIFFWORKFLOW_BACKEND_URL_FOR_FRONTEND:-http://localhost:${SPIFFWORKFLOW_FRONTEND_PORT:-8001}}"

--- a/bin/run_editor
+++ b/bin/run_editor
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+SPIFF_EDITOR_BPMN_SPEC_DIR=$1 \
 docker compose -f editor.docker-compose.yml up -d
 
 echo ""

--- a/bin/run_editor
+++ b/bin/run_editor
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+SPIFFWORKFLOW_BACKEND_URL_FOR_FRONTEND="${SPIFFWORKFLOW_BACKEND_URL_FOR_FRONTEND:-http://localhost:${SPIFFWORKFLOW_FRONTEND_PORT:-8001}}"
+
+docker compose -f editor.docker-compose.yml up -d
+
+echo ""
+echo "Spiff Editor is ready."
+echo ""
+echo "Please open ${SPIFFWORKFLOW_BACKEND_URL_FOR_FRONTEND}"

--- a/bin/stop_editor
+++ b/bin/stop_editor
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+docker compose -f editor.docker-compose.yml down

--- a/bin/update_editor
+++ b/bin/update_editor
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+docker compose -f editor.docker-compose.yml pull

--- a/editor.docker-compose.yml
+++ b/editor.docker-compose.yml
@@ -37,7 +37,7 @@ services:
     ports:
       - "${SPIFF_BACKEND_PORT:-8000}:${SPIFF_BACKEND_PORT:-8000}/tcp"
     volumes:
-      - ./process_models:/app/process_models
+      - "${SPIFF_EDITOR_BPMN_SPEC_DIR:-./process_models}:/app/process_models"
       - ./log:/app/log
     healthcheck:
       test: "curl localhost:${SPIFF_BACKEND_PORT:-8000}/v1.0/status --fail"

--- a/editor.docker-compose.yml
+++ b/editor.docker-compose.yml
@@ -1,0 +1,66 @@
+services:
+  spiffworkflow-frontend:
+    container_name: spiffworkflow-frontend
+    image: ghcr.io/sartography/spiffworkflow-frontend:latest
+    depends_on:
+      spiffworkflow-backend:
+        condition: service_healthy
+    environment:
+      APPLICATION_ROOT: "/"
+      PORT0: "${SPIFFWORKFLOW_FRONTEND_PORT:-8001}"
+    ports:
+      - "${SPIFFWORKFLOW_FRONTEND_PORT:-8001}:${SPIFFWORKFLOW_FRONTEND_PORT:-8001}/tcp"
+
+  spiffworkflow-backend:
+    container_name: spiffworkflow-backend
+    image: ghcr.io/sartography/spiffworkflow-backend:latest
+    environment:
+      SPIFFWORKFLOW_BACKEND_APPLICATION_ROOT: "/"
+      SPIFFWORKFLOW_BACKEND_ENV: "local_development"
+      FLASK_DEBUG: "0"
+      FLASK_SESSION_SECRET_KEY: "${FLASK_SESSION_SECRET_KEY:-super_secret_key}"
+      # WARNING: Frontend is a static site which assumes frontend port - 1 on localhost.
+      SPIFFWORKFLOW_BACKEND_URL: "http://localhost:${SPIFF_BACKEND_PORT:-8000}"
+
+      SPIFFWORKFLOW_BACKEND_BPMN_SPEC_ABSOLUTE_DIR: "/app/process_models"
+      SPIFFWORKFLOW_BACKEND_CONNECTOR_PROXY_URL: "http://spiffworkflow-connector:8004"
+      SPIFFWORKFLOW_BACKEND_DATABASE_TYPE: "sqlite"
+      SPIFFWORKFLOW_BACKEND_LOAD_FIXTURE_DATA: "false"
+      SPIFFWORKFLOW_BACKEND_OPEN_ID_CLIENT_ID: "spiffworkflow-backend"
+      SPIFFWORKFLOW_BACKEND_OPEN_ID_CLIENT_SECRET_KEY: "my_open_id_secret_key"
+      SPIFFWORKFLOW_BACKEND_OPEN_ID_SERVER_URL: "http://localhost:${SPIFF_BACKEND_PORT:-8000}/openid"
+      SPIFFWORKFLOW_BACKEND_PERMISSIONS_FILE_NAME: "example.yml"
+      SPIFFWORKFLOW_BACKEND_PORT: "${SPIFF_BACKEND_PORT:-8000}"
+      SPIFFWORKFLOW_BACKEND_RUN_BACKGROUND_SCHEDULER: "false"
+      SPIFFWORKFLOW_BACKEND_UPGRADE_DB: "true"
+      SPIFFWORKFLOW_BACKEND_URL_FOR_FRONTEND: "http://localhost:${SPIFFWORKFLOW_FRONTEND_PORT:-8001}"
+    ports:
+      - "${SPIFF_BACKEND_PORT:-8000}:${SPIFF_BACKEND_PORT:-8000}/tcp"
+    volumes:
+      - ./process_models:/app/process_models
+      - ./log:/app/log
+    healthcheck:
+      test: "curl localhost:${SPIFF_BACKEND_PORT:-8000}/v1.0/status --fail"
+      interval: 10s
+      timeout: 5s
+      retries: 20
+
+  spiffworkflow-connector:
+    container_name: spiffworkflow-connector
+    image: ghcr.io/sartography/connector-proxy-demo:latest
+    environment:
+      FLASK_ENV: "${FLASK_ENV:-development}"
+      FLASK_DEBUG: "0"
+      FLASK_SESSION_SECRET_KEY: "${FLASK_SESSION_SECRET_KEY:-super_secret_key}"
+      CONNECTOR_PROXY_PORT: "${SPIFF_CONNECTOR_PORT:-8004}"
+    ports:
+      - "${SPIFF_CONNECTOR_PORT:-8004}:${SPIFF_CONNECTOR_PORT:-8004}/tcp"
+    healthcheck:
+      test: "curl localhost:${SPIFF_CONNECTOR_PORT:-8004}/liveness --fail"
+      interval: 10s
+      timeout: 5s
+      retries: 20
+
+volumes:
+  spiffworkflow_backend:
+    driver: local

--- a/editor.docker-compose.yml
+++ b/editor.docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   spiffworkflow-frontend:
     container_name: spiffworkflow-frontend
-    image: ghcr.io/sartography/spiffworkflow-frontend:latest
+    image: ghcr.io/sartography/spiffworkflow-frontend:main-latest
     depends_on:
       spiffworkflow-backend:
         condition: service_healthy
@@ -13,7 +13,7 @@ services:
 
   spiffworkflow-backend:
     container_name: spiffworkflow-backend
-    image: ghcr.io/sartography/spiffworkflow-backend:latest
+    image: ghcr.io/sartography/spiffworkflow-backend:main-latest
     environment:
       SPIFFWORKFLOW_BACKEND_APPLICATION_ROOT: "/"
       SPIFFWORKFLOW_BACKEND_ENV: "local_development"


### PR DESCRIPTION
Adds the start of the "editor" via a `editor.docker-compose.yml` and a set of scripts to run/stop and update the editor images. Once auth-less/editor parameters are available we can set them in this docker-compose file to see how the editor looks. Once merged you can:

`./bin/run_editor ~/some/bpmn/dir` 