### PR TITLE
Feature/pin form schemas to revision

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/process_instance.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/process_instance.py
@@ -89,13 +89,15 @@ class ProcessInstanceModel(SpiffworkflowBaseDBModel):
     start_in_seconds: int | None = db.Column(db.Integer, index=True)
     end_in_seconds: int | None = db.Column(db.Integer, index=True)
     task_updated_at_in_seconds: int = db.Column(db.Integer, nullable=True)
-    updated_at_in_seconds: int = db.Column(db.Integer)
-    created_at_in_seconds: int = db.Column(db.Integer)
     status: str = db.Column(db.String(50), index=True)
 
-    bpmn_version_control_type: str = db.Column(db.String(50))
-    bpmn_version_control_identifier: str = db.Column(db.String(255))
-    last_milestone_bpmn_name: str = db.Column(db.String(255))
+    updated_at_in_seconds: int = db.Column(db.Integer)
+    created_at_in_seconds: int = db.Column(db.Integer)
+
+    bpmn_version_control_type: str | None = db.Column(db.String(50))
+    # this could also be a blank string for older instances since we were putting blank strings in here as well
+    bpmn_version_control_identifier: str | None = db.Column(db.String(255))
+    last_milestone_bpmn_name: str | None = db.Column(db.String(255))
 
     bpmn_xml_file_contents: str | None = None
     bpmn_xml_file_contents_retrieval_error: str | None = None

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
@@ -94,7 +94,7 @@ class ProcessInstanceService:
         try:
             current_git_revision = GitService.get_current_revision()
         except GitCommandError:
-            current_git_revision = ""
+            current_git_revision = None
         process_instance_model = ProcessInstanceModel(
             status=ProcessInstanceStatus.not_started.value,
             process_initiator_id=user.id,


### PR DESCRIPTION
Load forms using the git revision of the process instance to ensure they stay consistent.

To test:
* start a process model with a form, make a change to the schema json file and then go back to the form in the running instance and ensure the changes are not there