### PR TITLE
Feature/deny macro on permission

### DIFF
--- a/docs/DevOps_installation_integration/admin_and_permissions.md
+++ b/docs/DevOps_installation_integration/admin_and_permissions.md
@@ -14,16 +14,10 @@ groups:
     users: [admin@spiffworkflow.org]
 
 permissions:
-  admin:
+  admin-type-user:
     groups: [admin]
-    allowed_permissions: [create, read, update, delete]
+    actions: [create, read, update, delete]
     uri: /*
-```
-
-```{admonition} uri!
-:class: info
-
-The "uri" field defines the target resource for these permissions, which is set to "/*". This indicates that the permissions apply to all resources within the system.
 ```
 
 ### Groups
@@ -33,9 +27,16 @@ In this example, the "admin" group consists of a single user with the associated
 
 ### Permissions 
 
-The "permissions" section specifies the permissions and access control rules for the "admin" group.
-The "admin" permission set allows members of the "admin" group to perform actions such as create, read, update, start and delete or all.
-The "allowed_permissions" field lists the specific actions that are permitted for the "admin" group.
+Each permission has a name.
+This is just for documentation purposes, and isn't used by the system.
+In this example, we are describing permissions for an "admin-type-user."
+
+There are three keys allowed under each permission:
+* groups: lists the groups to which the permission applies (admin in this case)
+* actions: lists the specific actions that are permitted for the group
+   * actions can be negated by prepending with "DENY:"
+* uri: defines the target resource for these permissions
+   * /* indicates that the permissions apply to all resources within the system
 
 **Permissions allowed:**
 
@@ -50,6 +51,18 @@ The "allowed_permissions" field lists the specific actions that are permitted fo
 - start
 
 - all
+
+To allow reading and updating, it would look like this:
+
+````
+["read", "update"]
+````
+
+To allow reading and DISALLOW updating, it would look like this:
+
+````
+["read", "DENY:update"]
+````
   
 ## Site Administration
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/acceptance_tests.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/acceptance_tests.yml
@@ -12,5 +12,5 @@ groups:
 permissions:
   admin:
     groups: [admin]
-    allowed_permissions: [create, read, update, delete]
+    actions: [create, read, update, delete]
     uri: /*

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/demo.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/demo.yml
@@ -19,5 +19,5 @@ groups:
 permissions:
   admin:
     groups: [admin, tech_writers]
-    allowed_permissions: [create, read, update, delete]
+    actions: [create, read, update, delete]
     uri: /*

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/example.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/example.yml
@@ -40,26 +40,26 @@ permissions:
   # Admins have access to everything.
   admin:
     groups: [admin]
-    allowed_permissions: [all]
+    actions: [all]
     uri: /*
 
   # Everybody can participate in tasks assigned to them.
   # BASIC, PG, PM, are documented at https://spiff-arena.readthedocs.io/en/latest/DevOps_installation_integration/permission_url.html
   basic:
     groups: [everybody]
-    allowed_permissions: [all]
+    actions: [all]
     uri: BASIC
 
   # Everyone can see everything (all groups, and processes are visible)
   read-all-process-groups:
     groups: [ everybody ]
-    allowed_permissions: [ read ]
+    actions: [ read ]
     uri: PG:ALL
   read-all-process-models:
     groups: [ everybody ]
-    allowed_permissions: [ read ]
+    actions: [ read ]
     uri: PM:ALL
   run-all-process-models:
     groups: [ everybody ]
-    allowed_permissions: [ start ]
+    actions: [ start ]
     uri: PM:ALL

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/example_process_model_read_only.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/example_process_model_read_only.yml
@@ -5,13 +5,13 @@ groups:
 permissions:
   process-groups-ro:
     groups: [admin]
-    allowed_permissions: [read]
+    actions: [read]
     uri: PG:ALL
   basic:
     groups: [admin]
-    allowed_permissions: [all]
+    actions: [all]
     uri: BASIC
   elevated-operations:
     groups: [admin]
-    allowed_permissions: [all]
+    actions: [all]
     uri: ELEVATED

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/example_process_model_read_only_with_publish.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/example_process_model_read_only_with_publish.yml
@@ -5,17 +5,17 @@ groups:
 permissions:
   process-groups-ro:
     groups: [admin]
-    allowed_permissions: [read]
+    actions: [read]
     uri: PG:ALL
   basic:
     groups: [admin]
-    allowed_permissions: [all]
+    actions: [all]
     uri: BASIC
   elevated-operations:
     groups: [admin]
-    allowed_permissions: [all]
+    actions: [all]
     uri: ELEVATED
   process-model-publish:
     groups: [admin]
-    allowed_permissions: [create]
+    actions: [create]
     uri: /process-model-publish/*

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/local_development.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/local_development.yml
@@ -21,15 +21,15 @@ groups:
 permissions:
   admin:
     groups: [admin, group1]
-    allowed_permissions: [create, read, update, delete]
+    actions: [create, read, update, delete]
     uri: /*
 
   basic:
     groups: [group2]
-    allowed_permissions: [all]
+    actions: [all]
     uri: BASIC
 
   basic-read:
     groups: [group2]
-    allowed_permissions: [read]
+    actions: [read]
     uri: PG:ALL

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/terraform_deployed_environment.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/terraform_deployed_environment.yml
@@ -6,5 +6,5 @@ groups:
 permissions:
   admin:
     groups: [admin]
-    allowed_permissions: [create, read, update, delete]
+    actions: [create, read, update, delete]
     uri: /*

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/unit_testing.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/unit_testing.yml
@@ -18,33 +18,33 @@ groups:
 permissions:
   process-groups-all:
     groups: [admin]
-    allowed_permissions: [all]
+    actions: [all]
     uri: PG:ALL
   basic:
     groups: [admin]
-    allowed_permissions: [all]
+    actions: [all]
     uri: BASIC
   elevated-operations:
     groups: [admin]
-    allowed_permissions: [all]
+    actions: [all]
     uri: ELEVATED
 
   basic-permission:
     groups: [everybody]
-    allowed_permissions: [all]
+    actions: [all]
     uri: BASIC
 
   finance-admin-group:
     groups: ["Finance Team"]
-    allowed_permissions: [all]
+    actions: [all]
     uri: PG:finance
 
   finance-hr-start:
     groups: ["hr"]
-    allowed_permissions: [start]
+    actions: [start]
     uri: PG:finance
 
   read-all-finance:
     groups: [hr]
-    allowed_permissions: [read]
+    actions: [read]
     uri: PG:finance

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
@@ -737,6 +737,10 @@ class AuthorizationService:
         if "actions" in permission_config:
             actions = permission_config["actions"]
         elif "allowed_permissions" in permission_config:
+            current_app.logger.warning(
+                "DEPRECATION WARNING: found use of 'allowed_permissions' in permissions yaml. Please use 'actions'"
+                " instead of 'allowed_permissions' in your config file."
+            )
             actions = permission_config["allowed_permissions"]
         return actions
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
@@ -713,11 +713,11 @@ class AuthorizationService:
     ) -> list[PermissionAssignmentModel]:
         group = UserService.find_or_create_group(group_identifier)
         grant_type = "permit"
-        target_without_deny = target
-        if target.startswith("DENY:"):
-            target_without_deny = target.removeprefix("DENY:")
+        permission_without_deny = permission
+        if permission.startswith("DENY:"):
+            permission_without_deny = permission.removeprefix("DENY:")
             grant_type = "deny"
-        permissions_to_assign = cls.explode_permissions(permission, target_without_deny)
+        permissions_to_assign = cls.explode_permissions(permission_without_deny, target)
         permission_assignments = []
         for permission_to_assign in permissions_to_assign:
             permission_target = cls.find_or_create_permission_target(permission_to_assign.target_uri)
@@ -730,6 +730,15 @@ class AuthorizationService:
                 )
             )
         return permission_assignments
+
+    @classmethod
+    def get_permissions_from_config(cls, permission_config: dict) -> list[str]:
+        actions = []
+        if "actions" in permission_config:
+            actions = permission_config["actions"]
+        elif "allowed_permissions" in permission_config:
+            actions = permission_config["allowed_permissions"]
+        return actions
 
     @classmethod
     def parse_permissions_yaml_into_group_info(cls) -> list[GroupPermissionsDict]:
@@ -764,9 +773,10 @@ class AuthorizationService:
         if "permissions" in permission_configs:
             for _permission_identifier, permission_config in permission_configs["permissions"].items():
                 uri = permission_config["uri"]
+                actions = cls.get_permissions_from_config(permission_config)
                 for group_identifier in permission_config["groups"]:
                     group_permissions_by_group[group_identifier]["permissions"].append(
-                        {"actions": permission_config["allowed_permissions"], "uri": uri}
+                        {"actions": actions, "uri": uri}
                     )
 
         return list(group_permissions_by_group.values())

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_authorization_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_authorization_service.py
@@ -603,9 +603,9 @@ class TestAuthorizationService(BaseTest):
         user_group = UserService.find_or_create_group("group_one")
         UserService.add_user_to_group(user, user_group)
         AuthorizationService.add_permission_from_uri_or_macro(user_group.identifier, "read", "PG:hey")
-        AuthorizationService.add_permission_from_uri_or_macro(user_group.identifier, "read", "DENY:PG:hey:yo")
+        AuthorizationService.add_permission_from_uri_or_macro(user_group.identifier, "DENY:read", "PG:hey:yo")
         AuthorizationService.add_permission_from_uri_or_macro(
-            user_group.identifier, "read", "DENY:/process-groups/hey:new"
+            user_group.identifier, "DENY:read", "/process-groups/hey:new"
         )
 
         self.assert_user_has_permission(user, "read", "/v1.0/process-groups/hey")


### PR DESCRIPTION
This changes the use of the DENY permission to be set in the action rather than the uri. So instead of:
```
DENY:PG:ALL
```

it would be:
```
["DENY:read"]
```

Implements #666 