### PR TITLE
feature/use-context-with-git-commands

### DIFF
--- a/spiffworkflow-backend/bin/git_commit_bpmn_models_repo
+++ b/spiffworkflow-backend/bin/git_commit_bpmn_models_repo
@@ -24,6 +24,8 @@ function failed_to_get_lock() {
 }
 
 function run() {
+  # we are very careful not to run "cd" from python, since it is at the process level and will screw up other threads.
+  # we are safe in this case because this entire script is run in a new process.
   cd "${bpmn_models_absolute_dir}"
   git add .
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/file_system_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/file_system_service.py
@@ -2,7 +2,6 @@ import json
 import os
 from collections.abc import Callable
 from collections.abc import Generator
-from contextlib import contextmanager
 from datetime import datetime
 from typing import Any
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/file_system_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/file_system_service.py
@@ -33,17 +33,6 @@ class FileSystemService:
     PROCESS_GROUP_JSON_FILE = "process_group.json"
     PROCESS_MODEL_JSON_FILE = "process_model.json"
 
-    # https://stackoverflow.com/a/24176022/6090676
-    @staticmethod
-    @contextmanager
-    def cd(newdir: str) -> Generator:
-        prevdir = os.getcwd()
-        os.chdir(os.path.expanduser(newdir))
-        try:
-            yield
-        finally:
-            os.chdir(prevdir)
-
     @classmethod
     def walk_files(
         cls, start_dir: str, directory_predicate: DirectoryPredicate, file_predicate: FilePredicate

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_git_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_git_service.py
@@ -14,6 +14,6 @@ class TestGitService(BaseTest):
         with_db_and_bpmn_file_cleanup: None,
     ) -> None:
         output = GitService.run_shell_command_to_get_stdout(
-            ["echo", "   This output should not end in space or newline  \n"]
+            ["echo", "   This output should not end in space or newline  \n"], prepend_with_git=False
         )
         assert output == "This output should not end in space or newline"


### PR DESCRIPTION
Using os.chdir from python causes it to change the directory for the entire process including other threads. This causes issues when multiple git commands are run at once so instead of using chdir from python, use the "c" option with git so it can change the directory when necessary. Since those git commands will run in their own processes this should no longer cause an issue.