### PR TITLE
added a script task script to get a task data value based on key name…

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/scripts/get_task_data_value.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/scripts/get_task_data_value.py
@@ -1,0 +1,38 @@
+from typing import Any
+
+from spiffworkflow_backend.models.script_attributes_context import ScriptAttributesContext
+from spiffworkflow_backend.scripts.script import Script
+
+
+class GetTaskDataValue(Script):
+    @staticmethod
+    def requires_privileged_permissions() -> bool:
+        """We have deemed this function safe to run without elevated permissions."""
+        return False
+
+    def get_description(self) -> str:
+        return (
+            "Checks to see if given value is in task data and returns its value. "
+            "If does not exist or is None, it returns the default value."
+        )
+
+    def run(self, script_attributes_context: ScriptAttributesContext, *args: Any, **kwargs: Any) -> Any:
+        variable_to_check = args[0]
+        default_value = args[1]
+
+        task = script_attributes_context.task
+        if task is None:
+            return default_value
+
+        task_data = task.data
+        if task_data is None:
+            return default_value
+
+        if variable_to_check not in task_data.keys():
+            return default_value
+
+        value = task_data[variable_to_check]
+        if value is None:
+            return default_value
+
+        return value

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/scripts/test_get_task_data_value.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/scripts/test_get_task_data_value.py
@@ -19,7 +19,5 @@ class TestGetTaskDataValue(BaseTest):
             process_instance_id=process_instance_id,
             process_model_identifier=process_model_identifier,
         )
-        result = GetTaskDataValue().run(
-            script_attributes_context, "the_var_name", "the_default_value"
-        )
+        result = GetTaskDataValue().run(script_attributes_context, "the_var_name", "the_default_value")
         assert result == "the_default_value"

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/scripts/test_get_task_data_value.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/scripts/test_get_task_data_value.py
@@ -1,0 +1,25 @@
+from flask import Flask
+from spiffworkflow_backend.models.script_attributes_context import ScriptAttributesContext
+from spiffworkflow_backend.scripts.get_task_data_value import GetTaskDataValue
+
+from tests.spiffworkflow_backend.helpers.base_test import BaseTest
+
+
+class TestGetTaskDataValue(BaseTest):
+    def test_get_task_data_value_script(
+        self,
+        app: Flask,
+        with_db_and_bpmn_file_cleanup: None,
+    ) -> None:
+        process_model_identifier = "test_process_model"
+        process_instance_id = 1
+        script_attributes_context = ScriptAttributesContext(
+            task=None,
+            environment_identifier="unit_testing",
+            process_instance_id=process_instance_id,
+            process_model_identifier=process_model_identifier,
+        )
+        result = GetTaskDataValue().run(
+            script_attributes_context, "the_var_name", "the_default_value"
+        )
+        assert result == "the_default_value"


### PR DESCRIPTION
Adds a new script which can be used in script tasks to allow getting the value from task data and returning a default value if the item cannot be found or the value is None.

It currently only looks in the top level of the task data for the given attribute name but it if this works well, we can expand upon it to do more.