### PR TITLE
when loading task data from the server in task show, convert null bac…

### DIFF
--- a/spiffworkflow-frontend/src/helpers.test.tsx
+++ b/spiffworkflow-frontend/src/helpers.test.tsx
@@ -3,7 +3,7 @@ import {
   isInteger,
   slugifyString,
   underscorizeString,
-  recursivelyNullifyUndefinedValuesInPlace,
+  recursivelyChangeNullAndUndefined,
 } from './helpers';
 
 test('it can slugify a string', () => {
@@ -58,9 +58,43 @@ test('it can replace undefined values in object with null', () => {
 
   expect((sampleData.items[1] as any).contacts.zoom).toEqual(undefined);
 
-  const result = recursivelyNullifyUndefinedValuesInPlace(sampleData);
+  const result = recursivelyChangeNullAndUndefined(sampleData, null);
   expect(result).toEqual(sampleData);
   expect(result.items[1].contacts.zoom).toEqual(null);
+  expect(result.items[2]).toEqual('HEY');
+  expect(result.contacts.awesome).toEqual(false);
+  expect(result.contacts.info).toEqual('');
+});
+
+test('it can replace null values in object with undefined', () => {
+  const sampleData = {
+    talentType: 'foo',
+    rating: 'bar',
+    contacts: {
+      gmeets: null,
+      zoom: null,
+      phone: 'baz',
+      awesome: false,
+      info: '',
+    },
+    items: [
+      null,
+      {
+        contacts: {
+          gmeets: null,
+          zoom: null,
+          phone: 'baz',
+        },
+      },
+      'HEY',
+    ],
+  };
+
+  expect((sampleData.items[1] as any).contacts.zoom).toEqual(null);
+
+  const result = recursivelyChangeNullAndUndefined(sampleData, undefined);
+  expect(result).toEqual(sampleData);
+  expect(result.items[1].contacts.zoom).toEqual(undefined);
   expect(result.items[2]).toEqual('HEY');
   expect(result.contacts.awesome).toEqual(false);
   expect(result.contacts.info).toEqual('');

--- a/spiffworkflow-frontend/src/helpers.tsx
+++ b/spiffworkflow-frontend/src/helpers.tsx
@@ -26,19 +26,19 @@ export const underscorizeString = (inputString: string) => {
   return slugifyString(inputString).replace(/-/g, '_');
 };
 
-export const recursivelyNullifyUndefinedValuesInPlace = (obj: any) => {
+export const recursivelyChangeNullAndUndefined = (obj: any, newValue: any) => {
   if (obj === null || obj === undefined) {
-    return null;
+    return newValue;
   }
   if (Array.isArray(obj)) {
     obj.forEach((value: any, index: number) => {
       // eslint-disable-next-line no-param-reassign
-      obj[index] = recursivelyNullifyUndefinedValuesInPlace(value);
+      obj[index] = recursivelyChangeNullAndUndefined(value, newValue);
     });
   } else if (typeof obj === 'object') {
     Object.entries(obj).forEach(([key, value]) => {
       // eslint-disable-next-line no-param-reassign
-      obj[key] = recursivelyNullifyUndefinedValuesInPlace(value);
+      obj[key] = recursivelyChangeNullAndUndefined(value, newValue);
     });
   }
   return obj;

--- a/spiffworkflow-frontend/src/routes/TaskShow.tsx
+++ b/spiffworkflow-frontend/src/routes/TaskShow.tsx
@@ -17,7 +17,7 @@ import HttpService from '../services/HttpService';
 import useAPIError from '../hooks/UseApiError';
 import {
   modifyProcessIdentifierForPathParam,
-  recursivelyNullifyUndefinedValuesInPlace,
+  recursivelyChangeNullAndUndefined,
 } from '../helpers';
 import { EventDefinition, Task } from '../interfaces';
 import ProcessBreadcrumb from '../components/ProcessBreadcrumb';
@@ -49,7 +49,9 @@ export default function TaskShow() {
   useEffect(() => {
     const processResult = (result: Task) => {
       setTask(result);
-      setTaskData(result.data);
+
+      // convert null back to undefined so rjsf doesn't attempt to incorrectly validate them
+      setTaskData(recursivelyChangeNullAndUndefined(result.data, undefined));
       setDisabled(false);
       if (!result.can_complete) {
         navigateToInterstitial(result);
@@ -123,7 +125,7 @@ export default function TaskShow() {
 
     // NOTE: rjsf sets blanks values to undefined and JSON.stringify removes keys with undefined values
     // so we convert undefined values to null recursively so that we can unset values in form fields
-    recursivelyNullifyUndefinedValuesInPlace(dataToSubmit);
+    recursivelyChangeNullAndUndefined(dataToSubmit, null);
 
     HttpService.makeCallToBackend({
       path: `/tasks/${params.process_instance_id}/${params.task_id}${queryParams}`,


### PR DESCRIPTION
…k to undefined so rjsf does not validate the values w/ burnettk