### PR TITLE
Feature/do not save cancelled task events twice

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/task_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/task_service.py
@@ -177,6 +177,7 @@ class TaskService:
         self,
         spiff_task: SpiffTask,
         start_and_end_times: StartAndEndTimes | None = None,
+        cancelled_spiff_task_guids_with_events: list[str] | None = None,
     ) -> TaskModel:
         new_bpmn_process = None
         if str(spiff_task.id) in self.task_models:
@@ -210,21 +211,29 @@ class TaskService:
 
         # let failed tasks raise and we will log the event then
         if task_model.state in ["COMPLETED", "CANCELLED"]:
+            skip_event_entry = False
             event_type = ProcessInstanceEventType.task_completed.value
             if task_model.state == "CANCELLED":
+                if (
+                    cancelled_spiff_task_guids_with_events
+                    and task_model.guid in cancelled_spiff_task_guids_with_events
+                ):
+                    skip_event_entry = True
                 event_type = ProcessInstanceEventType.task_cancelled.value
-            timestamp = task_model.end_in_seconds or task_model.start_in_seconds or time.time()
-            (
-                process_instance_event,
-                _process_instance_error_detail,
-            ) = ProcessInstanceTmpService.add_event_to_process_instance(
-                self.process_instance,
-                event_type,
-                task_guid=task_model.guid,
-                timestamp=timestamp,
-                add_to_db_session=False,
-            )
-            self.process_instance_events[task_model.guid] = process_instance_event
+
+            if skip_event_entry is False:
+                timestamp = task_model.end_in_seconds or task_model.start_in_seconds or time.time()
+                (
+                    process_instance_event,
+                    _process_instance_error_detail,
+                ) = ProcessInstanceTmpService.add_event_to_process_instance(
+                    self.process_instance,
+                    event_type,
+                    task_guid=task_model.guid,
+                    timestamp=timestamp,
+                    add_to_db_session=False,
+                )
+                self.process_instance_events[task_model.guid] = process_instance_event
 
         self.update_bpmn_process(spiff_task.workflow, bpmn_process)
         return task_model


### PR DESCRIPTION
Attempting to avoid creating multiple events for the same cancelled task over and over again. This uses the udpated_ts filter for get_tasks in spiff which hopefully works fine for this use case.