### PR TITLE
feature/fix-regex-group-refresh

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/interfaces.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/interfaces.py
@@ -2,6 +2,9 @@ from typing import TYPE_CHECKING
 from typing import NewType
 from typing import TypedDict
 
+from spiffworkflow_backend.models.permission_assignment import PermissionAssignmentModel
+from spiffworkflow_backend.models.user_group_assignment_waiting import UserGroupAssignmentWaitingModel
+
 if TYPE_CHECKING:
     from spiffworkflow_backend.models.process_group import ProcessGroup
 
@@ -17,3 +20,26 @@ class ProcessGroupLite(TypedDict):
 class ProcessGroupLitesWithCache(TypedDict):
     cache: dict[str, "ProcessGroup"]
     process_groups: list[ProcessGroupLite]
+
+
+class UserToGroupDict(TypedDict):
+    username: str
+    group_identifier: str
+
+
+class AddedPermissionDict(TypedDict):
+    group_identifiers: set[str]
+    permission_assignments: list[PermissionAssignmentModel]
+    user_to_group_identifiers: list[UserToGroupDict]
+    waiting_user_group_assignments: list[UserGroupAssignmentWaitingModel]
+
+
+class DesiredGroupPermissionDict(TypedDict):
+    actions: list[str]
+    uri: str
+
+
+class GroupPermissionsDict(TypedDict):
+    users: list[str]
+    name: str
+    permissions: list[DesiredGroupPermissionDict]


### PR DESCRIPTION
Return the user group assignments that occurred during permission refresh so that we do not delete them later by accident.