### PR TITLE
Allow terminating not_started instances

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
@@ -370,6 +370,8 @@ def _interstitial_stream(process_instance: ProcessInstanceModel) -> Generator[st
 
     def render_instructions(spiff_task: SpiffTask) -> str:
         task_model = TaskModel.query.filter_by(guid=str(spiff_task.id)).first()
+        if task_model is None:
+            return ""
         extensions = TaskService.get_extensions_from_task_model(task_model)
         return _render_instructions_for_end_user(task_model, extensions)
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -8,6 +8,7 @@ import re
 import time
 import uuid
 from collections.abc import Callable
+from contextlib import suppress
 from datetime import datetime
 from datetime import timedelta
 from hashlib import sha256
@@ -15,7 +16,6 @@ from typing import Any
 from typing import NewType
 from typing import TypedDict
 from uuid import UUID
-from contextlib import suppress
 
 import _strptime  # type: ignore
 import dateparser


### PR DESCRIPTION
Instances driven by a start timer event can be in a state* where they are not really ready for deep processing of tasks. Suppress the KeyError that happens on terminate and allow the interstitial code to show an empty message instead of bailing on NoneType. I can't explicitly check for `not_started` since you could suspend a non_started instance and get into the same situation. When we create bpmn definitions on save this can be avoided (or at least for the most part).