### PR TITLE
Feature/ignore save draft errors

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
@@ -598,7 +598,14 @@ def task_save_draft(
     principal = _find_principal_or_raise()
     process_instance = _find_process_instance_by_id_or_raise(process_instance_id)
     if not process_instance.can_submit_task():
-        return make_response(jsonify({"ok": True}), 200)
+        raise ApiError(
+            error_code="process_instance_not_runnable",
+            message=(
+                f"Process Instance ({process_instance.id}) has status "
+                f"{process_instance.status} which does not allow draft data to be saved."
+            ),
+            status_code=400,
+        )
 
     try:
         AuthorizationService.assert_user_can_complete_task(process_instance.id, task_guid, principal.user)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
@@ -598,14 +598,7 @@ def task_save_draft(
     principal = _find_principal_or_raise()
     process_instance = _find_process_instance_by_id_or_raise(process_instance_id)
     if not process_instance.can_submit_task():
-        raise ApiError(
-            error_code="process_instance_not_runnable",
-            message=(
-                f"Process Instance ({process_instance.id}) has status "
-                f"{process_instance.status} which does not allow draft data to be saved."
-            ),
-            status_code=400,
-        )
+        return make_response(jsonify({"ok": True}), 200)
 
     try:
         AuthorizationService.assert_user_can_complete_task(process_instance.id, task_guid, principal.user)

--- a/spiffworkflow-frontend/src/interfaces.ts
+++ b/spiffworkflow-frontend/src/interfaces.ts
@@ -258,15 +258,16 @@ export type HotCrumbItem = HotCrumbItemArray | HotCrumbItemObject;
 export interface ErrorForDisplay {
   message: string;
 
-  messageClassName?: string;
-  sentry_link?: string;
-  task_name?: string;
-  task_id?: string;
-  line_number?: number;
+  error_code?: string;
   error_line?: string;
   file_name?: string;
-  task_trace?: string[];
+  line_number?: number;
+  messageClassName?: string;
+  sentry_link?: string;
   stacktrace?: string[];
+  task_id?: string;
+  task_name?: string;
+  task_trace?: string[];
 }
 
 export interface AuthenticationParam {


### PR DESCRIPTION
* Do not attempt to save draft data if a manual task
* Handle process_instance_not_runnable error from the frontend