### PR TITLE
updated the column names for the tables on the process instance show …

### DIFF
--- a/spiffworkflow-frontend/src/components/MessageInstanceList.tsx
+++ b/spiffworkflow-frontend/src/components/MessageInstanceList.tsx
@@ -139,12 +139,12 @@ export default function MessageInstanceList({ processInstanceId }: OwnProps) {
           <tr>
             <th>Id</th>
             <th>Process</th>
-            <th>Process Instance</th>
+            <th>Process instance</th>
             <th>Name</th>
             <th>Type</th>
             <th>Details</th>
             <th>Status</th>
-            <th>Created At</th>
+            <th>Created at</th>
           </tr>
         </thead>
         <tbody>{rows}</tbody>

--- a/spiffworkflow-frontend/src/components/ProcessInstanceLogList.tsx
+++ b/spiffworkflow-frontend/src/components/ProcessInstanceLogList.tsx
@@ -81,7 +81,7 @@ export default function ProcessInstanceLogList({
   if (variant === 'all') {
     processInstanceShowPageBaseUrl = `/admin/process-instances/${processModelId}`;
   }
-  const taskNameHeader = isEventsView ? 'Task Name' : 'Milestone';
+  const taskNameHeader = isEventsView ? 'Task name' : 'Milestone';
   const tableType = isEventsView ? 'events' : 'milestones';
   const paginationQueryParamPrefix = `log-list-${tableType}`;
 
@@ -320,7 +320,7 @@ export default function ProcessInstanceLogList({
       tableHeaders.push(
         <>
           <th>Id</th>
-          <th>Bpmn Process</th>
+          <th>Bpmn process</th>
           <th>{taskNameHeader}</th>
         </>
       );
@@ -328,16 +328,16 @@ export default function ProcessInstanceLogList({
       tableHeaders.push(
         <>
           <th>{taskNameHeader}</th>
-          <th>Bpmn Process</th>
+          <th>Bpmn process</th>
         </>
       );
     }
     if (isEventsView) {
       tableHeaders.push(
         <>
-          <th>Task Identifier</th>
-          <th>Task Type</th>
-          <th>Event Type</th>
+          <th>Task identifier</th>
+          <th>Task type</th>
+          <th>Event type</th>
           <th>User</th>
         </>
       );
@@ -423,7 +423,7 @@ export default function ProcessInstanceLogList({
               }}
               shouldFilterItem={shouldFilterStringItem}
               placeholder="Choose a task bpmn identifier"
-              titleText="Task Identifier"
+              titleText="Task identifier"
               selectedItem={searchParams.get('bpmn_identifier')}
             />
           </Column>
@@ -440,7 +440,7 @@ export default function ProcessInstanceLogList({
               }}
               shouldFilterItem={shouldFilterStringItem}
               placeholder="Choose a task type"
-              titleText="Task Type"
+              titleText="Task type"
               selectedItem={searchParams.get('task_type')}
             />
           </Column>
@@ -457,7 +457,7 @@ export default function ProcessInstanceLogList({
               }}
               shouldFilterItem={shouldFilterStringItem}
               placeholder="Choose an event type"
-              titleText="Event Type"
+              titleText="Event type"
               selectedItem={searchParams.get('event_type')}
             />
           </Column>


### PR DESCRIPTION
Some additional column name changes for the tables shown on the process instance show page. All column headers should only have the first word capitalized and the rest lowercase.

Related to https://github.com/sartography/spiff-arena/pull/425