### PR TITLE
use the task_updated_at_in_seconds column on the pi show page like we…

### DIFF
--- a/spiffworkflow-frontend/src/routes/ProcessInstanceShow.tsx
+++ b/spiffworkflow-frontend/src/routes/ProcessInstanceShow.tsx
@@ -323,7 +323,7 @@ export default function ProcessInstanceShow({ variant }: OwnProps) {
       return null;
     }
     let lastUpdatedTimeLabel = 'Updated At';
-    let lastUpdatedTime = processInstance.updated_at_in_seconds;
+    let lastUpdatedTime = processInstance.task_updated_at_in_seconds;
     if (processInstance.end_in_seconds) {
       lastUpdatedTimeLabel = 'Completed';
       lastUpdatedTime = processInstance.end_in_seconds;


### PR DESCRIPTION
This changes the Process Instance Show page to use the task_updated_at_in_seconds column for the updated time. This way it matches what is currently being done for the process instance list tables.