### PR TITLE
Feature/no data for finished spiff tasks

### DIFF
--- a/.github/workflows/docker_image_for_main_builds.yml
+++ b/.github/workflows/docker_image_for_main_builds.yml
@@ -32,7 +32,7 @@ on:
     branches:
       - main
       - spiffdemo
-      - feature/drop-id-column-on-json-data
+      - feature/no-data-for-finished-spiff-tasks
 
 jobs:
   create_frontend_docker_image:

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_api.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_api.py
@@ -9,7 +9,6 @@ from typing import Any
 import pytest
 from flask.app import Flask
 from flask.testing import FlaskClient
-from SpiffWorkflow.util.task import TaskState  # type: ignore
 from spiffworkflow_backend.exceptions.process_entity_not_found_error import ProcessEntityNotFoundError
 from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.models.process_group import ProcessGroup
@@ -2117,8 +2116,10 @@ class TestProcessApi(BaseTest):
         processor = ProcessInstanceProcessor(process_instance)
         spiff_task = processor.get_task_by_bpmn_identifier("script_task_two", processor.bpmn_process_instance)
         assert spiff_task is not None
-        assert spiff_task.state == TaskState.ERROR
-        assert spiff_task.data == {"my_var": "THE VAR"}
+        task_model = TaskModel.query.filter_by(guid=str(spiff_task.id)).first()
+        assert task_model is not None
+        assert task_model.state == "ERROR"
+        assert task_model.get_data() == {"my_var": "THE VAR"}
 
     def test_process_model_file_create(
         self,

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_processor.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_processor.py
@@ -876,8 +876,10 @@ class TestProcessInstanceProcessor(BaseTest):
             "script_task_two", processor_final.bpmn_process_instance
         )
         assert spiff_task is not None
-        assert spiff_task.state == TaskState.ERROR
-        assert spiff_task.data == {"my_var": "THE VAR"}
+        task_model = TaskModel.query.filter_by(guid=str(spiff_task.id)).first()
+        assert task_model is not None
+        assert task_model.state == "ERROR"
+        assert task_model.get_data() == {"my_var": "THE VAR"}
 
         process_instance_events = process_instance.process_instance_events
         assert len(process_instance_events) == 4


### PR DESCRIPTION
This avoids adding task data to finished tasks when assembling the process instance dict for spiff. This is to cut down on the overall size of the bpmn_process_instance and because spiff does not need task data for tasks that it will never execute again.

Implements: #658 