### PR TITLE
feature/fix-support-auth-perms

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
@@ -538,6 +538,7 @@ class AuthorizationService:
         for permission in ["create", "read", "update", "delete"]:
             permissions_to_assign.append(PermissionToAssign(permission=permission, target_uri="/secrets/*"))
 
+        permissions_to_assign.append(PermissionToAssign(permission="read", target_uri="/authentications"))
         permissions_to_assign.append(PermissionToAssign(permission="read", target_uri="/authentication/configuration"))
         permissions_to_assign.append(PermissionToAssign(permission="read", target_uri="/authentication_begin/*"))
         permissions_to_assign.append(
@@ -559,7 +560,6 @@ class AuthorizationService:
         # can also start through messages as well
         permissions_to_assign.append(PermissionToAssign(permission="create", target_uri="/messages/*"))
         permissions_to_assign.append(PermissionToAssign(permission="read", target_uri="/messages"))
-        permissions_to_assign.append(PermissionToAssign(permission="read", target_uri="/authentications"))
 
         permissions_to_assign.append(
             PermissionToAssign(permission="create", target_uri="/can-run-privileged-script/*")

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_authorization_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_authorization_service.py
@@ -476,7 +476,6 @@ class TestAuthorizationService(BaseTest):
         return sorted(
             self._expected_basic_permissions()
             + [
-                ("/authentications", "read"),
                 ("/can-run-privileged-script/*", "create"),
                 ("/data-stores/*", "read"),
                 ("/debug/*", "create"),
@@ -511,6 +510,7 @@ class TestAuthorizationService(BaseTest):
                 ("/authentication/configuration", "read"),
                 ("/authentication/configuration", "update"),
                 ("/authentication_begin/*", "read"),
+                ("/authentications", "read"),
                 ("/secrets/*", "create"),
                 ("/secrets/*", "delete"),
                 ("/secrets/*", "read"),


### PR DESCRIPTION
This updates the support permission macro to remove access to the authentications endpoint. This will make it so the Configuration tab in the webui will no longer be visible at all.