### PR TITLE
Feature/metadata column display type

### DIFF
--- a/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
+++ b/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
@@ -1714,7 +1714,14 @@ export default function ProcessInstanceListTable({
       return undefined;
     }
     const duration = intervalToDuration({ start: 0, end: value * 1000 });
-    return `${duration.hours}h ${duration.minutes}m`;
+    let durationString = `${duration.minutes}m ${duration.seconds}s`;
+    if (duration.hours !== undefined && duration.hours > 0) {
+      durationString = `${duration.hours}h ${durationString}`;
+    }
+    if (duration.days !== undefined && duration.days > 0) {
+      durationString = `${duration.days}d ${durationString}`;
+    }
+    return durationString;
   };
 
   const formattedColumn = (row: ProcessInstance, column: ReportColumn) => {

--- a/spiffworkflow-frontend/src/helpers.test.tsx
+++ b/spiffworkflow-frontend/src/helpers.test.tsx
@@ -1,6 +1,6 @@
 import {
   convertSecondsToFormattedDateString,
-  isInteger,
+  isANumber,
   slugifyString,
   underscorizeString,
   recursivelyChangeNullAndUndefined,
@@ -24,11 +24,13 @@ test('it can keep the correct date when converting seconds to date', () => {
 });
 
 test('it can validate numeric values', () => {
-  expect(isInteger('11')).toEqual(true);
-  expect(isInteger('hey')).toEqual(false);
-  expect(isInteger('        ')).toEqual(false);
-  expect(isInteger('1 2')).toEqual(false);
-  expect(isInteger(2)).toEqual(true);
+  expect(isANumber('11')).toEqual(true);
+  expect(isANumber('hey')).toEqual(false);
+  expect(isANumber('        ')).toEqual(false);
+  expect(isANumber('1 2')).toEqual(false);
+  expect(isANumber(2)).toEqual(true);
+  expect(isANumber(2.0)).toEqual(true);
+  expect(isANumber('2.0')).toEqual(true);
 });
 
 test('it can replace undefined values in object with null', () => {

--- a/spiffworkflow-frontend/src/helpers.tsx
+++ b/spiffworkflow-frontend/src/helpers.tsx
@@ -351,8 +351,10 @@ export const setPageTitle = (items: Array<string>) => {
   document.title = ['SpiffWorkflow'].concat(items).join(' - ');
 };
 
-export const isInteger = (str: string | number) => {
-  return /^\d+$/.test(str.toString());
+// calling it isANumber to avoid confusion with other libraries
+// that have isNumber methods
+export const isANumber = (str: string | number) => {
+  return /^\d+(\.\d+)?$/.test(str.toString());
 };
 
 export const encodeBase64 = (data: string) => {

--- a/spiffworkflow-frontend/src/interfaces.ts
+++ b/spiffworkflow-frontend/src/interfaces.ts
@@ -151,6 +151,10 @@ export interface FilterOperatorMapping {
   [key: string]: FilterOperator;
 }
 
+export interface FilterDisplayTypeMapping {
+  [key: string]: string;
+}
+
 export interface ProcessFile {
   content_type: string;
   last_modified: string;
@@ -228,6 +232,7 @@ export interface ReportColumn {
   Header: string;
   accessor: string;
   filterable: boolean;
+  display_type?: string;
 }
 
 export interface ReportColumnForEditing extends ReportColumn {

--- a/spiffworkflow-frontend/src/routes/ProcessInstanceFindById.tsx
+++ b/spiffworkflow-frontend/src/routes/ProcessInstanceFindById.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button, Form, Stack, TextInput } from '@carbon/react';
-import { isInteger, modifyProcessIdentifierForPathParam } from '../helpers';
+import { isANumber, modifyProcessIdentifierForPathParam } from '../helpers';
 import HttpService from '../services/HttpService';
 import ProcessInstanceListTabs from '../components/ProcessInstanceListTabs';
 import { ProcessInstance } from '../interfaces';
@@ -42,7 +42,7 @@ export default function ProcessInstanceFindById() {
   };
 
   const handleProcessInstanceIdChange = (event: any) => {
-    if (isInteger(event.target.value)) {
+    if (isANumber(event.target.value)) {
       setProcessInstanceIdValid(true);
     } else {
       setProcessInstanceIdValid(false);


### PR DESCRIPTION
This adds in the ability to define how metadata should display when creating a report. Right now only "Date / time" and "Duration" are supported.

This adds in the ability to turn off "with-tasks-for-me" from a report on the All instances list to make it easier for a user to share reports with someone who has access to the All screen.