### PR TITLE
feature/draft-data-handle-dup-key

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/json_data.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/json_data.py
@@ -81,6 +81,13 @@ class JsonDataModel(SpiffworkflowBaseDBModel):
 
     @classmethod
     def create_and_insert_json_data_from_dict(cls, data: dict) -> str:
-        json_data_hash = sha256(json.dumps(data, sort_keys=True).encode("utf8")).hexdigest()
-        cls.insert_or_update_json_data_dict({"hash": json_data_hash, "data": data})
-        return json_data_hash
+        json_data_dict = cls.json_data_dict_from_dict(data)
+        cls.insert_or_update_json_data_dict(json_data_dict)
+        return json_data_dict["hash"]
+
+    @classmethod
+    def json_data_dict_from_dict(cls, data: dict) -> JsonDataDict:
+        task_data_json = json.dumps(data, sort_keys=True)
+        task_data_hash: str = sha256(task_data_json.encode("utf8")).hexdigest()
+        json_data_dict: JsonDataDict = {"hash": task_data_hash, "data": data}
+        return json_data_dict

--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/task_draft_data.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/task_draft_data.py
@@ -1,14 +1,25 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TypedDict
 
+from flask import current_app
 from sqlalchemy import ForeignKey
 from sqlalchemy import UniqueConstraint
+from sqlalchemy.dialects.mysql import insert as mysql_insert
+from sqlalchemy.dialects.postgresql import insert as postgres_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
 from spiffworkflow_backend.models.db import SpiffworkflowBaseDBModel
 from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.models.json_data import JsonDataModel  # noqa: F401
 from spiffworkflow_backend.models.process_instance import ProcessInstanceModel
+
+
+class TaskDraftDataDict(TypedDict):
+    process_instance_id: int
+    task_definition_id_path: str
+    saved_form_data_hash: str | None
 
 
 @dataclass
@@ -36,3 +47,23 @@ class TaskDraftDataModel(SpiffworkflowBaseDBModel):
         if self.saved_form_data_hash is not None:
             return JsonDataModel.find_data_dict_by_hash(self.saved_form_data_hash)
         return None
+
+    @classmethod
+    def insert_or_update_task_draft_data_dict(cls, task_draft_data_dict: TaskDraftDataDict) -> None:
+        on_duplicate_key_stmt = None
+        if current_app.config["SPIFFWORKFLOW_BACKEND_DATABASE_TYPE"] == "mysql":
+            insert_stmt = mysql_insert(TaskDraftDataModel).values([task_draft_data_dict])
+            on_duplicate_key_stmt = insert_stmt.on_duplicate_key_update(
+                saved_form_data_hash=insert_stmt.inserted.saved_form_data_hash
+            )
+        else:
+            insert_stmt = None
+            if current_app.config["SPIFFWORKFLOW_BACKEND_DATABASE_TYPE"] == "sqlite":
+                insert_stmt = sqlite_insert(TaskDraftDataModel).values([task_draft_data_dict])
+            else:
+                insert_stmt = postgres_insert(TaskDraftDataModel).values([task_draft_data_dict])
+            on_duplicate_key_stmt = insert_stmt.on_conflict_do_update(
+                index_elements=["process_instance_id", "task_definition_id_path"],
+                set_={"saved_form_data_hash": task_draft_data_dict["saved_form_data_hash"]},
+            )
+        db.session.execute(on_duplicate_key_stmt)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/task_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/task_service.py
@@ -512,13 +512,11 @@ class TaskService:
     def update_task_data_on_task_model_and_return_dict_if_updated(
         cls, task_model: TaskModel, task_data_dict: dict, task_model_data_column: str
     ) -> JsonDataDict | None:
-        task_data_json = json.dumps(task_data_dict, sort_keys=True)
-        task_data_hash: str = sha256(task_data_json.encode("utf8")).hexdigest()
-        json_data_dict: JsonDataDict | None = None
-        if getattr(task_model, task_model_data_column) != task_data_hash:
-            json_data_dict = {"hash": task_data_hash, "data": task_data_dict}
-            setattr(task_model, task_model_data_column, task_data_hash)
-        return json_data_dict
+        json_data_dict = JsonDataModel.json_data_dict_from_dict(task_data_dict)
+        if getattr(task_model, task_model_data_column) != json_data_dict["hash"]:
+            setattr(task_model, task_model_data_column, json_data_dict["hash"])
+            return json_data_dict
+        return None
 
     @classmethod
     def bpmn_process_and_descendants(cls, bpmn_processes: list[BpmnProcessModel]) -> list[BpmnProcessModel]:


### PR DESCRIPTION
This will update the record for task draft data if there is a conflict with the unique key. This is to avoid unnecessary duplicate key issues in the table where we really should update anyway since it is temporary draft data.

To test:
* submit forms and ensure the duplicate key error on draft data is no longer seen