### PR TITLE
update bpmn-js-spiffworkflow

### DIFF
--- a/spiffworkflow-frontend/package-lock.json
+++ b/spiffworkflow-frontend/package-lock.json
@@ -8357,7 +8357,7 @@
     },
     "node_modules/bpmn-js-spiffworkflow": {
       "version": "0.0.8",
-      "resolved": "git+ssh://git@github.com/sartography/bpmn-js-spiffworkflow.git#9a5c333dee239a3489d3f0471a4fae86f343c0a6",
+      "resolved": "git+ssh://git@github.com/sartography/bpmn-js-spiffworkflow.git#6007a770a5938c993173001a013116cedfc80359",
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.4",
@@ -38246,7 +38246,7 @@
       }
     },
     "bpmn-js-spiffworkflow": {
-      "version": "git+ssh://git@github.com/sartography/bpmn-js-spiffworkflow.git#9a5c333dee239a3489d3f0471a4fae86f343c0a6",
+      "version": "git+ssh://git@github.com/sartography/bpmn-js-spiffworkflow.git#6007a770a5938c993173001a013116cedfc80359",
       "from": "bpmn-js-spiffworkflow@github:sartography/bpmn-js-spiffworkflow#main",
       "requires": {
         "inherits": "^2.0.4",


### PR DESCRIPTION
This prevents the editor from crashing when variable names are defined on signals (and other item aware events)