### PR TITLE
turn-off-publish-button-unless-configed

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/process_model.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/process_model.py
@@ -53,6 +53,8 @@ class ProcessModelInfo:
     # TODO: delete these once they no no longer mentioned in current process_model.json files
     display_order: int | None = 0
 
+    actions: dict | None = None
+
     def __post_init__(self) -> None:
         self.sort_index = self.id
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
@@ -157,6 +157,14 @@ def process_model_show(modified_process_model_identifier: str, include_file_refe
         current_git_revision = ""
 
     process_model.bpmn_version_control_identifier = current_git_revision
+
+    available_actions = {}
+    if GitService.check_for_publish_configs(raise_on_missing=False):
+        available_actions = {
+            "publish": {"path": f"/process-model-publish/{modified_process_model_identifier}", "method": "POST"}
+        }
+    process_model.actions = available_actions
+
     return make_response(jsonify(process_model), 200)
 
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/git_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/git_service.py
@@ -84,26 +84,35 @@ class GitService:
         return cls.run_shell_command_to_get_stdout(shell_command)
 
     @classmethod
-    def check_for_basic_configs(cls) -> None:
+    def check_for_basic_configs(cls, raise_on_missing: bool = True) -> bool:
         if current_app.config["SPIFFWORKFLOW_BACKEND_GIT_SOURCE_BRANCH"] is None:
-            raise MissingGitConfigsError(
-                "Missing config for SPIFFWORKFLOW_BACKEND_GIT_SOURCE_BRANCH. "
-                "This is required for publishing process models"
-            )
+            if raise_on_missing:
+                raise MissingGitConfigsError(
+                    "Missing config for SPIFFWORKFLOW_BACKEND_GIT_SOURCE_BRANCH. "
+                    "This is required for publishing process models"
+                )
+            return False
+        return True
 
     @classmethod
-    def check_for_publish_configs(cls) -> None:
-        cls.check_for_basic_configs()
+    def check_for_publish_configs(cls, raise_on_missing: bool = True) -> bool:
+        if not cls.check_for_basic_configs(raise_on_missing=raise_on_missing):
+            return False
         if current_app.config["SPIFFWORKFLOW_BACKEND_GIT_PUBLISH_TARGET_BRANCH"] is None:
-            raise MissingGitConfigsError(
-                "Missing config for SPIFFWORKFLOW_BACKEND_GIT_PUBLISH_TARGET_BRANCH. "
-                "This is required for publishing process models"
-            )
+            if raise_on_missing:
+                raise MissingGitConfigsError(
+                    "Missing config for SPIFFWORKFLOW_BACKEND_GIT_PUBLISH_TARGET_BRANCH. "
+                    "This is required for publishing process models"
+                )
+            return False
         if current_app.config["SPIFFWORKFLOW_BACKEND_GIT_PUBLISH_CLONE_URL"] is None:
-            raise MissingGitConfigsError(
-                "Missing config for SPIFFWORKFLOW_BACKEND_GIT_PUBLISH_CLONE_URL."
-                " This is required for publishing process models"
-            )
+            if raise_on_missing:
+                raise MissingGitConfigsError(
+                    "Missing config for SPIFFWORKFLOW_BACKEND_GIT_PUBLISH_CLONE_URL."
+                    " This is required for publishing process models"
+                )
+            return False
+        return True
 
     @classmethod
     def run_shell_command_as_boolean(cls, command: list[str]) -> bool:

--- a/spiffworkflow-frontend/src/interfaces.ts
+++ b/spiffworkflow-frontend/src/interfaces.ts
@@ -3,6 +3,14 @@ export interface User {
   username: string;
 }
 
+export interface ApiAction {
+  path: string;
+  method: string;
+}
+export interface ApiActions {
+  [key: string]: ApiAction;
+}
+
 export interface Secret {
   id: number;
   key: string;
@@ -265,6 +273,7 @@ export interface ProcessModel {
   fault_or_suspend_on_exception?: string;
   exception_notification_addresses?: string[];
   bpmn_version_control_identifier?: string;
+  actions?: ApiActions;
 }
 
 export interface ProcessGroup {

--- a/spiffworkflow-frontend/src/routes/ProcessModelShow.tsx
+++ b/spiffworkflow-frontend/src/routes/ProcessModelShow.tsx
@@ -680,21 +680,23 @@ export default function ProcessModelShow() {
               confirmButtonLabel="Delete"
             />
           </Can>
-          <Can
-            I="POST"
-            a={targetUris.processModelPublishPath}
-            ability={ability}
-          >
-            <Button
-              kind="ghost"
-              data-qa="publish-process-model-button"
-              renderIcon={Upload}
-              iconDescription="Publish Changes"
-              hasIconOnly
-              onClick={publishProcessModel}
-              disabled={publishDisabled}
-            />
-          </Can>
+          {!processModel.actions || processModel.actions.publish ? (
+            <Can
+              I="POST"
+              a={targetUris.processModelPublishPath}
+              ability={ability}
+            >
+              <Button
+                kind="ghost"
+                data-qa="publish-process-model-button"
+                renderIcon={Upload}
+                iconDescription="Publish Changes"
+                hasIconOnly
+                onClick={publishProcessModel}
+                disabled={publishDisabled}
+              />
+            </Can>
+          ) : null}
           <Can I="POST" a={targetUris.processModelTestsPath} ability={ability}>
             {hasTestCaseFiles ? (
               <ProcessModelTestRun titleText="Run all BPMN unit tests for this process model" />


### PR DESCRIPTION
This will hide the publish button on the process-model page if the configs are not properly set up to publish.