### PR TITLE
hotfix/multi-instance-task-spec

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -1403,7 +1403,7 @@ class ProcessInstanceProcessor:
         tasks = self.bpmn_process_instance.get_tasks(state=TaskState.DEFINITE_MASK)
         loaded_specs = set(self.bpmn_process_instance.subprocess_specs.keys())
         for task in tasks:
-            if task.task_spec.description != "Call Activity":
+            if task.task_spec.__class__.__name__ != "CallActivity":
                 continue
             spec_to_check = task.task_spec.spec
 


### PR DESCRIPTION
This was created from the 7083427eb925a10b5c7bdfe00b8341133672235d revision to changes that came after.

This updates the lazy loader to check if a task is a call activity by using the class name instead of the description. This is to avoid lazy loading tasks like "SequentialMultiInstanceTask".