### PR TITLE
Remove backend references to Box

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -32,6 +32,7 @@ from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine  # type: ig
 from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import BasePythonScriptEngineEnvironment  # type: ignore
 from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import Box
 from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import BoxedTaskDataEnvironment
+from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import TaskDataEnvironment
 from SpiffWorkflow.bpmn.serializer.default.task_spec import EventConverter  # type: ignore
 from SpiffWorkflow.bpmn.serializer.helpers.registry import DefaultRegistry  # type: ignore
 from SpiffWorkflow.bpmn.serializer.workflow import BpmnWorkflowSerializer  # type: ignore
@@ -139,7 +140,7 @@ class MissingProcessInfoError(Exception):
     pass
 
 
-class BoxedTaskDataBasedScriptEngineEnvironment(BoxedTaskDataEnvironment):  # type: ignore
+class TaskDataBasedScriptEngineEnvironment(TaskDataEnvironment):  # type: ignore
     def __init__(self, environment_globals: dict[str, Any]):
         self._last_result: dict[str, Any] = {}
         super().__init__(environment_globals)
@@ -263,7 +264,7 @@ class NonTaskDataBasedScriptEngineEnvironment(BasePythonScriptEngineEnvironment)
                 self.state[result_variable] = task.data.pop(result_variable)
 
 
-class CustomScriptEngineEnvironment(NonTaskDataBasedScriptEngineEnvironment):
+class CustomScriptEngineEnvironment(TaskDataBasedScriptEngineEnvironment):
     pass
 
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -30,7 +30,6 @@ from SpiffWorkflow.bpmn.exceptions import WorkflowTaskException  # type: ignore
 from SpiffWorkflow.bpmn.parser.ValidationException import ValidationException  # type: ignore
 from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine  # type: ignore
 from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import BasePythonScriptEngineEnvironment  # type: ignore
-from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import Box
 from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import TaskDataEnvironment
 from SpiffWorkflow.bpmn.serializer.default.task_spec import EventConverter  # type: ignore
 from SpiffWorkflow.bpmn.serializer.helpers.registry import DefaultRegistry  # type: ignore
@@ -335,7 +334,7 @@ class CustomBpmnScriptEngine(PythonScriptEngine):  # type: ignore
     def _evaluate(
         self,
         expression: str,
-        context: dict[str, str],
+        context: dict[str, Any],
         task: SpiffTask | None = None,
         external_methods: dict[str, Any] | None = None,
     ) -> Any:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -190,8 +190,6 @@ class NonTaskDataBasedScriptEngineEnvironment(BasePythonScriptEngineEnvironment)
         context: dict[str, Any],
         external_methods: dict[str, Any] | None = None,
     ) -> Any:
-        # TODO: once integrated look at the tests that fail without Box
-        Box.convert_to_box(context)
         state = {}
         state.update(self.globals)
         state.update(external_methods or {})
@@ -205,9 +203,6 @@ class NonTaskDataBasedScriptEngineEnvironment(BasePythonScriptEngineEnvironment)
         context: dict[str, Any],
         external_methods: dict[str, Any] | None = None,
     ) -> bool:
-        # TODO: once integrated look at the tests that fail without Box
-        # context is task.data
-        Box.convert_to_box(context)
         self.state.update(self.globals)
         self.state.update(external_methods or {})
         self.state.update(context)
@@ -268,12 +263,7 @@ class NonTaskDataBasedScriptEngineEnvironment(BasePythonScriptEngineEnvironment)
                 self.state[result_variable] = task.data.pop(result_variable)
 
 
-# SpiffWorkflow at revision f162aac43af3af18d1a55186aeccea154fb8b05d runs script tasks on ready
-# which means that our will_complete_task hook does not have the correct env state when it runs
-# so save everything to task data for now until we can figure out a better way to hook into that.
-# Revision 6cad2981712bb61eca23af1adfafce02d3277cb9 is the last revision that can run with this.
-# class CustomScriptEngineEnvironment(NonTaskDataBasedScriptEngineEnvironment):
-class CustomScriptEngineEnvironment(BoxedTaskDataBasedScriptEngineEnvironment):
+class CustomScriptEngineEnvironment(NonTaskDataBasedScriptEngineEnvironment):
     pass
 
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -31,7 +31,6 @@ from SpiffWorkflow.bpmn.parser.ValidationException import ValidationException  #
 from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine  # type: ignore
 from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import BasePythonScriptEngineEnvironment  # type: ignore
 from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import Box
-from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import BoxedTaskDataEnvironment
 from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import TaskDataEnvironment
 from SpiffWorkflow.bpmn.serializer.default.task_spec import EventConverter  # type: ignore
 from SpiffWorkflow.bpmn.serializer.helpers.registry import DefaultRegistry  # type: ignore
@@ -336,7 +335,7 @@ class CustomBpmnScriptEngine(PythonScriptEngine):  # type: ignore
     def _evaluate(
         self,
         expression: str,
-        context: dict[str, Box | str],
+        context: dict[str, str],
         task: SpiffTask | None = None,
         external_methods: dict[str, Any] | None = None,
     ) -> Any:

--- a/spiffworkflow-backend/tests/data/message_send_two_conversations/message_receiver_one.bpmn
+++ b/spiffworkflow-backend/tests/data/message_send_two_conversations/message_receiver_one.bpmn
@@ -34,8 +34,8 @@
   <bpmn:message id="message_response_one" name="Message Response One">
     <bpmn:extensionElements>
       <spiffworkflow:messagePayload>{
-"topica_one": payload_var_one.topica_one,
-"topicb_one": payload_var_one.topicb_one,
+"topica_one": payload_var_one["topica_one"],
+"topicb_one": payload_var_one["topicb_one"],
 "second_var_one": second_var_one
 }</spiffworkflow:messagePayload>
     </bpmn:extensionElements>
@@ -54,7 +54,7 @@
     <bpmn:scriptTask id="add_numbers" name="Add Numbers" scriptFormat="python">
       <bpmn:incoming>Flow_0rx0bxv</bpmn:incoming>
       <bpmn:outgoing>Flow_197lbl3</bpmn:outgoing>
-      <bpmn:script>second_var_one = payload_var_one.initial_var_one + 1</bpmn:script>
+      <bpmn:script>second_var_one = payload_var_one["initial_var_one"] + 1</bpmn:script>
     </bpmn:scriptTask>
     <bpmn:startEvent id="receive_message" name="Receive Message">
       <bpmn:outgoing>Flow_0rx0bxv</bpmn:outgoing>

--- a/spiffworkflow-backend/tests/data/message_send_two_conversations/message_receiver_two.bpmn
+++ b/spiffworkflow-backend/tests/data/message_send_two_conversations/message_receiver_two.bpmn
@@ -34,8 +34,8 @@
   <bpmn:message id="message_response_two" name="Message Response Two">
     <bpmn:extensionElements>
       <spiffworkflow:messagePayload>{
-"topic_two_a": payload_var_two.topica_two,
-"topic_two_b": payload_var_two.topicb_two,
+"topic_two_a": payload_var_two["topica_two"],
+"topic_two_b": payload_var_two["topicb_two"],
 "second_var_two": second_var_two
 }</spiffworkflow:messagePayload>
     </bpmn:extensionElements>
@@ -54,7 +54,7 @@
     <bpmn:scriptTask id="add_numbers" name="Add Numbers" scriptFormat="python">
       <bpmn:incoming>Flow_0rx0bxv</bpmn:incoming>
       <bpmn:outgoing>Flow_197lbl3</bpmn:outgoing>
-      <bpmn:script>second_var_two = payload_var_two.initial_var_two + 1</bpmn:script>
+      <bpmn:script>second_var_two = payload_var_two["initial_var_two"] + 1</bpmn:script>
     </bpmn:scriptTask>
     <bpmn:startEvent id="receive_message" name="Receive Message">
       <bpmn:outgoing>Flow_0rx0bxv</bpmn:outgoing>


### PR DESCRIPTION
Switched to use Spiff's `TaskDataEnvironment` instead of `BoxedTaskDataEnvironment`, which is largely the same underlying environment, just Box is not used. This should be less risky than going from `BoxedTaskDataEnvionment` to `NonTaskDataBasedScriptEngineEnvironment` (which also had 14 test failures). I'd like to get back to using the non task data based environment, but don't want that to hold up removing Box.