### PR TITLE
Fix issue when timer start event is greater than a day

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/specs/start_event.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/specs/start_event.py
@@ -56,7 +56,7 @@ class StartEvent(DefaultStartEvent):  # type: ignore
                 duration = cycle_duration.seconds
 
         start_delay_in_seconds = int(time_delta.total_seconds())
-                
+
         return (cycles, start_delay_in_seconds, duration)
 
     def evaluated_timer_expression(self, my_task: SpiffTask) -> Any:

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_workflow_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_workflow_service.py
@@ -45,6 +45,7 @@ def example_start_datetime_minus_5_mins_in_utc(
     example_datetime = datetime.fromisoformat(example_start_datetime_in_utc_str)
     yield example_datetime - timedelta(minutes=5)
 
+
 @pytest.fixture()
 def example_start_datetime_minus_1_day_and_5_mins_in_utc(
     example_start_datetime_in_utc_str: str,
@@ -110,7 +111,7 @@ class TestWorkflowService(BaseTest):
         cycles, _, duration = WorkflowService.next_start_event_configuration(workflow, now_in_utc)  # type: ignore
         assert cycles == 0
         assert duration == 0
-        
+
     def test_run_at_delay_is_30_for_30_second_duration_start_timer_event(self, now_in_utc: datetime) -> None:
         workflow = workflow_from_fragment(
             """

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_workflow_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_workflow_service.py
@@ -183,3 +183,49 @@ class TestWorkflowService(BaseTest):
             workflow, example_start_datetime_minus_1_day_and_5_mins_in_utc
         )  # type: ignore
         assert delay == 86700
+
+    def test_5_cycles_of_30_second_cycle_start_timer_event(self, now_in_utc: datetime) -> None:
+        workflow = workflow_from_fragment(
+            """
+            <bpmn:process id="Process_aldvgey" isExecutable="true">
+              <bpmn:startEvent id="StartEvent_1">
+                <bpmn:outgoing>Flow_1x1o335</bpmn:outgoing>
+                <bpmn:timerEventDefinition id="TimerEventDefinition_1vi6a54">
+                  <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">"R5/PT30S"</bpmn:timeCycle>
+                </bpmn:timerEventDefinition>
+              </bpmn:startEvent>
+              <bpmn:sequenceFlow id="Flow_1x1o335" sourceRef="StartEvent_1" targetRef="Event_0upbokh" />
+              <bpmn:endEvent id="Event_0upbokh">
+                <bpmn:incoming>Flow_1x1o335</bpmn:incoming>
+              </bpmn:endEvent>
+            </bpmn:process>
+            """,
+            "Process_aldvgey",
+        )
+        cycles, delay, duration = WorkflowService.next_start_event_configuration(workflow, now_in_utc)  # type: ignore
+        assert cycles == 5
+        assert delay == 30
+        assert duration == 30
+
+    def test_5_cycles_of_10000_second_cycle_start_timer_event(self, now_in_utc: datetime) -> None:
+        workflow = workflow_from_fragment(
+            """
+            <bpmn:process id="Process_aldvgey" isExecutable="true">
+              <bpmn:startEvent id="StartEvent_1">
+                <bpmn:outgoing>Flow_1x1o335</bpmn:outgoing>
+                <bpmn:timerEventDefinition id="TimerEventDefinition_1vi6a54">
+                  <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">"R5/PT10000S"</bpmn:timeCycle>
+                </bpmn:timerEventDefinition>
+              </bpmn:startEvent>
+              <bpmn:sequenceFlow id="Flow_1x1o335" sourceRef="StartEvent_1" targetRef="Event_0upbokh" />
+              <bpmn:endEvent id="Event_0upbokh">
+                <bpmn:incoming>Flow_1x1o335</bpmn:incoming>
+              </bpmn:endEvent>
+            </bpmn:process>
+            """,
+            "Process_aldvgey",
+        )
+        cycles, delay, duration = WorkflowService.next_start_event_configuration(workflow, now_in_utc)  # type: ignore
+        assert cycles == 5
+        assert delay == 10000
+        assert duration == 10000


### PR DESCRIPTION
Got bit by `timedelta.seconds` vs `timedelta.total_seconds()`. Fix is to always use `total_seconds()`. Also added some more unit tests around cycles and times greater than a day.