### PR TITLE
Feature/pm readme file

### DIFF
--- a/spiffworkflow-frontend/src/components/MarkdownDisplayForFile.tsx
+++ b/spiffworkflow-frontend/src/components/MarkdownDisplayForFile.tsx
@@ -1,0 +1,34 @@
+import MDEditor from '@uiw/react-md-editor';
+import { useEffect, useState } from 'react';
+import HttpService from '../services/HttpService';
+
+type OwnProps = {
+  apiPath: string;
+};
+
+export default function MarkdownDisplayForFile({ apiPath }: OwnProps) {
+  const [markdownContents, setMarkdownContents] = useState<string | null>(null);
+
+  useEffect(() => {
+    const processResult = (result: any) => {
+      if (result.file_contents) {
+        setMarkdownContents(result.file_contents);
+      }
+    };
+
+    HttpService.makeCallToBackend({
+      path: apiPath,
+      successCallback: processResult,
+    });
+  }, [apiPath]);
+
+  if (markdownContents) {
+    return (
+      <div data-color-mode="light" className="with-bottom-margin">
+        <MDEditor.Markdown linkTarget="_blank" source={markdownContents} />
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
+++ b/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
@@ -1840,6 +1840,9 @@ export default function ProcessInstanceListTable({
         </Column>
       );
     }
+    if (!headerElement && !filterButtonLink) {
+      return null;
+    }
     return (
       <>
         <Column

--- a/spiffworkflow-frontend/src/index.css
+++ b/spiffworkflow-frontend/src/index.css
@@ -216,6 +216,14 @@ h1.with-icons {
   margin-top: 5px;
 }
 
+.with-icons {
+  margin-top: 10px;
+}
+
+.readme-container {
+  max-width: 640px;
+}
+
 dl {
   display: block;
   grid-template-columns: 35% 65%;

--- a/spiffworkflow-frontend/src/index.css
+++ b/spiffworkflow-frontend/src/index.css
@@ -484,11 +484,6 @@ th.table-header-right-align .cds--data-table, th.table-header-right-align .cds--
   margin-bottom: 1rem;
 }
 
-/* top and bottom margin since this is sort of the middle of three sections on the process model show page */
-.process-model-files-section {
-  margin: 2rem 0;
-}
-
 .filter-icon {
   text-align: right;
   padding-bottom: 10px;

--- a/spiffworkflow-frontend/src/routes/ReactFormEditor.tsx
+++ b/spiffworkflow-frontend/src/routes/ReactFormEditor.tsx
@@ -6,6 +6,7 @@ import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 // @ts-ignore
 import { Button, ButtonSet, Modal } from '@carbon/react';
 import { Can } from '@casl/react';
+import MDEditor from '@uiw/react-md-editor';
 import ProcessBreadcrumb from '../components/ProcessBreadcrumb';
 import HttpService from '../services/HttpService';
 import ButtonWithConfirmation from '../components/ButtonWithConfirmation';
@@ -57,6 +58,7 @@ export default function ReactFormEditor() {
 
   const hasDiagram = fileExtension === 'bpmn' || fileExtension === 'dmn';
   const hasFormBuilder = fileExtension === 'json';
+  const defaultFileName = searchParams.get('default_file_name');
 
   const editorDefaultLanguage = (() => {
     if (fileExtension === 'json') {
@@ -106,7 +108,8 @@ export default function ReactFormEditor() {
       setProcessModelFile(file);
     }
     if (!params.file_name) {
-      const fileNameWithExtension = `${newFileName}.${fileExtension}`;
+      const fileNameWithExtension =
+        defaultFileName ?? `${newFileName}.${fileExtension}`;
       navigate(
         `/admin/process-models/${modifiedProcessModelId}/form/${fileNameWithExtension}`
       );
@@ -119,7 +122,7 @@ export default function ReactFormEditor() {
 
     let url = `/process-models/${modifiedProcessModelId}/files`;
     let httpMethod = 'PUT';
-    let fileNameWithExtension = params.file_name;
+    let fileNameWithExtension = params.file_name || defaultFileName;
 
     if (newFileName) {
       fileNameWithExtension = `${newFileName}.${fileExtension}`;
@@ -217,6 +220,30 @@ export default function ReactFormEditor() {
       );
     }
     return null;
+  };
+
+  const editorArea = () => {
+    if (fileExtension === 'md') {
+      return (
+        <div data-color-mode="light">
+          <MDEditor
+            height={600}
+            highlightEnable={false}
+            value={processModelFileContents || ''}
+            onChange={(value) => setProcessModelFileContents(value || '')}
+          />
+        </div>
+      );
+    }
+    return (
+      <Editor
+        height={600}
+        width="auto"
+        defaultLanguage={editorDefaultLanguage}
+        defaultValue={processModelFileContents || ''}
+        onChange={(value) => setProcessModelFileContents(value || '')}
+      />
+    );
   };
 
   if (processModelFile || !params.file_name) {
@@ -318,13 +345,7 @@ export default function ReactFormEditor() {
             <ActiveUsers />
           </Can>
         </ButtonSet>
-        <Editor
-          height={600}
-          width="auto"
-          defaultLanguage={editorDefaultLanguage}
-          defaultValue={processModelFileContents || ''}
-          onChange={(value) => setProcessModelFileContents(value || '')}
-        />
+        {editorArea()}
       </main>
     );
   }


### PR DESCRIPTION
This adds the ability to create and view README.md files for process-models. This also updates the ReactFormEditor to use the MDEditor when viewing an md file instead of the monaco editor.

Testing notes:
 * if a process model does NOT have a README.md file, the show page will default to the files view. if the "About" tab is clicked, it should have a button that will take the user to a page where they can make a README.md file
 * if a process model does have a README.md it should display right away in the "About" tab