### PR TITLE
restore loop collection references

### DIFF
--- a/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
+++ b/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
@@ -467,11 +467,32 @@ export default function ReactDiagramEditor({
       if (alreadyImportedXmlRef.current) {
         return;
       }
-      diagramModelerToUse.importXML(diagramXMLToDisplay).then(() => {
-        if (diagramType === 'bpmn' || diagramType === 'readonly') {
-          diagramModelerToUse.get('canvas').zoom('fit-viewport');
-        }
-      });
+      diagramModelerToUse._moddle // eslint-disable-line no-underscore-dangle
+        .fromXML(diagramXMLToDisplay)
+        .then((result: any) => {
+          const refs = result.references.filter(
+            (r: any) =>
+              r.property === 'bpmn:loopDataInputRef' ||
+              r.property === 'bpmn:loopDataOutputRef'
+          );
+          const desc =
+            diagramModelerToUse._moddle.registry.getEffectiveDescriptor( // eslint-disable-line
+              'bpmn:ItemAwareElement'
+            );
+          refs.forEach((ref: any) => {
+            const props = {
+              id: ref.id,
+              name: ref.id ? typeof ref.name === 'undefined' : ref.name,
+            };
+            const elem = diagramModelerToUse._moddle.create(desc, props); // eslint-disable-line no-underscore-dangle
+            elem.$parent = ref.element;
+            ref.element.set(ref.property, elem);
+          });
+          diagramModelerToUse.importDefinitions(result.rootElement);
+          if (diagramType === 'bpmn' || diagramType === 'readonly') {
+            diagramModelerToUse.get('canvas').zoom('fit-viewport');
+          }
+        });
 
       alreadyImportedXmlRef.current = true;
     }

--- a/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
+++ b/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
@@ -467,32 +467,33 @@ export default function ReactDiagramEditor({
       if (alreadyImportedXmlRef.current) {
         return;
       }
-      diagramModelerToUse._moddle // eslint-disable-line no-underscore-dangle
-        .fromXML(diagramXMLToDisplay)
-        .then((result: any) => {
-          const refs = result.references.filter(
-            (r: any) =>
-              r.property === 'bpmn:loopDataInputRef' ||
-              r.property === 'bpmn:loopDataOutputRef'
-          );
-          const desc =
-            diagramModelerToUse._moddle.registry.getEffectiveDescriptor( // eslint-disable-line
-              'bpmn:ItemAwareElement'
+      if (diagramType === 'bpmn') {
+        diagramModelerToUse._moddle // eslint-disable-line no-underscore-dangle
+          .fromXML(diagramXMLToDisplay)
+          .then((result: any) => {
+            const refs = result.references.filter(
+              (r: any) =>
+                r.property === 'bpmn:loopDataInputRef' ||
+                r.property === 'bpmn:loopDataOutputRef'
             );
-          refs.forEach((ref: any) => {
-            const props = {
-              id: ref.id,
-              name: ref.id ? typeof ref.name === 'undefined' : ref.name,
-            };
-            const elem = diagramModelerToUse._moddle.create(desc, props); // eslint-disable-line no-underscore-dangle
-            elem.$parent = ref.element;
-            ref.element.set(ref.property, elem);
+            const desc =
+              diagramModelerToUse._moddle.registry.getEffectiveDescriptor( // eslint-disable-line
+                'bpmn:ItemAwareElement'
+              );
+            refs.forEach((ref: any) => {
+              const props = {
+                id: ref.id,
+                name: ref.id ? typeof ref.name === 'undefined' : ref.name,
+              };
+              const elem = diagramModelerToUse._moddle.create(desc, props); // eslint-disable-line no-underscore-dangle
+              elem.$parent = ref.element;
+              ref.element.set(ref.property, elem);
+            });
+            diagramModelerToUse.importDefinitions(result.rootElement);
           });
-          diagramModelerToUse.importDefinitions(result.rootElement);
-          if (diagramType === 'bpmn' || diagramType === 'readonly') {
-            diagramModelerToUse.get('canvas').zoom('fit-viewport');
-          }
-        });
+      } else {
+        diagramModelerToUse.importXML(diagramXMLToDisplay);
+      }
 
       alreadyImportedXmlRef.current = true;
     }


### PR DESCRIPTION
The modeller strips the input and output collections when paring the XML because it can't resolve them; this adds them back in.