### PR TITLE
feature/reassign-task-issue

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_report_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_report_service.py
@@ -498,12 +498,29 @@ class ProcessInstanceReportService:
                 HumanTaskModel,
                 and_(
                     HumanTaskModel.process_instance_id == ProcessInstanceModel.id,
-                    HumanTaskModel.lane_assignment_id.is_(None),  # type: ignore
                     HumanTaskModel.completed.is_(False),  # type: ignore
                 ),
             ).join(
                 HumanTaskUserModel,
                 and_(HumanTaskUserModel.human_task_id == HumanTaskModel.id, HumanTaskUserModel.user_id == user.id),
+            )
+
+            user_group_assignment_for_lane_assignment = aliased(UserGroupAssignmentModel)
+            process_instance_query = process_instance_query.outerjoin(
+                user_group_assignment_for_lane_assignment,
+                and_(
+                    user_group_assignment_for_lane_assignment.group_id == HumanTaskModel.lane_assignment_id,
+                    user_group_assignment_for_lane_assignment.user_id == user.id,
+                ),
+            ).filter(
+                # it should show up in your "Waiting for me" list IF:
+                #   1) task is not assigned to a group OR
+                #   2) you are not in the group
+                # In the case of number 2, it probably means you were added to the task individually by an admin
+                or_(
+                    HumanTaskModel.lane_assignment_id.is_(None),  # type: ignore
+                    user_group_assignment_for_lane_assignment.group_id.is_(None),
+                )
             )
             human_task_already_joined = True
             restrict_human_tasks_to_user = user


### PR DESCRIPTION
This updates the query for the process instance report instances_with_tasks_waiting_for_me it will return instances that have tasks manually assigned to a user through the assignment feature.

To test:
1. start a process model with a lane in it
2. when the instance gets to the human task within the lane, assign it to a user NOT in the group
3. check that the process instance shows up in the newly assigned user's "Waiting for me" table while a user that IS in the group has the instance in their "Waiting for [group]" table