### PR TITLE
use editor when navigating to a process model file

### DIFF
--- a/spiffworkflow-frontend/src/routes/ReactFormEditor.tsx
+++ b/spiffworkflow-frontend/src/routes/ReactFormEditor.tsx
@@ -288,7 +288,7 @@ export default function ReactFormEditor() {
               <Button
                 onClick={() =>
                   navigate(
-                    `/admin/process-models/${modifiedProcessModelId}/files/${params.file_name}`
+                    `/editor/process-models/${modifiedProcessModelId}/files/${params.file_name}`
                   )
                 }
                 variant="danger"


### PR DESCRIPTION
I think this is the only bad location. I ran this to verify:
```
grep -R '\/admin\/process-models\/' src/ -A 4 | grep files
```