### PR TITLE
use a less wrong schema for save-draft

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
@@ -1949,7 +1949,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ProcessGroup"
+              $ref: "#/components/schemas/AwesomeUnspecifiedPayload"
       responses:
         "200":
           description: One task
@@ -3160,6 +3160,13 @@ components:
         report_metadata:
           nullable: false
           $ref: "#/components/schemas/ReportMetadata"
+    # if we pass a payload and give it a field of the wrong type (say we pass a field with value null and it wants a string)
+    # it will fail validation and not pass the request to the controller. that is generally not desirable
+    # until we take a closer look at the schemas in here.
+    AwesomeUnspecifiedPayload:
+      properties:
+        anythingyouwant:
+          type: string
     ReportMetadata:
       properties:
         columns:


### PR DESCRIPTION
rather than using the wrong data type, use one that is unspecified, since we cannot know the form of this request in advance. that way, when we happen to use a form field with a name that matches a property in the schema (like if we pass `{"name": null}` or similar), it will not fail at the connection api.yml validation step because the name is not a string.