### PR TITLE
allow turning off restricted python

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
@@ -169,6 +169,12 @@ SPIFFWORKFLOW_BACKEND_ENGINE_STEP_DEFAULT_STRATEGY_WEB = environ.get(
 # this is only used in CI. use SPIFFWORKFLOW_BACKEND_DATABASE_URI instead for real configuration
 SPIFFWORKFLOW_BACKEND_DATABASE_PASSWORD = environ.get("SPIFFWORKFLOW_BACKEND_DATABASE_PASSWORD", default=None)
 
+# we load the CustomBpmnScriptEngine at import time, where we do not have access to current_app,
+# so instead of using config, we use os.environ directly here.
+# SPIFFWORKFLOW_BACKEND_USE_RESTRICTED_SCRIPT_ENGINE = (
+#     environ.get("SPIFFWORKFLOW_BACKEND_USE_RESTRICTED_SCRIPT_ENGINE", default="true") == "true"
+# )
+
 SPIFFWORKFLOW_BACKEND_FEATURE_ELEMENT_UNITS_ENABLED = (
     environ.get("SPIFFWORKFLOW_BACKEND_FEATURE_ELEMENT_UNITS_ENABLED", default="false") == "true"
 )

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -278,9 +278,15 @@ class CustomBpmnScriptEngine(PythonScriptEngine):  # type: ignore
             "set": set,
         }
 
-        # This will overwrite the standard builtins
-        default_globals.update(safe_globals)
-        default_globals["__builtins__"]["__import__"] = _import
+        use_restricted_script_engine = True
+        if os.environ.get("SPIFFWORKFLOW_BACKEND_USE_RESTRICTED_SCRIPT_ENGINE") == "false":
+            use_restricted_script_engine = False
+
+        if use_restricted_script_engine:
+            # This will overwrite the standard builtins
+            default_globals.update(safe_globals)
+            default_globals["__builtins__"]["__import__"] = _import
+
         environment = CustomScriptEngineEnvironment(default_globals)
         super().__init__(environment=environment)
 


### PR DESCRIPTION
If people have a use case where they don't need to worry about security as much, it is now possible to turn off RestrictedPython using this environment variable:

`SPIFFWORKFLOW_BACKEND_USE_RESTRICTED_SCRIPT_ENGINE=false`