### PR TITLE
Show callers for non primary files

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
@@ -633,14 +633,17 @@ paths:
               schema:
                 type: string
 
-  /processes/callers:
+  /processes/callers/{bpmn_process_identifiers}:
     parameters:
-      - name: bpmn_process_identifier
-        in: query
+      - name: bpmn_process_identifiers
+        in: path
         required: true
-        description: the bpmn process identifier/id (not the name with spaces and not the process model identifier)
+        description: the bpmn process identifiers/ids (not the names with spaces and not the process model identifiers)
         schema:
-          type: string
+          type: array
+          items:
+            type: string
+          minItems: 1
     get:
       operationId: spiffworkflow_backend.routes.process_api_blueprint.process_caller_list
       summary:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/file.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/file.py
@@ -70,6 +70,7 @@ class File:
     references: list[SpecReference] | None = None
     file_contents: bytes | None = None
     process_model_id: str | None = None
+    bpmn_process_ids: list[str] | None = None
     file_contents_hash: str | None = None
 
     def __post_init__(self) -> None:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
@@ -69,8 +69,6 @@ def process_list() -> Any:
 
 
 def process_caller_list(bpmn_process_identifiers: list[str]) -> Any:
-    print(f"______________>>>> {bpmn_process_identifiers}")
-    print(f"______________>>>> {type(bpmn_process_identifiers)}")
     callers = ProcessCallerService.callers(bpmn_process_identifiers)
     references = (
         SpecReferenceCache.query.filter_by(type="process").filter(SpecReferenceCache.identifier.in_(callers)).all()

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
@@ -68,8 +68,10 @@ def process_list() -> Any:
     return SpecReferenceSchema(many=True).dump(references)
 
 
-def process_caller_list(bpmn_process_identifier: str) -> Any:
-    callers = ProcessCallerService.callers(bpmn_process_identifier)
+def process_caller_list(bpmn_process_identifiers: list[str]) -> Any:
+    print(f"______________>>>> {bpmn_process_identifiers}")
+    print(f"______________>>>> {type(bpmn_process_identifiers)}")
+    callers = ProcessCallerService.callers(bpmn_process_identifiers)
     references = (
         SpecReferenceCache.query.filter_by(type="process").filter(SpecReferenceCache.identifier.in_(callers)).all()
     )

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
@@ -16,6 +16,7 @@ from werkzeug.datastructures import FileStorage
 
 from spiffworkflow_backend.exceptions.api_error import ApiError
 from spiffworkflow_backend.interfaces import IdToProcessGroupMapping
+from spiffworkflow_backend.models.file import FileType
 from spiffworkflow_backend.models.process_group import ProcessGroup
 from spiffworkflow_backend.models.process_instance_report import ProcessInstanceReportModel
 from spiffworkflow_backend.models.process_model import ProcessModelInfo
@@ -34,8 +35,7 @@ from spiffworkflow_backend.services.process_model_service import ProcessModelWit
 from spiffworkflow_backend.services.process_model_test_runner_service import ProcessModelTestRunner
 from spiffworkflow_backend.services.spec_file_service import ProcessModelFileInvalidError
 from spiffworkflow_backend.services.spec_file_service import SpecFileService
-from spiffworkflow_backend.services.process_caller_service import ProcessCallerService
-from spiffworkflow_backend.models.file import FileType
+
 
 def process_model_create(
     modified_process_group_id: str, body: dict[str, str | bool | int | None | list]
@@ -294,7 +294,7 @@ def process_model_file_show(modified_process_model_identifier: str, file_name: s
 
     if file.type == FileType.bpmn.value:
         file.bpmn_process_ids = SpecFileService.get_bpmn_process_ids_for_file_contents(file_contents)
-    
+
     return make_response(jsonify(file), 200)
 
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
@@ -291,6 +291,9 @@ def process_model_file_show(modified_process_model_identifier: str, file_name: s
     file_contents_hash = sha256(file_contents).hexdigest()
     file.file_contents_hash = file_contents_hash
     file.process_model_id = process_model.id
+
+    if file.type == FileType.bpmn.value:
+        file.bpmn_process_ids = SpecFileService.get_bpmn_process_ids_for_file_contents(file_contents)
     
     return make_response(jsonify(file), 200)
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
@@ -34,7 +34,8 @@ from spiffworkflow_backend.services.process_model_service import ProcessModelWit
 from spiffworkflow_backend.services.process_model_test_runner_service import ProcessModelTestRunner
 from spiffworkflow_backend.services.spec_file_service import ProcessModelFileInvalidError
 from spiffworkflow_backend.services.spec_file_service import SpecFileService
-
+from spiffworkflow_backend.services.process_caller_service import ProcessCallerService
+from spiffworkflow_backend.models.file import FileType
 
 def process_model_create(
     modified_process_group_id: str, body: dict[str, str | bool | int | None | list]
@@ -290,6 +291,7 @@ def process_model_file_show(modified_process_model_identifier: str, file_name: s
     file_contents_hash = sha256(file_contents).hexdigest()
     file.file_contents_hash = file_contents_hash
     file.process_model_id = process_model.id
+    
     return make_response(jsonify(file), 200)
 
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_caller_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_caller_service.py
@@ -1,8 +1,7 @@
 from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.models.process_caller import ProcessCallerCacheModel
 from sqlalchemy import or_
-from spiffworkflow_backend.services.custom_parser import MyCustomParser
-import io
+
 
 class ProcessCallerService:
     @staticmethod

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_caller_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_caller_service.py
@@ -1,7 +1,8 @@
 from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.models.process_caller import ProcessCallerCacheModel
 from sqlalchemy import or_
-
+from spiffworkflow_backend.services.custom_parser import MyCustomParser
+import io
 
 class ProcessCallerService:
     @staticmethod
@@ -30,10 +31,10 @@ class ProcessCallerService:
         db.session.commit()
 
     @staticmethod
-    def callers(process_id: str) -> list[str]:
+    def callers(process_ids: list[str]) -> list[str]:
         records = (
             db.session.query(ProcessCallerCacheModel)
-            .filter(ProcessCallerCacheModel.process_identifier == process_id)
+            .filter(ProcessCallerCacheModel.process_identifier.in_(process_ids))
             .all()
         )
-        return list({r.calling_process_identifier for r in records})
+        return sorted({r.calling_process_identifier for r in records})

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -790,7 +790,9 @@ class ProcessInstanceProcessor:
                 )
             else:
                 if group_model is None:
-                    raise (NoPotentialOwnersForTaskError(f"Could not find a group with name matching lane: {task_lane}"))
+                    raise (
+                        NoPotentialOwnersForTaskError(f"Could not find a group with name matching lane: {task_lane}")
+                    )
                 potential_owner_ids = [i.user_id for i in group_model.user_group_assignments]
                 self.raise_if_no_potential_owners(
                     potential_owner_ids,

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/spec_file_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/spec_file_service.py
@@ -82,7 +82,7 @@ class SpecFileService(FileSystemService):
         parser = MyCustomParser()
         parser.add_bpmn_xml(cls.get_etree_from_xml_bytes(binary_data))
         return list(parser.process_parsers.keys())
-    
+
     @classmethod
     def get_references_for_file_contents(
         cls, process_model_info: ProcessModelInfo, file_name: str, binary_data: bytes

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/spec_file_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/spec_file_service.py
@@ -78,6 +78,12 @@ class SpecFileService(FileSystemService):
         return etree.fromstring(binary_data, parser=etree_xml_parser)  # noqa: S320
 
     @classmethod
+    def get_bpmn_process_ids_for_file_contents(cls, binary_data: bytes) -> list[str]:
+        parser = MyCustomParser()
+        parser.add_bpmn_xml(cls.get_etree_from_xml_bytes(binary_data))
+        return list(parser.process_parsers.keys())
+    
+    @classmethod
     def get_references_for_file_contents(
         cls, process_model_info: ProcessModelInfo, file_name: str, binary_data: bytes
     ) -> list[SpecReference]:

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_api.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_api.py
@@ -565,7 +565,7 @@ class TestProcessApi(BaseTest):
 
         # get the results
         response = client.get(
-            "/v1.0/processes/callers?bpmn_process_identifier=Level2",
+            "/v1.0/processes/callers/Level2",
             headers=self.logged_in_headers(with_super_admin_user),
         )
         assert response.json is not None

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_caller_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_caller_service.py
@@ -110,19 +110,19 @@ class TestProcessCallerService(BaseTest):
         assert ProcessCallerService.count() == 2
 
     def test_can_return_no_callers_when_no_records(self, with_no_process_callers: None) -> None:
-        assert ProcessCallerService.callers("bob") == []
+        assert ProcessCallerService.callers(["bob"]) == []
 
     def test_can_return_no_callers_when_process_id_is_unknown(self, with_multiple_process_callers: None) -> None:
-        assert ProcessCallerService.callers("bob") == []
+        assert ProcessCallerService.callers(["bob"]) == []
 
     def test_can_return_single_caller(self, with_single_process_caller: None) -> None:
-        assert ProcessCallerService.callers("called_once") == ["one_caller"]
+        assert ProcessCallerService.callers(["called_once"]) == ["one_caller"]
 
     def test_can_return_mulitple_callers(self, with_multiple_process_callers: None) -> None:
-        callers = sorted(ProcessCallerService.callers("called_many"))
+        callers = sorted(ProcessCallerService.callers(["called_many"]))
         assert callers == ["one_caller", "three_caller", "two_caller"]
 
     def test_can_return_single_caller_when_there_are_other_process_ids(
         self, with_single_process_caller: None, with_multiple_process_callers: None
     ) -> None:
-        assert ProcessCallerService.callers("called_once") == ["one_caller"]
+        assert ProcessCallerService.callers(["called_once"]) == ["one_caller"]

--- a/spiffworkflow-frontend/src/interfaces.ts
+++ b/spiffworkflow-frontend/src/interfaces.ts
@@ -124,6 +124,7 @@ export interface ProcessFile {
   type: string;
   file_contents?: string;
   file_contents_hash?: string;
+  bpmn_process_ids?: string[];
 }
 
 export interface ProcessInstanceMetadata {

--- a/spiffworkflow-frontend/src/routes/ProcessModelEditDiagram.tsx
+++ b/spiffworkflow-frontend/src/routes/ProcessModelEditDiagram.tsx
@@ -173,7 +173,7 @@ export default function ProcessModelEditDiagram() {
   useEffect(() => {
     if (processModel !== null) {
       HttpService.makeCallToBackend({
-        path: `/processes/callers?bpmn_process_identifier=${processModel.primary_process_id}`,
+        path: `/processes/callers/${processModel.primary_process_id},bob`,
         successCallback: setCallers,
       });
     }

--- a/spiffworkflow-frontend/src/routes/ProcessModelEditDiagram.tsx
+++ b/spiffworkflow-frontend/src/routes/ProcessModelEditDiagram.tsx
@@ -171,9 +171,10 @@ export default function ProcessModelEditDiagram() {
   }, [processModelPath, params]);
 
   useEffect(() => {
-    if (processModel !== null) {
+    const bpmn_process_ids = processModelFile?.bpmn_process_ids;
+    if (processModel !== null && bpmn_process_ids) {
       HttpService.makeCallToBackend({
-        path: `/processes/callers/${processModel.primary_process_id},bob`,
+        path: `/processes/callers/${bpmn_process_ids.join(',')}`,
         successCallback: setCallers,
       });
     }


### PR DESCRIPTION
Fixes `8db276d473cd40c39697913b48aa8b12`. When a bpmn file is opened for editing, return a list of its process ids which are then passed to the callers endpoint. Previous the process id of the primary file was returned. I moved the inputs into the path since specifying multiple params in the url was weird from a variable naming standpoint. Also makes the frontend code a bit simpler.