### PR TITLE
Feature/fix_action_column 

### DIFF
--- a/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
+++ b/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
@@ -207,7 +207,8 @@ export default function ProcessInstanceListTable({
 
   const [showAdvancedOptions, setShowAdvancedOptions] =
     useState<boolean>(false);
-  const [withOldestOpenTask, setWithOldestOpenTask] = useState<boolean>(false);
+  const [withOldestOpenTask, setWithOldestOpenTask] =
+    useState<boolean>(showActionsColumn);
   const [systemReport, setSystemReport] = useState<string | null>(null);
   const [selectedUserGroup, setSelectedUserGroup] = useState<string | null>(
     null
@@ -434,6 +435,14 @@ export default function ProcessInstanceListTable({
           if (!reportMetadataBodyToUse.filter_by.includes(arf)) {
             reportMetadataBodyToUse.filter_by.push(arf);
           }
+        });
+      }
+
+      // If the showActionColumn is set to true, we need to include the with_oldest_open_task in the query params
+      if (showActionsColumn) {
+        reportMetadataBodyToUse.filter_by.push({
+          field_name: 'with_oldest_open_task',
+          field_value: true,
         });
       }
 

--- a/spiffworkflow-frontend/src/routes/ProcessInstanceList.tsx
+++ b/spiffworkflow-frontend/src/routes/ProcessInstanceList.tsx
@@ -49,7 +49,7 @@ export default function ProcessInstanceList({ variant }: OwnProps) {
       <br />
       {processInstanceBreadcrumbElement()}
       {processInstanceTitleElement()}
-      <ProcessInstanceListTable variant={variant} showActionsColumn />
+      <ProcessInstanceListTable  variant={variant} />
     </>
   );
 }

--- a/spiffworkflow-frontend/src/routes/ProcessInstanceList.tsx
+++ b/spiffworkflow-frontend/src/routes/ProcessInstanceList.tsx
@@ -49,7 +49,7 @@ export default function ProcessInstanceList({ variant }: OwnProps) {
       <br />
       {processInstanceBreadcrumbElement()}
       {processInstanceTitleElement()}
-      <ProcessInstanceListTable  variant={variant} />
+      <ProcessInstanceListTable variant={variant} showActionsColumn />
     </>
   );
 }


### PR DESCRIPTION
Was orginally going to drop the action column on the Process Instance List page, but after looking at how it would handle the links from the front page decided it really did have to work.  So now I just check to see if the "show_action" flag is set when creating the process instance list component, if it exists, we add a parameter to the filters of "with_oldest_open_task" that will give us the information we need to present a go button when appropriate. 