### PR TITLE
fix standard loop task serialization

### DIFF
--- a/spiffworkflow-backend/bin/create_and_run_process_instance.py
+++ b/spiffworkflow-backend/bin/create_and_run_process_instance.py
@@ -1,9 +1,9 @@
-from spiffworkflow_backend import create_app
-from spiffworkflow_backend.services.user_service import UserService
 import sys
+
+from spiffworkflow_backend import create_app
 from spiffworkflow_backend.models.user import UserModel
-from spiffworkflow_backend.models.process_instance import ProcessInstanceModel
 from spiffworkflow_backend.services.process_instance_service import ProcessInstanceService
+from spiffworkflow_backend.services.user_service import UserService
 
 
 def main() -> None:

--- a/spiffworkflow-backend/bin/create_and_run_process_instance.py
+++ b/spiffworkflow-backend/bin/create_and_run_process_instance.py
@@ -1,0 +1,28 @@
+from spiffworkflow_backend import create_app
+from spiffworkflow_backend.services.user_service import UserService
+import sys
+from spiffworkflow_backend.models.user import UserModel
+from spiffworkflow_backend.models.process_instance import ProcessInstanceModel
+from spiffworkflow_backend.services.process_instance_service import ProcessInstanceService
+
+
+def main() -> None:
+    app = create_app()
+    process_model_identifier = sys.argv[1]
+
+    with app.app_context():
+        user = UserModel.query.first()
+        if user is None:
+            username = "testuser"
+            user = UserService.create_user(username, "service", "service")
+        process_instance = ProcessInstanceService.create_process_instance_from_process_model_identifier(
+            process_model_identifier, user
+        )
+        execution_strategy_name = app.config["SPIFFWORKFLOW_BACKEND_ENGINE_STEP_DEFAULT_STRATEGY_BACKGROUND"]
+        ProcessInstanceService.run_process_instance_with_processor(
+            process_instance, execution_strategy_name=execution_strategy_name
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -100,6 +100,10 @@ from spiffworkflow_backend.services.workflow_execution_service import execution_
 from spiffworkflow_backend.specs.start_event import StartEvent
 from sqlalchemy import and_
 
+# fix for StandardLoopTask
+from SpiffWorkflow.spiff.specs.defaults import StandardLoopTask
+from SpiffWorkflow.spiff.serializer.task_spec import StandardLoopTaskConverter
+SPIFF_CONFIG[StandardLoopTask] = StandardLoopTaskConverter
 
 # this custom converter is just so we use 'ServiceTask' as the typename in the serialization
 # rather than 'CustomServiceTask'
@@ -107,14 +111,14 @@ class CustomServiceTaskConverter(ServiceTaskConverter):  # type: ignore
     def __init__(self, target_class, registry, typename: str = "ServiceTask"):  # type: ignore
         super().__init__(target_class, registry, typename)
 
+SPIFF_CONFIG[CustomServiceTask] = CustomServiceTaskConverter
+del SPIFF_CONFIG[ServiceTask]
 
 SPIFF_CONFIG[StartEvent] = EventConverter
 SPIFF_CONFIG[JSONDataStore] = JSONDataStoreConverter
 SPIFF_CONFIG[JSONFileDataStore] = JSONFileDataStoreConverter
 SPIFF_CONFIG[KKVDataStore] = KKVDataStoreConverter
 SPIFF_CONFIG[TypeaheadDataStore] = TypeaheadDataStoreConverter
-SPIFF_CONFIG[CustomServiceTask] = CustomServiceTaskConverter
-del SPIFF_CONFIG[ServiceTask]
 
 # Sorry about all this crap.  I wanted to move this thing to another file, but
 # importing a bunch of types causes circular imports.

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -41,7 +41,11 @@ from SpiffWorkflow.serializer.exceptions import MissingSpecError  # type: ignore
 from SpiffWorkflow.spiff.parser.process import SpiffBpmnParser  # type: ignore
 from SpiffWorkflow.spiff.serializer.config import SPIFF_CONFIG  # type: ignore
 from SpiffWorkflow.spiff.serializer.task_spec import ServiceTaskConverter  # type: ignore
+from SpiffWorkflow.spiff.serializer.task_spec import StandardLoopTaskConverter
 from SpiffWorkflow.spiff.specs.defaults import ServiceTask  # type: ignore
+
+# fix for StandardLoopTask
+from SpiffWorkflow.spiff.specs.defaults import StandardLoopTask
 from SpiffWorkflow.task import Task as SpiffTask  # type: ignore
 from SpiffWorkflow.util.deep_merge import DeepMerge  # type: ignore
 from SpiffWorkflow.util.task import TaskIterator  # type: ignore
@@ -100,16 +104,15 @@ from spiffworkflow_backend.services.workflow_execution_service import execution_
 from spiffworkflow_backend.specs.start_event import StartEvent
 from sqlalchemy import and_
 
-# fix for StandardLoopTask
-from SpiffWorkflow.spiff.specs.defaults import StandardLoopTask
-from SpiffWorkflow.spiff.serializer.task_spec import StandardLoopTaskConverter
 SPIFF_CONFIG[StandardLoopTask] = StandardLoopTaskConverter
+
 
 # this custom converter is just so we use 'ServiceTask' as the typename in the serialization
 # rather than 'CustomServiceTask'
 class CustomServiceTaskConverter(ServiceTaskConverter):  # type: ignore
     def __init__(self, target_class, registry, typename: str = "ServiceTask"):  # type: ignore
         super().__init__(target_class, registry, typename)
+
 
 SPIFF_CONFIG[CustomServiceTask] = CustomServiceTaskConverter
 del SPIFF_CONFIG[ServiceTask]


### PR DESCRIPTION
fix for StandardLoopTask serialization issue, which was introduced with 4918f4fe (https://github.com/sartography/spiff-arena/pull/540)
script to create and run process instance. replicated with:

````
SPIFFWORKFLOW_BACKEND_BPMN_SPEC_ABSOLUTE_DIR=$HOME/projects/github/sartography/sartography-process-models bin/run_local_python_script bin/create_and_run_process_instance.py bpmn-unit-tests/expected-to-pass/single-activity-tests/loop-manual-task
````

if this fix belongs in spiff lib, we can always come back and undo this and bump spiff.