### PR TITLE
Feature/hide private data objects

### DIFF
--- a/spiffworkflow-backend/bin/get_perms
+++ b/spiffworkflow-backend/bin/get_perms
@@ -19,7 +19,7 @@ mysql -uroot "$database" -e '
     JOIN `user_group_assignment` uga ON uga.user_id = u.id
     JOIN `group` g ON g.id = uga.group_id;
 
-  select pa.id, g.identifier group_identifier, pt.uri, permission from permission_assignment pa
+  select pa.id pa_id, g.identifier group_identifier, pt.uri, pa.grant_type, permission, p.id principal_id from permission_assignment pa
   JOIN principal p ON p.id = pa.principal_id
   JOIN `group` g ON g.id = p.group_id
   JOIN permission_target pt ON pt.id = pa.permission_target_id;

--- a/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
@@ -1803,7 +1803,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/OkTrue"
 
-  /process-data/{modified_process_model_identifier}/{process_instance_id}/{process_data_identifier}:
+  /process-data/{modified_process_model_identifier}/{process_data_identifier}/{process_instance_id}:
     parameters:
       - name: modified_process_model_identifier
         in: path

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
@@ -705,10 +705,15 @@ class AuthorizationService:
 
     @classmethod
     def add_permission_from_uri_or_macro(
-        cls, group_identifier: str, permission: str, target: str, grant_type: str = "permit"
+        cls, group_identifier: str, permission: str, target: str
     ) -> list[PermissionAssignmentModel]:
         group = UserService.find_or_create_group(group_identifier)
-        permissions_to_assign = cls.explode_permissions(permission, target)
+        grant_type = "permit"
+        target_without_deny = target
+        if target.startswith("DENY:"):
+            target_without_deny = target.removeprefix("DENY:")
+            grant_type = "deny"
+        permissions_to_assign = cls.explode_permissions(permission, target_without_deny)
         permission_assignments = []
         for permission_to_assign in permissions_to_assign:
             permission_target = cls.find_or_create_permission_target(permission_to_assign.target_uri)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
@@ -229,7 +229,6 @@ class AuthorizationService:
             principal_id=principal.id,
             permission_target_id=permission_target.id,
             permission=permission,
-            grant_type=grant_type,
         ).first()
         if permission_assignment is None:
             permission_assignment = PermissionAssignmentModel(
@@ -238,6 +237,10 @@ class AuthorizationService:
                 permission=permission,
                 grant_type=grant_type,
             )
+            db.session.add(permission_assignment)
+            db.session.commit()
+        elif permission_assignment.grant_type != grant_type:
+            permission_assignment.grant_type = grant_type
             db.session.add(permission_assignment)
             db.session.commit()
         return permission_assignment

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/helpers/base_test.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/helpers/base_test.py
@@ -312,9 +312,12 @@ class BaseTest:
         username: str,
         target_uri: str = PermissionTargetModel.URI_ALL,
         permission_names: list[str] | None = None,
+        grant_type: str = "permit",
     ) -> UserModel:
         user = BaseTest.find_or_create_user(username=username)
-        return cls.add_permissions_to_user(user, target_uri=target_uri, permission_names=permission_names)
+        return cls.add_permissions_to_user(
+            user, target_uri=target_uri, permission_names=permission_names, grant_type=grant_type
+        )
 
     @classmethod
     def add_permissions_to_user(
@@ -322,14 +325,17 @@ class BaseTest:
         user: UserModel,
         target_uri: str = PermissionTargetModel.URI_ALL,
         permission_names: list[str] | None = None,
+        grant_type: str = "permit",
     ) -> UserModel:
         principal = user.principal
-        cls.add_permissions_to_principal(principal, target_uri=target_uri, permission_names=permission_names)
+        cls.add_permissions_to_principal(
+            principal, target_uri=target_uri, permission_names=permission_names, grant_type=grant_type
+        )
         return user
 
     @classmethod
     def add_permissions_to_principal(
-        cls, principal: PrincipalModel, target_uri: str, permission_names: list[str] | None
+        cls, principal: PrincipalModel, target_uri: str, permission_names: list[str] | None, grant_type: str = "permit"
     ) -> None:
         permission_target = AuthorizationService.find_or_create_permission_target(target_uri)
 
@@ -341,6 +347,7 @@ class BaseTest:
                 principal=principal,
                 permission_target=permission_target,
                 permission=permission,
+                grant_type=grant_type,
             )
 
     def assert_user_has_permission(

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_api.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_api.py
@@ -107,11 +107,15 @@ class TestProcessApi(BaseTest):
         UserService.add_user_to_group(user, group)
         self.add_permissions_to_principal(principal, target_uri="/v1.0/process-groups/%", permission_names=["read"])
         self.add_permissions_to_principal(
+            principal, target_uri="/v1.0/process-groups/deny_group:%", permission_names=["create"], grant_type="deny"
+        )
+        self.add_permissions_to_principal(
             principal, target_uri="/v1.0/process-groups/test_group:%", permission_names=["create"]
         )
         request_body = {
             "requests_to_check": {
                 "/v1.0/process-groups": ["GET", "POST"],
+                "/v1.0/process-groups/deny_group:hey": ["GET", "POST"],
                 "/v1.0/process-groups/test_group": ["GET", "POST"],
                 "/v1.0/process-models": ["GET"],
             }
@@ -119,6 +123,7 @@ class TestProcessApi(BaseTest):
         expected_response_body = {
             "results": {
                 "/v1.0/process-groups": {"GET": True, "POST": False},
+                "/v1.0/process-groups/deny_group:hey": {"GET": True, "POST": False},
                 "/v1.0/process-groups/test_group": {"GET": True, "POST": True},
                 "/v1.0/process-models": {"GET": False},
             }

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_api.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_api.py
@@ -3295,7 +3295,7 @@ class TestProcessApi(BaseTest):
         assert process_instance_one.status == "user_input_required"
 
         response = client.get(
-            f"/v1.0/process-data/{self.modify_process_identifier_for_path_param(process_model.id)}/{process_instance_one.id}/the_data_object_var",
+            f"/v1.0/process-data/{self.modify_process_identifier_for_path_param(process_model.id)}/the_data_object_var/{process_instance_one.id}",
             headers=self.logged_in_headers(with_super_admin_user),
         )
 

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_authorization_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_authorization_service.py
@@ -617,3 +617,8 @@ class TestAuthorizationService(BaseTest):
         # test wildcard deny
         self.assert_user_has_permission(user, "read", "/v1.0/process-groups/hey:new", expected_result=False)
         self.assert_user_has_permission(user, "read", "/v1.0/process-groups/hey:new:group", expected_result=True)
+
+        # test it can be permitted again
+        AuthorizationService.add_permission_from_uri_or_macro(user_group.identifier, "read", "PG:hey:yo")
+        self.assert_user_has_permission(user, "read", "/v1.0/process-groups/hey:yo", expected_result=True)
+        self.assert_user_has_permission(user, "read", "/v1.0/process-groups/hey:yo:me", expected_result=True)

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_authorization_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_authorization_service.py
@@ -603,9 +603,9 @@ class TestAuthorizationService(BaseTest):
         user_group = UserService.find_or_create_group("group_one")
         UserService.add_user_to_group(user, user_group)
         AuthorizationService.add_permission_from_uri_or_macro(user_group.identifier, "read", "PG:hey")
-        AuthorizationService.add_permission_from_uri_or_macro(user_group.identifier, "read", "PG:hey:yo", "deny")
+        AuthorizationService.add_permission_from_uri_or_macro(user_group.identifier, "read", "DENY:PG:hey:yo")
         AuthorizationService.add_permission_from_uri_or_macro(
-            user_group.identifier, "read", "/process-groups/hey:new", "deny"
+            user_group.identifier, "read", "DENY:/process-groups/hey:new"
         )
 
         self.assert_user_has_permission(user, "read", "/v1.0/process-groups/hey")

--- a/spiffworkflow-frontend/src/interfaces.ts
+++ b/spiffworkflow-frontend/src/interfaces.ts
@@ -29,6 +29,8 @@ export interface Onboarding {
 export interface ProcessData {
   process_data_identifier: string;
   process_data_value: any;
+
+  authorized?: boolean;
 }
 
 export interface RecentProcessModel {

--- a/spiffworkflow-frontend/src/routes/ProcessInstanceShow.tsx
+++ b/spiffworkflow-frontend/src/routes/ProcessInstanceShow.tsx
@@ -646,7 +646,7 @@ export default function ProcessInstanceShow({ variant }: OwnProps) {
     if (shapeElement.type === 'bpmn:DataObjectReference') {
       const dataObjectIdentifer = shapeElement.businessObject.dataObjectRef.id;
       HttpService.makeCallToBackend({
-        path: `/process-data/${params.process_model_id}/${params.process_instance_id}/${dataObjectIdentifer}`,
+        path: `/process-data/${params.process_model_id}/${dataObjectIdentifer}/${params.process_instance_id}`,
         httpMethod: 'GET',
         successCallback: handleProcessDataShowResponse,
       });

--- a/spiffworkflow-frontend/src/routes/ProcessInstanceShow.tsx
+++ b/spiffworkflow-frontend/src/routes/ProcessInstanceShow.tsx
@@ -619,6 +619,21 @@ export default function ProcessInstanceShow({ variant }: OwnProps) {
 
   const processDataDisplayArea = () => {
     if (processDataToDisplay) {
+      let bodyComponent = (
+        <>
+          <p>Value:</p>
+          <pre>{JSON.stringify(processDataToDisplay.process_data_value)}</pre>
+        </>
+      );
+      if (processDataToDisplay.authorized === false) {
+        bodyComponent = (
+          <>
+            {childrenForErrorObject(
+              errorForDisplayFromString(processDataToDisplay.process_data_value)
+            )}
+          </>
+        );
+      }
       return (
         <Modal
           open={!!processDataToDisplay}
@@ -627,8 +642,7 @@ export default function ProcessInstanceShow({ variant }: OwnProps) {
         >
           <h2>Data Object: {processDataToDisplay.process_data_identifier}</h2>
           <br />
-          <p>Value:</p>
-          <pre>{JSON.stringify(processDataToDisplay.process_data_value)}</pre>
+          {bodyComponent}
         </Modal>
       );
     }
@@ -636,6 +650,18 @@ export default function ProcessInstanceShow({ variant }: OwnProps) {
   };
 
   const handleProcessDataShowResponse = (processData: ProcessData) => {
+    setProcessDataToDisplay(processData);
+  };
+
+  const handleProcessDataShowReponseUnauthorized = (
+    dataObjectIdentifer: string,
+    result: any
+  ) => {
+    const processData: ProcessData = {
+      process_data_identifier: dataObjectIdentifer,
+      process_data_value: result.message,
+      authorized: false,
+    };
     setProcessDataToDisplay(processData);
   };
 
@@ -649,6 +675,8 @@ export default function ProcessInstanceShow({ variant }: OwnProps) {
         path: `/process-data/${params.process_model_id}/${dataObjectIdentifer}/${params.process_instance_id}`,
         httpMethod: 'GET',
         successCallback: handleProcessDataShowResponse,
+        onUnauthorized: (result: any) =>
+          handleProcessDataShowReponseUnauthorized(dataObjectIdentifer, result),
       });
     } else if (tasks) {
       const matchingTask: Task | undefined = tasks.find((task: Task) => {


### PR DESCRIPTION
This adds support for denying permissions to a given target. This is supported in both the refresh_permissions script task script and in the permission yml file.

To use:
Add `DENY:` to the beginning of the target or permission uri. for example: `PG:group_one` would become `DENY:PG:group_one`.