### PR TITLE
Feature/event payload migration fix

### DIFF
--- a/.github/workflows/docker_image_for_main_builds.yml
+++ b/.github/workflows/docker_image_for_main_builds.yml
@@ -32,6 +32,7 @@ on:
     branches:
       - main
       - feature/event-payloads-part-2
+      - feature/event-payload-migration-fix
       - spiffdemo
 
 jobs:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_migrations/version_1_3.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_migrations/version_1_3.py
@@ -121,6 +121,9 @@ class VersionOneThree:
                 db.session.add(child_task_definition)
 
     def process_task_model(self, task_model: TaskModel, task_definition: TaskDefinitionModel) -> None:
+        if task_definition.typename != "BoundaryEventSplit":
+            return
+
         task_model.properties_json["task_spec"] = task_definition.bpmn_identifier
         flag_modified(task_model, "properties_json")  # type: ignore
         db.session.add(task_model)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_migrations/version_1_3.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_migrations/version_1_3.py
@@ -59,12 +59,12 @@ class VersionOneThree:
         properties_json["name"] = task_definition.bpmn_identifier
 
         # mostly for ExclusiveGateways
-        if "cond_task_specs" in properties_json:
+        if "cond_task_specs" in properties_json and properties_json["cond_task_specs"] is not None:
             for cond_task_spec in properties_json["cond_task_specs"]:
                 cond_task_spec["task_spec"] = cond_task_spec["task_spec"].replace(
                     "BoundaryEventParent", "BoundaryEventSplit"
                 )
-        if "default_task_spec" in properties_json:
+        if "default_task_spec" in properties_json and properties_json["default_task_spec"] is not None:
             properties_json["default_task_spec"] = properties_json["default_task_spec"].replace(
                 "BoundaryEventParent", "BoundaryEventSplit"
             )

--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_migrations/version_1_3.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_migrations/version_1_3.py
@@ -60,10 +60,14 @@ class VersionOneThree:
 
         # mostly for ExclusiveGateways
         if "cond_task_specs" in properties_json:
-            for cond_task_spec in properties_json['cond_task_specs']:
-                cond_task_spec['task_spec'] = cond_task_spec['task_spec'].replace('BoundaryEventParent', 'BoundaryEventSplit')
+            for cond_task_spec in properties_json["cond_task_specs"]:
+                cond_task_spec["task_spec"] = cond_task_spec["task_spec"].replace(
+                    "BoundaryEventParent", "BoundaryEventSplit"
+                )
         if "default_task_spec" in properties_json:
-            properties_json['default_task_spec'] = properties_json['default_task_spec'].replace('BoundaryEventParent', 'BoundaryEventSplit')
+            properties_json["default_task_spec"] = properties_json["default_task_spec"].replace(
+                "BoundaryEventParent", "BoundaryEventSplit"
+            )
 
         task_definition.properties_json = properties_json
         flag_modified(task_definition, "properties_json")  # type: ignore

--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_migrations/version_1_3.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_migrations/version_1_3.py
@@ -41,70 +41,80 @@ class VersionOneThree:
         print("end VersionOneThree.run")
 
     def get_relevant_task_definitions(self) -> list[TaskDefinitionModel]:
-        task_definitions: list[TaskDefinitionModel] = TaskDefinitionModel.query.filter_by(
-            typename="_BoundaryEventParent"
+        task_definitions: list[TaskDefinitionModel] = TaskDefinitionModel.query.filter(
+            # this actually affect most types of gateways but Exclusive is the only we fully support in the WebUi as of 2023-08-15
+            TaskDefinitionModel.typename.in_(["_BoundaryEventParent", "ExclusiveGateway"])  # type: ignore
         ).all()
         return task_definitions
 
     def process_task_definition(self, task_definition: TaskDefinitionModel) -> None:
-        task_definition.typename = "BoundaryEventSplit"
+        task_definition.typename = task_definition.typename.replace("_BoundaryEventParent", "BoundaryEventSplit")
         task_definition.bpmn_identifier = task_definition.bpmn_identifier.replace(
             "BoundaryEventParent", "BoundaryEventSplit"
         )
 
         properties_json = copy.copy(task_definition.properties_json)
-        properties_json.pop("main_child_task_spec")
+        properties_json.pop("main_child_task_spec", None)
         properties_json["typename"] = task_definition.typename
         properties_json["name"] = task_definition.bpmn_identifier
+
+        # mostly for ExclusiveGateways
+        if "cond_task_specs" in properties_json:
+            for cond_task_spec in properties_json['cond_task_specs']:
+                cond_task_spec['task_spec'] = cond_task_spec['task_spec'].replace('BoundaryEventParent', 'BoundaryEventSplit')
+        if "default_task_spec" in properties_json:
+            properties_json['default_task_spec'] = properties_json['default_task_spec'].replace('BoundaryEventParent', 'BoundaryEventSplit')
+
         task_definition.properties_json = properties_json
         flag_modified(task_definition, "properties_json")  # type: ignore
         db.session.add(task_definition)
 
-        join_properties_json = {
-            "name": task_definition.bpmn_identifier.replace("BoundaryEventSplit", "BoundaryEventJoin"),
-            "manual": False,
-            "bpmn_id": None,
-            "lookahead": 2,
-            "inputs": properties_json["outputs"],
-            "outputs": [],
-            "split_task": task_definition.bpmn_identifier,
-            "threshold": None,
-            "cancel": True,
-            "typename": "BoundaryEventJoin",
-        }
+        if task_definition.typename == "BoundaryEventSplit":
+            join_properties_json = {
+                "name": task_definition.bpmn_identifier.replace("BoundaryEventSplit", "BoundaryEventJoin"),
+                "manual": False,
+                "bpmn_id": None,
+                "lookahead": 2,
+                "inputs": properties_json["outputs"],
+                "outputs": [],
+                "split_task": task_definition.bpmn_identifier,
+                "threshold": None,
+                "cancel": True,
+                "typename": "BoundaryEventJoin",
+            }
 
-        join_task_definition = TaskDefinitionModel(
-            bpmn_process_definition_id=task_definition.bpmn_process_definition_id,
-            bpmn_identifier=join_properties_json["name"],
-            typename=join_properties_json["typename"],
-            properties_json=join_properties_json,
-        )
-        db.session.add(join_task_definition)
-
-        for parent_bpmn_identifier in properties_json["inputs"]:
-            parent_task_definition = TaskDefinitionModel.query.filter_by(
-                bpmn_identifier=parent_bpmn_identifier,
+            join_task_definition = TaskDefinitionModel(
                 bpmn_process_definition_id=task_definition.bpmn_process_definition_id,
-            ).first()
-            parent_task_definition.properties_json["outputs"] = [
-                name.replace("BoundaryEventParent", "BoundaryEventSplit")
-                for name in parent_task_definition.properties_json["outputs"]
-            ]
-            flag_modified(parent_task_definition, "properties_json")  # type: ignore
-            db.session.add(parent_task_definition)
+                bpmn_identifier=join_properties_json["name"],
+                typename=join_properties_json["typename"],
+                properties_json=join_properties_json,
+            )
+            db.session.add(join_task_definition)
 
-        for child_bpmn_identifier in properties_json["outputs"]:
-            child_task_definition = TaskDefinitionModel.query.filter_by(
-                bpmn_identifier=child_bpmn_identifier,
-                bpmn_process_definition_id=task_definition.bpmn_process_definition_id,
-            ).first()
-            child_task_definition.properties_json["outputs"].append(join_task_definition.bpmn_identifier)
-            child_task_definition.properties_json["inputs"] = [
-                name.replace("BoundaryEventParent", "BoundaryEventSplit")
-                for name in child_task_definition.properties_json["inputs"]
-            ]
-            flag_modified(child_task_definition, "properties_json")  # type: ignore
-            db.session.add(child_task_definition)
+            for parent_bpmn_identifier in properties_json["inputs"]:
+                parent_task_definition = TaskDefinitionModel.query.filter_by(
+                    bpmn_identifier=parent_bpmn_identifier,
+                    bpmn_process_definition_id=task_definition.bpmn_process_definition_id,
+                ).first()
+                parent_task_definition.properties_json["outputs"] = [
+                    name.replace("BoundaryEventParent", "BoundaryEventSplit")
+                    for name in parent_task_definition.properties_json["outputs"]
+                ]
+                flag_modified(parent_task_definition, "properties_json")  # type: ignore
+                db.session.add(parent_task_definition)
+
+            for child_bpmn_identifier in properties_json["outputs"]:
+                child_task_definition = TaskDefinitionModel.query.filter_by(
+                    bpmn_identifier=child_bpmn_identifier,
+                    bpmn_process_definition_id=task_definition.bpmn_process_definition_id,
+                ).first()
+                child_task_definition.properties_json["outputs"].append(join_task_definition.bpmn_identifier)
+                child_task_definition.properties_json["inputs"] = [
+                    name.replace("BoundaryEventParent", "BoundaryEventSplit")
+                    for name in child_task_definition.properties_json["inputs"]
+                ]
+                flag_modified(child_task_definition, "properties_json")  # type: ignore
+                db.session.add(child_task_definition)
 
     def process_task_model(self, task_model: TaskModel, task_definition: TaskDefinitionModel) -> None:
         task_model.properties_json["task_spec"] = task_definition.bpmn_identifier


### PR DESCRIPTION
This fixes the migration related to https://github.com/sartography/spiff-arena/pull/401.

We found that ExclusiveGateways also made references to BoundaryEventParents so we need to ensure that we are updating those references as well to BoundaryEventSplit.

This will not fix already error'd instances caused by the PR-401 migration, but it should make it so newly migrated instances are migrated correctly and should not give the "AssertionError".