### PR TITLE
fixed up the unit test permission yml to better match the way we do p…

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/unit_testing.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/unit_testing.yml
@@ -29,20 +29,10 @@ permissions:
     allowed_permissions: [all]
     uri: ELEVATED
 
-  read-all:
-    groups: ["Finance Team", hr, admin]
-    allowed_permissions: [read]
-    uri: /*
-
-  process-instances-find-by-id:
+  basic-permission:
     groups: [everybody]
-    allowed_permissions: [read]
-    uri: /process-instances/find-by-id/*
-
-  tasks-crud:
-    groups: [everybody]
-    allowed_permissions: [create, read, update, delete]
-    uri: /tasks/*
+    allowed_permissions: [all]
+    uri: BASIC
 
   finance-admin-group:
     groups: ["Finance Team"]
@@ -54,12 +44,7 @@ permissions:
     allowed_permissions: [start]
     uri: PG:finance
 
-  finance-admin-model-lanes:
-    groups: ["Finance Team"]
-    allowed_permissions: [create, read, update, delete]
-    uri: /process-models/finance:model_with_lanes/*
-
-  finance-admin-instance-run:
-    groups: ["Finance Team"]
-    allowed_permissions: [create, read, update, delete]
-    uri: /process-instances/*
+  read-all-finance:
+    groups: [hr]
+    allowed_permissions: [read]
+    uri: PG:finance

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_openid_blueprint.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_openid_blueprint.py
@@ -61,7 +61,7 @@ class TestFlaskOpenId(BaseTest):
             "redirect_url": "http://localhost:7000/v1.0/login_return",
         }
         response = client.post("/openid/token", data=data, headers=headers)
-        assert response
+        assert response.status_code == 200
         assert response.is_json
         assert "access_token" in response.json
         assert "id_token" in response.json

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_authorization_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_authorization_service.py
@@ -48,6 +48,7 @@ class TestAuthorizationService(BaseTest):
         self.assert_user_has_permission(users["testuser2"], "update", "/v1.0/process-groups/finance:model1")
         self.assert_user_has_permission(users["testuser2"], "update", "/v1.0/process-groups", expected_result=False)
         self.assert_user_has_permission(users["testuser2"], "read", "/v1.0/process-groups")
+        self.assert_user_has_permission(users["testuser2"], "update", "/v1.0/process-groups", expected_result=False)
 
     def test_user_can_be_added_to_human_task_on_first_login(
         self,


### PR DESCRIPTION
This fixes permission tests to attempt to avoid false positives on passing permission tests when api calls change.

This is a CI change only.