### PR TITLE
do not convert null to a string when clearing out a typeahead field

### DIFF
--- a/spiffworkflow-frontend/src/rjsf/custom_widgets/TypeaheadWidget/TypeaheadWidget.tsx
+++ b/spiffworkflow-frontend/src/rjsf/custom_widgets/TypeaheadWidget/TypeaheadWidget.tsx
@@ -114,7 +114,15 @@ export default function TypeaheadWidget({
       onInputChange={typeaheadSearch}
       onChange={(event: any) => {
         setSelectedItem(event.selectedItem);
-        onChange(JSON.stringify(event.selectedItem));
+        let valueToUse = event.selectedItem;
+
+        // if the value is not truthy then do not stringify it
+        // otherwise things like null becomes "null"
+        if (valueToUse) {
+          valueToUse = JSON.stringify(valueToUse);
+        }
+
+        onChange(valueToUse);
       }}
       id={id}
       items={items}


### PR DESCRIPTION
The TypeaheadWidget component was previously assuming that everything was ok to convert to a json string.
We now special case falsey values, which preserves `null` as `null`, for example, rather than wrongly converting it to "null."