### PR TITLE
Allow cycle timers to cycle when a human task is in play

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
@@ -685,7 +685,7 @@ def _task_submit_shared(
             status_code=400,
         )
 
-    processor = ProcessInstanceProcessor(process_instance)
+    processor = ProcessInstanceProcessor(process_instance, workflow_completed_handler=ProcessInstanceService.schedule_next_process_model_cycle)
     spiff_task = _get_spiff_task_from_process_instance(task_guid, process_instance, processor=processor)
     AuthorizationService.assert_user_can_complete_task(process_instance.id, str(spiff_task.id), principal.user)
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
@@ -685,7 +685,9 @@ def _task_submit_shared(
             status_code=400,
         )
 
-    processor = ProcessInstanceProcessor(process_instance, workflow_completed_handler=ProcessInstanceService.schedule_next_process_model_cycle)
+    processor = ProcessInstanceProcessor(
+        process_instance, workflow_completed_handler=ProcessInstanceService.schedule_next_process_model_cycle
+    )
     spiff_task = _get_spiff_task_from_process_instance(task_guid, process_instance, processor=processor)
     AuthorizationService.assert_user_can_complete_task(process_instance.id, str(spiff_task.id), principal.user)
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -95,7 +95,8 @@ TypeaheadDataStore.register_converter(SPIFF_SPEC_CONFIG)
 # Sorry about all this crap.  I wanted to move this thing to another file, but
 # importing a bunch of types causes circular imports.
 
-WorkflowCompletedHandler = Callable[[ProcessInstanceModel], None] 
+WorkflowCompletedHandler = Callable[[ProcessInstanceModel], None]
+
 
 def _import(name: str, glbls: dict[str, Any], *args: Any) -> None:
     if name not in glbls:
@@ -398,7 +399,7 @@ class ProcessInstanceProcessor:
         process_instance_model: ProcessInstanceModel,
         validate_only: bool = False,
         script_engine: PythonScriptEngine | None = None,
-        workflow_completed_handler: WorkflowCompletedHandler | None = None
+        workflow_completed_handler: WorkflowCompletedHandler | None = None,
     ) -> None:
         """Create a Workflow Processor based on the serialized information available in the process_instance model."""
         self._script_engine = script_engine or self.__class__._default_script_engine

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
@@ -259,7 +259,9 @@ class ProcessInstanceService:
     ) -> ProcessInstanceProcessor | None:
         processor = None
         with ProcessInstanceQueueService.dequeued(process_instance):
-            processor = ProcessInstanceProcessor(process_instance, workflow_completed_handler=cls.schedule_next_process_model_cycle)
+            processor = ProcessInstanceProcessor(
+                process_instance, workflow_completed_handler=cls.schedule_next_process_model_cycle
+            )
         if status_value and cls.can_optimistically_skip(processor, status_value):
             current_app.logger.info(f"Optimistically skipped process_instance {process_instance.id}")
             return None

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
@@ -240,8 +240,6 @@ class ProcessInstanceService:
                 cls.run_process_instance_with_processor(
                     process_instance, status_value=status_value, execution_strategy_name=execution_strategy_name
                 )
-                if process_instance.status == "complete":
-                    cls.schedule_next_process_model_cycle(process_instance)
             except ProcessInstanceIsAlreadyLockedError:
                 continue
             except Exception as e:
@@ -261,7 +259,7 @@ class ProcessInstanceService:
     ) -> ProcessInstanceProcessor | None:
         processor = None
         with ProcessInstanceQueueService.dequeued(process_instance):
-            processor = ProcessInstanceProcessor(process_instance)
+            processor = ProcessInstanceProcessor(process_instance, workflow_completed_handler=cls.schedule_next_process_model_cycle)
         if status_value and cls.can_optimistically_skip(processor, status_value):
             current_app.logger.info(f"Optimistically skipped process_instance {process_instance.id}")
             return None


### PR DESCRIPTION
Fix for issue #463 - the problem was the next cycle for a workflow with a cycle timer start event was only schedule if the background processor completed the workflow. Fix is to also schedule when the "web" completes the workflow, which can happen if a human task is in play. To prevent circular dependencies between the process instance processor and process instance service, added a new `workflow_completed_handler` which is provided by the background processor and tasks_controller.