### PR TITLE
Don't schedule a cycle with 0 second duration

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
@@ -115,16 +115,16 @@ class ProcessInstanceService:
 
         for cycle in cycles:
             db.session.delete(cycle)
-            
+
         db.session.commit()
 
         if cycle_count != 0:
             if duration_in_seconds == 0:
                 raise ApiError(
-                        error_code="process_model_cycle_has_0_second_duration",
-                        message=f"Can not schedule a process model cycle with a duration in seconds of 0.",
-                    )
-            
+                    error_code="process_model_cycle_has_0_second_duration",
+                    message="Can not schedule a process model cycle with a duration in seconds of 0.",
+                )
+
             cycle = ProcessModelCycleModel(
                 process_model_identifier=process_model_identifier,
                 cycle_count=cycle_count,
@@ -133,7 +133,6 @@ class ProcessInstanceService:
             )
             db.session.add(cycle)
             db.session.commit()
-
 
     @classmethod
     def schedule_next_process_model_cycle(cls, process_instance_model: ProcessInstanceModel) -> None:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
@@ -116,7 +116,7 @@ class ProcessInstanceService:
         for cycle in cycles:
             db.session.delete(cycle)
 
-        if cycle_count != 0:
+        if cycle_count != 0 and duration_in_seconds != 0:
             cycle = ProcessModelCycleModel(
                 process_model_identifier=process_model_identifier,
                 cycle_count=cycle_count,

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
@@ -115,8 +115,16 @@ class ProcessInstanceService:
 
         for cycle in cycles:
             db.session.delete(cycle)
+            
+        db.session.commit()
 
-        if cycle_count != 0 and duration_in_seconds != 0:
+        if cycle_count != 0:
+            if duration_in_seconds == 0:
+                raise ApiError(
+                        error_code="process_model_cycle_has_0_second_duration",
+                        message=f"Can not schedule a process model cycle with a duration in seconds of 0.",
+                    )
+            
             cycle = ProcessModelCycleModel(
                 process_model_identifier=process_model_identifier,
                 cycle_count=cycle_count,
@@ -124,8 +132,8 @@ class ProcessInstanceService:
                 current_cycle=0,
             )
             db.session.add(cycle)
+            db.session.commit()
 
-        db.session.commit()
 
     @classmethod
     def schedule_next_process_model_cycle(cls, process_instance_model: ProcessInstanceModel) -> None:


### PR DESCRIPTION
If a cycle has a duration of 0 seconds don't schedule it else the system will continuously run the process. If the process equivalent of a while true loop is really desired, configure the cycle timer to fire every second. This should help with the cycle timer issue (5ce8a7a921d14e61bdb75d7907c52bbb) but is not a true root cause fix.