### PR TITLE
feature/formatting-in-extension-md

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/extensions_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/extensions_controller.py
@@ -153,11 +153,12 @@ def _run_extension(
             script_engine=CustomBpmnScriptEngine(use_restricted_script_engine=False),
             process_id_to_run=process_id_to_run,
         )
+        save_to_db = process_instance.persistence_level != "none"
         if body and "extension_input" in body:
-            processor.do_engine_steps(save=False, execution_strategy_name="run_current_ready_tasks")
+            processor.do_engine_steps(save=save_to_db, execution_strategy_name="run_current_ready_tasks")
             next_task = processor.next_task()
             next_task.update_data(body["extension_input"])
-        processor.do_engine_steps(save=False, execution_strategy_name="greedy")
+        processor.do_engine_steps(save=save_to_db, execution_strategy_name="greedy")
     except (
         ApiError,
         ProcessInstanceIsNotEnqueuedError,

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_report_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_report_service.py
@@ -643,6 +643,10 @@ class ProcessInstanceReportService:
                     join_conditions.append(instance_metadata_alias.value == filter_for_column["field_value"])
                 elif filter_for_column["operator"] == "not_equals":
                     join_conditions.append(instance_metadata_alias.value != filter_for_column["field_value"])
+                elif filter_for_column["operator"] == "greater_than_or_equal_to":
+                    join_conditions.append(instance_metadata_alias.value >= filter_for_column["field_value"])
+                elif filter_for_column["operator"] == "less_than":
+                    join_conditions.append(instance_metadata_alias.value < filter_for_column["field_value"])
                 elif filter_for_column["operator"] == "contains":
                     join_conditions.append(instance_metadata_alias.value.like(f"%{filter_for_column['field_value']}%"))
                 elif filter_for_column["operator"] == "is_empty":

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/helpers/base_test.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/helpers/base_test.py
@@ -488,6 +488,7 @@ class BaseTest:
         process_instance: ProcessInstanceModel,
         operator: str,
         filter_field_value: str = "",
+        expect_to_find_instance: bool = True,
     ) -> None:
         report_metadata: ReportMetadata = {
             "columns": [
@@ -506,8 +507,17 @@ class BaseTest:
         response = self.post_to_process_instance_list(
             client, user, report_metadata=process_instance_report.get_report_metadata()
         )
-        assert len(response.json["results"]) == 1
-        assert response.json["results"][0]["id"] == process_instance.id
+
+        if expect_to_find_instance is True:
+            assert len(response.json["results"]) == 1
+            assert response.json["results"][0]["id"] == process_instance.id
+        else:
+            if len(response.json["results"]) == 1:
+                assert (
+                    response.json["results"][0]["id"] != process_instance.id
+                ), "expected not to find a specific process instance, but we found it"
+            else:
+                assert len(response.json["results"]) == 0
         db.session.delete(process_instance_report)
         db.session.commit()
 

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_api.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_api.py
@@ -2938,7 +2938,99 @@ class TestProcessApi(BaseTest):
             filter_field_value="hey",
         )
         self.assert_report_with_process_metadata_operator_includes_instance(
+            client=client,
+            user=with_super_admin_user,
+            process_instance=process_instance_one,
+            operator="less_than",
+            filter_field_value="value4",
+        )
+        self.assert_report_with_process_metadata_operator_includes_instance(
+            client=client,
+            user=with_super_admin_user,
+            process_instance=process_instance_one,
+            operator="greater_than_or_equal_to",
+            filter_field_value="value1",
+        )
+        self.assert_report_with_process_metadata_operator_includes_instance(
             client=client, user=with_super_admin_user, process_instance=process_instance_two, operator="is_empty"
+        )
+
+    def test_can_get_process_instance_list_with_report_metadata_using_different_operators_when_no_matches(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        process_model = load_test_spec(
+            process_model_id="save_process_instance_metadata/save_process_instance_metadata",
+            bpmn_file_name="save_process_instance_metadata.bpmn",
+            process_model_source_directory="save_process_instance_metadata",
+        )
+
+        process_instance_one_metadata = {"key1": "value1"}
+        process_instance_one = self.create_process_instance_with_synthetic_metadata(
+            process_model=process_model, process_instance_metadata_dict=process_instance_one_metadata
+        )
+
+        process_instance_two_metadata = {"key2": "value2"}
+        process_instance_two = self.create_process_instance_with_synthetic_metadata(
+            process_model=process_model, process_instance_metadata_dict=process_instance_two_metadata
+        )
+
+        self.assert_report_with_process_metadata_operator_includes_instance(
+            client=client,
+            user=with_super_admin_user,
+            process_instance=process_instance_two,
+            operator="is_not_empty",
+            expect_to_find_instance=False,
+        )
+        self.assert_report_with_process_metadata_operator_includes_instance(
+            client=client,
+            user=with_super_admin_user,
+            process_instance=process_instance_one,
+            operator="equals",
+            filter_field_value="value2",
+            expect_to_find_instance=False,
+        )
+        self.assert_report_with_process_metadata_operator_includes_instance(
+            client=client,
+            user=with_super_admin_user,
+            process_instance=process_instance_one,
+            operator="contains",
+            filter_field_value="alunooo",
+            expect_to_find_instance=False,
+        )
+        self.assert_report_with_process_metadata_operator_includes_instance(
+            client=client,
+            user=with_super_admin_user,
+            process_instance=process_instance_one,
+            operator="not_equals",
+            filter_field_value="value1",
+            expect_to_find_instance=False,
+        )
+        self.assert_report_with_process_metadata_operator_includes_instance(
+            client=client,
+            user=with_super_admin_user,
+            process_instance=process_instance_one,
+            operator="less_than",
+            filter_field_value="value1",
+            expect_to_find_instance=False,
+        )
+        self.assert_report_with_process_metadata_operator_includes_instance(
+            client=client,
+            user=with_super_admin_user,
+            process_instance=process_instance_one,
+            operator="greater_than_or_equal_to",
+            filter_field_value="value2",
+            expect_to_find_instance=False,
+        )
+        self.assert_report_with_process_metadata_operator_includes_instance(
+            client=client,
+            user=with_super_admin_user,
+            process_instance=process_instance_one,
+            operator="is_empty",
+            expect_to_find_instance=False,
         )
 
     def test_can_get_process_instance_list_with_report_metadata_and_process_initiator(

--- a/spiffworkflow-frontend/src/components/InstructionsForEndUser.tsx
+++ b/spiffworkflow-frontend/src/components/InstructionsForEndUser.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 // @ts-ignore
 import MDEditor from '@uiw/react-md-editor';
 import { Toggle } from '@carbon/react';
+import FormattingService from '../services/FormattingService';
 
 type OwnProps = {
   task: any;
@@ -25,6 +26,7 @@ export default function InstructionsForEndUser({
   if (instructionsForEndUser) {
     instructions = instructionsForEndUser;
   }
+  instructions = FormattingService.checkForSpiffFormats(instructions);
 
   const maxLineCount: number = 8;
   const maxWordCount: number = 75;

--- a/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
+++ b/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
@@ -50,8 +50,8 @@ import {
   REFRESH_TIMEOUT_SECONDS,
   titleizeString,
   truncateString,
-  isANumber,
   formatDurationForDisplay,
+  formatDateTime,
 } from '../helpers';
 import { useUriListForPermissions } from '../hooks/UriListForPermissions';
 
@@ -1695,24 +1695,6 @@ export default function ProcessInstanceListTable({
   };
   const defaultFormatter = (_row: ProcessInstance, value: any) => {
     return value;
-  };
-
-  const formatDateTime = (_row: ProcessInstance, value: any) => {
-    if (value === undefined || value === null) {
-      return value;
-    }
-    let dateInSeconds = value;
-    if (!isANumber(value)) {
-      const timeArgs = value.split('T');
-      dateInSeconds = convertDateAndTimeStringsToSeconds(
-        timeArgs[0],
-        timeArgs[1]
-      );
-    }
-    if (dateInSeconds) {
-      return convertSecondsToFormattedDateTime(dateInSeconds);
-    }
-    return null;
   };
 
   const formattedColumn = (row: ProcessInstance, column: ReportColumn) => {

--- a/spiffworkflow-frontend/src/helpers.tsx
+++ b/spiffworkflow-frontend/src/helpers.tsx
@@ -442,3 +442,21 @@ export const formatDurationForDisplay = (_row: any, value: any) => {
   }
   return durationTimes.join(' ');
 };
+
+export const formatDateTime = (_row: any, value: any) => {
+  if (value === undefined || value === null) {
+    return value;
+  }
+  let dateInSeconds = value;
+  if (!isANumber(value)) {
+    const timeArgs = value.split('T');
+    dateInSeconds = convertDateAndTimeStringsToSeconds(
+      timeArgs[0],
+      timeArgs[1]
+    );
+  }
+  if (dateInSeconds) {
+    return convertSecondsToFormattedDateTime(dateInSeconds);
+  }
+  return null;
+};

--- a/spiffworkflow-frontend/src/routes/Extension.tsx
+++ b/spiffworkflow-frontend/src/routes/Extension.tsx
@@ -7,11 +7,7 @@ import { useUriListForPermissions } from '../hooks/UriListForPermissions';
 import { ProcessFile, ProcessModel } from '../interfaces';
 import HttpService from '../services/HttpService';
 import useAPIError from '../hooks/UseApiError';
-import {
-  formatDateTime,
-  formatDurationForDisplay,
-  recursivelyChangeNullAndUndefined,
-} from '../helpers';
+import { recursivelyChangeNullAndUndefined } from '../helpers';
 import CustomForm from '../components/CustomForm';
 import { BACKEND_BASE_URL } from '../config';
 import {
@@ -132,30 +128,6 @@ export default function Extension() {
     targetUris.extensionListPath,
     targetUris.extensionPath,
   ]);
-
-  // this relies on the MDEditor rendering the markdown before
-  // this useEffect triggers which may or may not alwasy be the case
-  // so we may need to change implementation to a search/replace
-  // before renddering any markdown.
-  useEffect(() => {
-    const convertField = (className: string, conversionFunction: any) => {
-      const elements = document.getElementsByClassName(className);
-      if (elements.length > 0) {
-        for (let i = 0; i < elements.length; i += 1) {
-          const element = elements[i];
-          if (element) {
-            const originalValue = element.innerHTML;
-            element.innerHTML = conversionFunction(undefined, originalValue);
-          }
-        }
-      }
-    };
-    convertField('convert_seconds_to_date_time_for_display', formatDateTime);
-    convertField(
-      'convert_seconds_to_duration_for_display',
-      formatDurationForDisplay
-    );
-  }, [markdownToRenderOnLoad, markdownToRenderOnSubmit]);
 
   const interpolateNavigationString = (
     navigationString: string,

--- a/spiffworkflow-frontend/src/services/FormattingService.tsx
+++ b/spiffworkflow-frontend/src/services/FormattingService.tsx
@@ -1,0 +1,30 @@
+import { formatDateTime, formatDurationForDisplay } from '../helpers';
+
+const spiffFormatFunctions: { [key: string]: Function } = {
+  convert_seconds_to_date_time_for_display: formatDateTime,
+  convert_seconds_to_duration_for_display: formatDurationForDisplay,
+};
+
+const checkForSpiffFormats = (markdown: string) => {
+  const replacer = (
+    match: string,
+    spiffFormat: string,
+    originalValue: string
+  ) => {
+    if (spiffFormat in spiffFormatFunctions) {
+      return spiffFormatFunctions[spiffFormat](undefined, originalValue);
+    }
+    console.warn(
+      `attempted: ${match}, but ${spiffFormat} is not a valid conversion function`
+    );
+
+    return match;
+  };
+  return markdown.replaceAll(/SPIFF_FORMAT:::(\w+)\(([^)]+)\)/g, replacer);
+};
+
+const FormattingService = {
+  checkForSpiffFormats,
+};
+
+export default FormattingService;

--- a/spiffworkflow-frontend/tsconfig.json
+++ b/spiffworkflow-frontend/tsconfig.json
@@ -6,7 +6,7 @@
     "module": "commonjs",
     "skipLibCheck": true,
     "strict": true,
-    "target": "es2016",
+    "target": "es2021",
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
Includes:
* support to use some limited formatting functions from within markdown fields
  * can be used in both Extension markdown and InstructionsForEndUser
  * used like:  SPIFF_FORMAT:::convert_seconds_to_date_time_for_display(1697736060.0)
* added operators `greater_than_or_equal_to` and `less_than` for metadata filters
  * these were not added to the frontend yet
* updated typescript to use es2021

Supported Markdown formatters:
* convert_seconds_to_date_time_for_display
* convert_seconds_to_duration_for_display