### PR TITLE
feature/fix-task-last-state-change

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_migrations/version_1_3.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_migrations/version_1_3.py
@@ -37,6 +37,9 @@ class VersionOneThree:
         for tdwe in task_definitions_with_events:
             self.update_event_definitions(tdwe)
 
+        # TODO: remove this once this gets out to prod
+        self.update_tasks_where_last_change_is_null()
+
         db.session.commit()
         print("end VersionOneThree.run")
 
@@ -210,3 +213,12 @@ class VersionOneThree:
             task_definition.properties_json = properties_json
             flag_modified(task_definition, "properties_json")  # type: ignore
             db.session.add(task_definition)
+
+    def update_tasks_where_last_change_is_null(self) -> None:
+        task_models = TaskModel.query.filter(TaskModel.properties_json.like('%last_state_change": null%')).all()  # type: ignore
+        for task_model in task_models:
+            parent_task_model = task_model.parent_task_model()
+            task_model.properties_json["last_state_change"] = parent_task_model.properties_json['last_state_change']
+            task_model.properties_json["task_spec"] = task_model.task_definition.bpmn_identifier
+            flag_modified(task_model, "properties_json")  # type: ignore
+        db.session.bulk_save_objects(task_models)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_migrations/version_1_3.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_migrations/version_1_3.py
@@ -218,7 +218,7 @@ class VersionOneThree:
         task_models = TaskModel.query.filter(TaskModel.properties_json.like('%last_state_change": null%')).all()  # type: ignore
         for task_model in task_models:
             parent_task_model = task_model.parent_task_model()
-            task_model.properties_json["last_state_change"] = parent_task_model.properties_json['last_state_change']
+            task_model.properties_json["last_state_change"] = parent_task_model.properties_json["last_state_change"]
             task_model.properties_json["task_spec"] = task_model.task_definition.bpmn_identifier
             flag_modified(task_model, "properties_json")  # type: ignore
         db.session.bulk_save_objects(task_models)


### PR DESCRIPTION
This will update tasks that have the incorrect task spec name and has last_state_change set to null in the properties json.

Once this is out, the following mysql query should return no results:
```
select count(*) from task where properties_json like '%last_state_change": null%';
```