### PR TITLE
Hotfix/user task with timer cancel

### DIFF
--- a/spiffworkflow-backend/bin/boot_server_in_docker
+++ b/spiffworkflow-backend/bin/boot_server_in_docker
@@ -93,7 +93,7 @@ fi
 
 # DELETE after this runs on all necessary environments
 # TODO: make a system somewhat like schema migrations (storing versions in a db table) to handle data migrations
-poetry run python ./bin/data_migrations/version_1_3.py
+poetry run python ./bin/data_migrations/run_all.py
 
 # --worker-class is not strictly necessary, since setting threads will automatically set the worker class to gthread, but meh
 export IS_GUNICORN="true"

--- a/spiffworkflow-backend/bin/data_migrations/run_all.py
+++ b/spiffworkflow-backend/bin/data_migrations/run_all.py
@@ -1,5 +1,6 @@
 import time
 
+from flask import current_app
 from spiffworkflow_backend import create_app
 from spiffworkflow_backend.data_migrations.version_1_3 import VersionOneThree
 from spiffworkflow_backend.data_migrations.version_2 import Version2
@@ -8,28 +9,75 @@ from spiffworkflow_backend.models.process_instance import ProcessInstanceModel
 from sqlalchemy import update
 
 
+# simple decorator to time the func
+# https://stackoverflow.com/a/11151365/6090676, thank you
+def benchmark_log_func(func):
+    """
+    decorator to calculate the total time of a func
+    """
+
+    def st_func(*args, **kwargs):
+        t1 = time.time()
+        r = func(*args, **kwargs)
+        t2 = time.time()
+        # __qualname__, i know you use it every day. but if not, it's the function name prefixed with any qualifying class names
+        current_app.logger.debug(f"Function={func.__qualname__}, Time={t2 - t1}")
+        return r
+
+    return st_func
+
+
+@benchmark_log_func
+def put_serializer_version_onto_numeric_track() -> None:
+    old_busted_serializer_version = "1.0-spiffworkflow-backend"
+    update_query = (
+        update(ProcessInstanceModel)
+        .where(ProcessInstanceModel.spiff_serializer_version == old_busted_serializer_version)
+        .values(spiff_serializer_version="1")
+    )
+    db.session.execute(update_query)
+    db.session.commit()
+
+
+def all_potentially_relevant_process_instances() -> list[ProcessInstanceModel]:
+    return ProcessInstanceModel.query.filter(
+        ProcessInstanceModel.spiff_serializer_version < Version2.VERSION,
+        ProcessInstanceModel.status.in_(ProcessInstanceModel.non_terminal_statuses()),
+    ).all()
+
+
+@benchmark_log_func
+def run_version_1() -> None:
+    VersionOneThree().run()  # make this a class method
+
+
+@benchmark_log_func
+def run_version_2(process_instances: list[ProcessInstanceModel]) -> None:
+    Version2.run(process_instances)
+
+
 def main() -> None:
     start_time = time.time()
     app = create_app()
     end_time = time.time()
-    print(
-        f"data_migrations/run_all::create_app took {end_time - start_time} seconds"
-    )
-    start_time = time.time()
 
     with app.app_context():
-        old_busted_serializer_version = '1.0-spiffworkflow-backend'
-        update_query = update(ProcessInstanceModel).where(ProcessInstanceModel.spiff_serializer_version == old_busted_serializer_version).values(spiff_serializer_version='1')
-        db.session.execute(update_query)
-        db.session.commit()
-        process_instances = ProcessInstanceModel.query.filter(ProcessInstanceModel.spiff_serializer_version < "2", ProcessInstanceModel.status.in_(ProcessInstanceModel.non_terminal_statuses())).all()
-        Version2.run(process_instances)
-        VersionOneThree().run()
+        current_app.logger.debug(f"data_migrations/run_all::create_app took {end_time - start_time} seconds")
+        start_time = time.time()
+        put_serializer_version_onto_numeric_track()
+        process_instances = all_potentially_relevant_process_instances()
+        potentially_relevant_instance_count = len(process_instances)
+        current_app.logger.debug(
+            f"Found potentially relevant process_instances: {potentially_relevant_instance_count}"
+        )
+        if potentially_relevant_instance_count > 0:
+            run_version_1()
+            run_version_2(process_instances)
 
-    end_time = time.time()
-    print(
-        f"done running data migration from ./bin/data_migrations/version_1_3.py. took {end_time - start_time} seconds"
-    )
+        end_time = time.time()
+        current_app.logger.debug(
+            f"done running data migrations in ./bin/data_migrations/run_all.py. took {end_time - start_time} seconds"
+        )
 
 
 if __name__ == "__main__":

--- a/spiffworkflow-backend/bin/data_migrations/run_all.py
+++ b/spiffworkflow-backend/bin/data_migrations/run_all.py
@@ -1,0 +1,36 @@
+import time
+
+from spiffworkflow_backend import create_app
+from spiffworkflow_backend.data_migrations.version_1_3 import VersionOneThree
+from spiffworkflow_backend.data_migrations.version_2 import Version2
+from spiffworkflow_backend.models.db import db
+from spiffworkflow_backend.models.process_instance import ProcessInstanceModel
+from sqlalchemy import update
+
+
+def main() -> None:
+    start_time = time.time()
+    app = create_app()
+    end_time = time.time()
+    print(
+        f"data_migrations/run_all::create_app took {end_time - start_time} seconds"
+    )
+    start_time = time.time()
+
+    with app.app_context():
+        old_busted_serializer_version = '1.0-spiffworkflow-backend'
+        update_query = update(ProcessInstanceModel).where(ProcessInstanceModel.spiff_serializer_version == old_busted_serializer_version).values(spiff_serializer_version='1')
+        db.session.execute(update_query)
+        db.session.commit()
+        process_instances = ProcessInstanceModel.query.filter(ProcessInstanceModel.spiff_serializer_version < "2", ProcessInstanceModel.status.in_(ProcessInstanceModel.non_terminal_statuses())).all()
+        Version2.run(process_instances)
+        VersionOneThree().run()
+
+    end_time = time.time()
+    print(
+        f"done running data migration from ./bin/data_migrations/version_1_3.py. took {end_time - start_time} seconds"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/spiffworkflow-backend/bin/data_migrations/run_all.py
+++ b/spiffworkflow-backend/bin/data_migrations/run_all.py
@@ -72,7 +72,8 @@ def main() -> None:
         )
         if potentially_relevant_instance_count > 0:
             run_version_1()
-            run_version_2(process_instances)
+            # this will run while using the new per instance on demand data migration framework
+            # run_version_2(process_instances)
 
         end_time = time.time()
         current_app.logger.debug(

--- a/spiffworkflow-backend/bin/run_data_migrations_locally
+++ b/spiffworkflow-backend/bin/run_data_migrations_locally
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+function error_handler() {
+  >&2 echo "Exited with BAD EXIT CODE '${2}' in ${0} script at line: ${1}."
+  exit "$2"
+}
+trap 'error_handler ${LINENO} $?' ERR
+set -o errtrace -o errexit -o nounset -o pipefail
+
+script_dir="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+. "${script_dir}/local_development_environment_setup"
+poetry run python ./bin/data_migrations/run_all.py

--- a/spiffworkflow-backend/bin/run_data_migrations_locally
+++ b/spiffworkflow-backend/bin/run_data_migrations_locally
@@ -9,4 +9,5 @@ set -o errtrace -o errexit -o nounset -o pipefail
 
 script_dir="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 . "${script_dir}/local_development_environment_setup"
+SPIFFWORKFLOW_BACKEND_RUN_BACKGROUND_SCHEDULER_IN_CREATE_APP=false
 poetry run python ./bin/data_migrations/run_all.py

--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_migrations/process_instance_migrator.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_migrations/process_instance_migrator.py
@@ -1,0 +1,47 @@
+import time
+
+from flask import current_app
+from typing import Any
+from spiffworkflow_backend.data_migrations.version_2 import Version2
+from spiffworkflow_backend.models.db import db
+from spiffworkflow_backend.models.process_instance import ProcessInstanceModel
+
+
+# simple decorator to time the func
+# https://stackoverflow.com/a/11151365/6090676, thank you
+def benchmark_log_func(func: Any) -> Any:
+    """
+    decorator to calculate the total time of a func
+    """
+
+    def st_func(*args: list, **kwargs: dict) -> Any:
+        t1 = time.time()
+        r = func(*args, **kwargs)
+        t2 = time.time()
+        # __qualname__, i know you use it every day. but if not, it's the function name prefixed with any qualifying class names
+        current_app.logger.debug(f"Function={func.__qualname__}, Time={t2 - t1}")
+        return r
+
+    return st_func
+
+
+class ProcessInstanceMigrator:
+    @classmethod
+    @benchmark_log_func
+    def run_version_2(cls, process_instance: ProcessInstanceModel) -> None:
+        if process_instance.spiff_serializer_version < Version2.VERSION:
+            Version2.run(process_instance)
+            process_instance.spiff_serializer_version = Version2.VERSION
+            db.session.add(process_instance)
+            db.session.commit()
+
+    @classmethod
+    def run(cls, process_instance: ProcessInstanceModel) -> None:
+        """This updates the serialization of an instance to the current expected state.
+
+        We do not run the migrator in cases where we do not expect to update the spiff internal state,
+        such as the process instance show page (where we do instantiate a processor).
+        Someday, we might need to run the migrator in more places, if using spiff to read depends on
+        an updated serialization.
+        """
+        cls.run_version_2(process_instance)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_migrations/process_instance_migrator.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_migrations/process_instance_migrator.py
@@ -1,7 +1,7 @@
 import time
+from typing import Any
 
 from flask import current_app
-from typing import Any
 from spiffworkflow_backend.data_migrations.version_2 import Version2
 from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.models.process_instance import ProcessInstanceModel

--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_migrations/version_2.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_migrations/version_2.py
@@ -1,0 +1,35 @@
+from flask import current_app
+from spiffworkflow_backend.models.db import db
+from spiffworkflow_backend.models.process_instance import ProcessInstanceModel
+from spiffworkflow_backend.services.process_instance_processor import ProcessInstanceProcessor
+from spiffworkflow_backend.services.task_service import TaskService
+
+
+class Version2:
+
+    MY_VERSION = "2"
+
+    @classmethod
+    def run(cls, process_instances: list[ProcessInstanceModel]) -> None:
+        for process_instance in process_instances:
+            try:
+                processor = ProcessInstanceProcessor(process_instance)
+                processor.bpmn_process_instance._predict()
+
+                spiff_tasks = processor.bpmn_process_instance.get_tasks()
+                task_service = TaskService(
+                    process_instance,
+                    processor._serializer,
+                    processor.bpmn_definition_to_task_definitions_mappings
+                )
+
+                # implicit begin db transaction
+                for spiff_task in spiff_tasks:
+                    task_service.update_task_model_with_spiff_task(spiff_task)
+
+                task_service.save_objects_to_database()
+                process_instance.spiff_serializer_version = cls.MY_VERSION
+                db.session.add(process_instance)
+                db.session.commit()
+            except Exception as ex:
+                current_app.logger.warning(f"Failed to migrate process_instance '{process_instance.id}'. The error was {str(ex)}")

--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_migrations/version_2.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_migrations/version_2.py
@@ -1,3 +1,4 @@
+from SpiffWorkflow.bpmn.workflow import TaskState
 from flask import current_app
 from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.models.process_instance import ProcessInstanceModel
@@ -20,7 +21,7 @@ class Version2:
                 processor = ProcessInstanceProcessor(process_instance)
                 processor.bpmn_process_instance._predict()
 
-                spiff_tasks = processor.bpmn_process_instance.get_tasks()
+                spiff_tasks = processor.bpmn_process_instance.get_tasks(state=TaskState.PREDICTED_MASK)
                 task_service = TaskService(
                     process_instance, processor._serializer, processor.bpmn_definition_to_task_definitions_mappings
                 )
@@ -28,6 +29,7 @@ class Version2:
                 # implicit begin db transaction
                 for spiff_task in spiff_tasks:
                     task_service.update_task_model_with_spiff_task(spiff_task)
+                    task_service.update_task_model_with_spiff_task(spiff_task.parent)
 
                 task_service.save_objects_to_database()
                 process_instance.spiff_serializer_version = cls.VERSION

--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_migrations/version_2.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_migrations/version_2.py
@@ -1,7 +1,7 @@
-from SpiffWorkflow.bpmn.workflow import TaskState
 import time
-from SpiffWorkflow.task import Task as SpiffTask # type: ignore
+
 from flask import current_app
+from SpiffWorkflow.task import Task as SpiffTask  # type: ignore
 from spiffworkflow_backend.models.process_instance import ProcessInstanceModel
 from spiffworkflow_backend.services.process_instance_processor import ProcessInstanceProcessor
 from spiffworkflow_backend.services.task_service import TaskService

--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_migrations/version_2.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_migrations/version_2.py
@@ -10,7 +10,12 @@ class Version2:
 
     @classmethod
     def run(cls, process_instances: list[ProcessInstanceModel]) -> None:
+        process_instance_count = len(process_instances)
+        current_app.logger.info(f"process_instance_count: {process_instance_count}")
+        ii = 0
         for process_instance in process_instances:
+            ii += 1
+            current_app.logger.info(f"working process_instance: {ii} of {process_instance_count}")
             try:
                 processor = ProcessInstanceProcessor(process_instance)
                 processor.bpmn_process_instance._predict()

--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_migrations/version_2.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_migrations/version_2.py
@@ -6,8 +6,7 @@ from spiffworkflow_backend.services.task_service import TaskService
 
 
 class Version2:
-
-    MY_VERSION = "2"
+    VERSION = "2"
 
     @classmethod
     def run(cls, process_instances: list[ProcessInstanceModel]) -> None:
@@ -18,9 +17,7 @@ class Version2:
 
                 spiff_tasks = processor.bpmn_process_instance.get_tasks()
                 task_service = TaskService(
-                    process_instance,
-                    processor._serializer,
-                    processor.bpmn_definition_to_task_definitions_mappings
+                    process_instance, processor._serializer, processor.bpmn_definition_to_task_definitions_mappings
                 )
 
                 # implicit begin db transaction
@@ -28,8 +25,10 @@ class Version2:
                     task_service.update_task_model_with_spiff_task(spiff_task)
 
                 task_service.save_objects_to_database()
-                process_instance.spiff_serializer_version = cls.MY_VERSION
+                process_instance.spiff_serializer_version = cls.VERSION
                 db.session.add(process_instance)
                 db.session.commit()
             except Exception as ex:
-                current_app.logger.warning(f"Failed to migrate process_instance '{process_instance.id}'. The error was {str(ex)}")
+                current_app.logger.warning(
+                    f"Failed to migrate process_instance '{process_instance.id}'. The error was {str(ex)}"
+                )

--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/process_instance.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/process_instance.py
@@ -89,13 +89,15 @@ class ProcessInstanceModel(SpiffworkflowBaseDBModel):
     start_in_seconds: int | None = db.Column(db.Integer, index=True)
     end_in_seconds: int | None = db.Column(db.Integer, index=True)
     task_updated_at_in_seconds: int = db.Column(db.Integer, nullable=True)
-    updated_at_in_seconds: int = db.Column(db.Integer)
-    created_at_in_seconds: int = db.Column(db.Integer)
     status: str = db.Column(db.String(50), index=True)
 
-    bpmn_version_control_type: str = db.Column(db.String(50))
-    bpmn_version_control_identifier: str = db.Column(db.String(255))
-    last_milestone_bpmn_name: str = db.Column(db.String(255))
+    updated_at_in_seconds: int = db.Column(db.Integer)
+    created_at_in_seconds: int = db.Column(db.Integer)
+
+    bpmn_version_control_type: str | None = db.Column(db.String(50))
+    # this could also be a blank string for older instances since we were putting blank strings in here as well
+    bpmn_version_control_identifier: str | None = db.Column(db.String(255))
+    last_milestone_bpmn_name: str | None = db.Column(db.String(255))
 
     bpmn_xml_file_contents: str | None = None
     bpmn_xml_file_contents_retrieval_error: str | None = None

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/extensions_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/extensions_controller.py
@@ -147,6 +147,7 @@ def _run_extension(
 
     processor = None
     try:
+        # this is only creates new process instances so no need to worry about process instance migrations
         processor = ProcessInstanceProcessor(
             process_instance,
             script_engine=CustomBpmnScriptEngine(use_restricted_script_engine=False),

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_instances_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_instances_controller.py
@@ -11,6 +11,7 @@ from flask.wrappers import Response
 from sqlalchemy import and_
 from sqlalchemy import or_
 from sqlalchemy.orm import aliased
+from spiffworkflow_backend.data_migrations.process_instance_migrator import ProcessInstanceMigrator
 
 from spiffworkflow_backend.exceptions.api_error import ApiError
 from spiffworkflow_backend.models.bpmn_process import BpmnProcessModel
@@ -158,10 +159,11 @@ def process_instance_terminate(
     modified_process_model_identifier: str,
 ) -> flask.wrappers.Response:
     process_instance = _find_process_instance_by_id_or_raise(process_instance_id)
-    processor = ProcessInstanceProcessor(process_instance)
 
     try:
         with ProcessInstanceQueueService.dequeued(process_instance):
+            ProcessInstanceMigrator.run(process_instance)
+            processor = ProcessInstanceProcessor(process_instance)
             processor.terminate()
     except (
         ProcessInstanceIsNotEnqueuedError,
@@ -660,9 +662,10 @@ def send_bpmn_event(
 
 
 def _send_bpmn_event(process_instance: ProcessInstanceModel, body: dict) -> Response:
-    processor = ProcessInstanceProcessor(process_instance)
     try:
         with ProcessInstanceQueueService.dequeued(process_instance):
+            ProcessInstanceMigrator.run(process_instance)
+            processor = ProcessInstanceProcessor(process_instance)
             processor.send_bpmn_event(body)
     except (
         ProcessInstanceIsNotEnqueuedError,

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_instances_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_instances_controller.py
@@ -11,8 +11,8 @@ from flask.wrappers import Response
 from sqlalchemy import and_
 from sqlalchemy import or_
 from sqlalchemy.orm import aliased
-from spiffworkflow_backend.data_migrations.process_instance_migrator import ProcessInstanceMigrator
 
+from spiffworkflow_backend.data_migrations.process_instance_migrator import ProcessInstanceMigrator
 from spiffworkflow_backend.exceptions.api_error import ApiError
 from spiffworkflow_backend.models.bpmn_process import BpmnProcessModel
 from spiffworkflow_backend.models.bpmn_process_definition import BpmnProcessDefinitionModel

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
@@ -54,6 +54,8 @@ from spiffworkflow_backend.services.authorization_service import HumanTaskNotFou
 from spiffworkflow_backend.services.authorization_service import UserDoesNotHaveAccessToTaskError
 from spiffworkflow_backend.services.error_handling_service import ErrorHandlingService
 from spiffworkflow_backend.services.file_system_service import FileSystemService
+from spiffworkflow_backend.services.git_service import GitCommandError
+from spiffworkflow_backend.services.git_service import GitService
 from spiffworkflow_backend.services.jinja_service import JinjaService
 from spiffworkflow_backend.services.process_instance_processor import ProcessInstanceProcessor
 from spiffworkflow_backend.services.process_instance_queue_service import ProcessInstanceIsAlreadyLockedError
@@ -452,9 +454,10 @@ def task_show(
                 )
 
             form_dict = _prepare_form_data(
-                form_schema_file_name,
-                task_model,
-                process_model_with_form,
+                form_file=form_schema_file_name,
+                task_model=task_model,
+                process_model=process_model_with_form,
+                revision=process_instance.bpmn_version_control_identifier,
             )
 
             _update_form_schema_with_task_data_as_needed(form_dict, task_model.data)
@@ -464,9 +467,10 @@ def task_show(
 
             if form_ui_schema_file_name:
                 ui_form_contents = _prepare_form_data(
-                    form_ui_schema_file_name,
-                    task_model,
-                    process_model_with_form,
+                    form_file=form_ui_schema_file_name,
+                    task_model=task_model,
+                    process_model=process_model_with_form,
+                    revision=process_instance.bpmn_version_control_identifier,
                 )
                 if ui_form_contents:
                     task_model.form_ui_schema = ui_form_contents
@@ -940,30 +944,50 @@ def _get_tasks(
     return make_response(jsonify(response_json), 200)
 
 
-def _prepare_form_data(form_file: str, task_model: TaskModel, process_model: ProcessModelInfo) -> dict:
+def _prepare_form_data(
+    form_file: str, task_model: TaskModel, process_model: ProcessModelInfo, revision: str | None = None
+) -> dict:
     if task_model.data is None:
         return {}
 
-    file_contents = SpecFileService.get_data(process_model, form_file).decode("utf-8")
+    try:
+        file_contents = GitService.get_file_contents_for_revision_if_git_revision(
+            process_model=process_model,
+            revision=revision,
+            file_name=form_file,
+        )
+    except GitCommandError as exception:
+        raise (
+            ApiError(
+                error_code="git_error_loading_form",
+                message=(
+                    f"Could not load form schema from: {form_file}. Was git history rewritten such that revision"
+                    f" '{revision}' no longer exists? Error was: {str(exception)}"
+                ),
+                status_code=400,
+            )
+        ) from exception
+
     try:
         form_contents = JinjaService.render_jinja_template(file_contents, task=task_model)
-        try:
-            # form_contents is a str
-            hot_dict: dict = json.loads(form_contents)
-            return hot_dict
-        except Exception as exception:
-            raise (
-                ApiError(
-                    error_code="error_loading_form",
-                    message=f"Could not load form schema from: {form_file}. Error was: {str(exception)}",
-                    status_code=400,
-                )
-            ) from exception
     except TaskModelError as wfe:
         wfe.add_note(f"Error in Json Form File '{form_file}'")
         api_error = ApiError.from_workflow_exception("instructions_error", str(wfe), exp=wfe)
         api_error.file_name = form_file
         raise api_error
+
+    try:
+        # form_contents is a str
+        hot_dict: dict = json.loads(form_contents)
+        return hot_dict
+    except Exception as exception:
+        raise (
+            ApiError(
+                error_code="error_loading_form",
+                message=f"Could not load form schema from: {form_file}. Error was: {str(exception)}",
+                status_code=400,
+            )
+        ) from exception
 
 
 def _get_spiff_task_from_process_instance(

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
@@ -1,6 +1,5 @@
 import json
 import os
-from spiffworkflow_backend.data_migrations.process_instance_migrator import ProcessInstanceMigrator
 import uuid
 from collections import OrderedDict
 from collections.abc import Generator
@@ -27,6 +26,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import aliased
 from sqlalchemy.orm.util import AliasedClass
 
+from spiffworkflow_backend.data_migrations.process_instance_migrator import ProcessInstanceMigrator
 from spiffworkflow_backend.exceptions.api_error import ApiError
 from spiffworkflow_backend.models.db import SpiffworkflowBaseDBModel
 from spiffworkflow_backend.models.db import db

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/git_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/git_service.py
@@ -10,6 +10,7 @@ from spiffworkflow_backend.config import ConfigurationError
 from spiffworkflow_backend.models.process_model import ProcessModelInfo
 from spiffworkflow_backend.services.data_setup_service import DataSetupService
 from spiffworkflow_backend.services.file_system_service import FileSystemService
+from spiffworkflow_backend.services.spec_file_service import SpecFileService
 
 
 class MissingGitConfigsError(Exception):
@@ -48,20 +49,44 @@ class GitService:
         cls,
         process_model: ProcessModelInfo,
         revision: str,
-        file_name: str | None = None,
+        file_name: str,
     ) -> str:
         bpmn_spec_absolute_dir = current_app.config["SPIFFWORKFLOW_BACKEND_BPMN_SPEC_ABSOLUTE_DIR"]
         process_model_relative_path = FileSystemService.process_model_relative_path(process_model)
-        file_name_to_use = file_name
-        if file_name_to_use is None:
-            file_name_to_use = process_model.primary_file_name
         with FileSystemService.cd(bpmn_spec_absolute_dir):
             shell_command = [
                 "git",
                 "show",
-                f"{revision}:{process_model_relative_path}/{file_name_to_use}",
+                f"{revision}:{process_model_relative_path}/{file_name}",
             ]
             return cls.run_shell_command_to_get_stdout(shell_command)
+
+    @classmethod
+    def get_file_contents_for_revision_if_git_revision(
+        cls,
+        process_model: ProcessModelInfo,
+        file_name: str,
+        revision: str | None = None,
+    ) -> str:
+        try:
+            current_version_control_revision = cls.get_current_revision()
+        except GitCommandError:
+            current_version_control_revision = None
+        file_contents = None
+        if (
+            revision is None
+            or revision == ""
+            or current_version_control_revision is None
+            or revision == current_version_control_revision
+        ):
+            file_contents = SpecFileService.get_data(process_model, file_name).decode("utf-8")
+        else:
+            file_contents = GitService.get_instance_file_contents_for_revision(
+                process_model,
+                revision,
+                file_name=file_name,
+            )
+        return file_contents
 
     @classmethod
     def commit(
@@ -95,7 +120,7 @@ class GitService:
             if raise_on_missing:
                 raise MissingGitConfigsError(
                     "Missing config for SPIFFWORKFLOW_BACKEND_GIT_SOURCE_BRANCH. "
-                    "This is required for publishing process models"
+                    "This is required for committing and publishing process models"
                 )
             return False
         return True

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -478,6 +478,11 @@ class ProcessInstanceProcessor:
                 ),
             ) from ke
 
+        # this only needs to happen for versions less than 2 since we were not saving LIKELY and MAYBE then
+        # once save is called, this should be in the correct form
+        if self.process_instance_model.spiff_serializer_version < "2":
+            self.bpmn_process_instance._predict()
+
     @classmethod
     def get_process_model_and_subprocesses(
         cls,

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -1403,7 +1403,7 @@ class ProcessInstanceProcessor:
         tasks = self.bpmn_process_instance.get_tasks(state=TaskState.DEFINITE_MASK)
         loaded_specs = set(self.bpmn_process_instance.subprocess_specs.keys())
         for task in tasks:
-            if task.task_spec.description != "Call Activity":
+            if task.task_spec.__class__.__name__ != "CallActivity":
                 continue
             spec_to_check = task.task_spec.spec
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -1043,9 +1043,6 @@ class ProcessInstanceProcessor:
         db.session.add(self.process_instance_model)
         db.session.commit()
 
-        if self.process_instance_model.id == 82:
-            self.dump_to_disk()
-
         human_tasks = HumanTaskModel.query.filter_by(
             process_instance_id=self.process_instance_model.id, completed=False
         ).all()

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -478,11 +478,6 @@ class ProcessInstanceProcessor:
                 ),
             ) from ke
 
-        # this only needs to happen for versions less than 2 since we were not saving LIKELY and MAYBE then
-        # once save is called, this should be in the correct form
-        if self.process_instance_model.spiff_serializer_version < "2":
-            self.bpmn_process_instance._predict()
-
     @classmethod
     def get_process_model_and_subprocesses(
         cls,
@@ -1061,9 +1056,6 @@ class ProcessInstanceProcessor:
             process_model_display_name = process_model_info.display_name
 
         self.extract_metadata(process_model_info)
-
-        # if self.process_instance_model.id == 82:
-        #     with open("tasks.txt", "w") as f: f.write(str(ready_or_waiting_tasks))
 
         for ready_or_waiting_task in ready_or_waiting_tasks:
             # filter out non-usertasks

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -386,9 +386,13 @@ class CustomBpmnScriptEngine(PythonScriptEngine):  # type: ignore
 IdToBpmnProcessSpecMapping = NewType("IdToBpmnProcessSpecMapping", dict[str, BpmnProcessSpec])
 
 
+# update process_instance set serializer_version = '1' where serializer_version = '1.0-spiffworkflow-backend';
+# select * where coerce_int(serializer_version) < 2 and open;
+ # predict
+ # save
 class ProcessInstanceProcessor:
     _default_script_engine = CustomBpmnScriptEngine()
-    SERIALIZER_VERSION = "1.0-spiffworkflow-backend"
+    SERIALIZER_VERSION = "2"
 
     wf_spec_converter = BpmnWorkflowSerializer.configure_workflow_spec_converter(SPIFF_SPEC_CONFIG)
     _serializer = BpmnWorkflowSerializer(wf_spec_converter, version=SERIALIZER_VERSION)
@@ -1043,6 +1047,9 @@ class ProcessInstanceProcessor:
         db.session.add(self.process_instance_model)
         db.session.commit()
 
+        if self.process_instance_model.id == 82:
+            self.dump_to_disk()
+
         human_tasks = HumanTaskModel.query.filter_by(
             process_instance_id=self.process_instance_model.id, completed=False
         ).all()
@@ -1056,6 +1063,9 @@ class ProcessInstanceProcessor:
             process_model_display_name = process_model_info.display_name
 
         self.extract_metadata(process_model_info)
+
+        # if self.process_instance_model.id == 82:
+        #     with open("tasks.txt", "w") as f: f.write(str(ready_or_waiting_tasks))
 
         for ready_or_waiting_task in ready_or_waiting_tasks:
             # filter out non-usertasks

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -386,10 +386,6 @@ class CustomBpmnScriptEngine(PythonScriptEngine):  # type: ignore
 IdToBpmnProcessSpecMapping = NewType("IdToBpmnProcessSpecMapping", dict[str, BpmnProcessSpec])
 
 
-# update process_instance set serializer_version = '1' where serializer_version = '1.0-spiffworkflow-backend';
-# select * where coerce_int(serializer_version) < 2 and open;
- # predict
- # save
 class ProcessInstanceProcessor:
     _default_script_engine = CustomBpmnScriptEngine()
     SERIALIZER_VERSION = "2"

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
@@ -94,7 +94,7 @@ class ProcessInstanceService:
         try:
             current_git_revision = GitService.get_current_revision()
         except GitCommandError:
-            current_git_revision = ""
+            current_git_revision = None
         process_instance_model = ProcessInstanceModel(
             status=ProcessInstanceStatus.not_started.value,
             process_initiator_id=user.id,

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
@@ -1,5 +1,6 @@
 import base64
 import hashlib
+from spiffworkflow_backend.data_migrations.process_instance_migrator import ProcessInstanceMigrator
 import time
 from collections.abc import Generator
 from datetime import datetime
@@ -71,6 +72,7 @@ class ProcessInstanceService:
     @staticmethod
     def next_start_event_configuration(process_instance_model: ProcessInstanceModel) -> StartConfiguration:
         try:
+            # this is only called from create_process_instance so no need to worry about process instance migrations
             processor = ProcessInstanceProcessor(process_instance_model)
             start_configuration = WorkflowService.next_start_event_configuration(
                 processor.bpmn_process_instance, datetime.now(timezone.utc)
@@ -259,6 +261,7 @@ class ProcessInstanceService:
     ) -> ProcessInstanceProcessor | None:
         processor = None
         with ProcessInstanceQueueService.dequeued(process_instance):
+            ProcessInstanceMigrator.run(process_instance)
             processor = ProcessInstanceProcessor(
                 process_instance, workflow_completed_handler=cls.schedule_next_process_model_cycle
             )

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
@@ -1,6 +1,5 @@
 import base64
 import hashlib
-from spiffworkflow_backend.data_migrations.process_instance_migrator import ProcessInstanceMigrator
 import time
 from collections.abc import Generator
 from datetime import datetime
@@ -17,6 +16,7 @@ from SpiffWorkflow.bpmn.specs.event_definitions.timer import TimerEventDefinitio
 from SpiffWorkflow.task import Task as SpiffTask  # type: ignore
 from SpiffWorkflow.util.task import TaskState  # type: ignore
 from spiffworkflow_backend import db
+from spiffworkflow_backend.data_migrations.process_instance_migrator import ProcessInstanceMigrator
 from spiffworkflow_backend.exceptions.api_error import ApiError
 from spiffworkflow_backend.models.group import GroupModel
 from spiffworkflow_backend.models.human_task import HumanTaskModel


### PR DESCRIPTION
This was a hotfix to revision d22364a1a432332aad288f36f888297cf8c081b6 to migrate old process instances.

The issue was that when we weren't saving LIKELY and MAYBE tasks to the db, when timers would execute when associated with a user task, it would not cause that user task to get cancelled and instead that user task could still be completed. This caused the following gateway to marked as "cancelled" and nothing would proceed after that. This migration runs predict on instances potentially in this state and then saves them.