### PR TITLE
feature/specify-valid-client-ids

### DIFF
--- a/spiffworkflow-backend/bin/local_development_environment_setup
+++ b/spiffworkflow-backend/bin/local_development_environment_setup
@@ -36,7 +36,7 @@ elif [[ "$process_model_dir" == "localopenid" ]]; then
   export SPIFFWORKFLOW_BACKEND_AUTH_CONFIGS__0__identifier="openid"
   export SPIFFWORKFLOW_BACKEND_AUTH_CONFIGS__0__label="openid"
   export SPIFFWORKFLOW_BACKEND_AUTH_CONFIGS__0__uri="http://localhost:$port/openid"
-  export SPIFFWORKFLOW_BACKEND_AUTH_CONFIGS__0__client_id="spiffworkflow-backend"
+  export SPIFFWORKFLOW_BACKEND_AUTH_CONFIGS__0__client_id="spiffworkflow-backend-HEY"
   export SPIFFWORKFLOW_BACKEND_AUTH_CONFIGS__0__client_secret="JXeQExm0JhQPLumgHtIIqf52bDalHz0q"
   export SPIFFWORKFLOW_BACKEND_PERMISSIONS_FILE_NAME="example.yml"
 

--- a/spiffworkflow-backend/bin/local_development_environment_setup
+++ b/spiffworkflow-backend/bin/local_development_environment_setup
@@ -36,7 +36,7 @@ elif [[ "$process_model_dir" == "localopenid" ]]; then
   export SPIFFWORKFLOW_BACKEND_AUTH_CONFIGS__0__identifier="openid"
   export SPIFFWORKFLOW_BACKEND_AUTH_CONFIGS__0__label="openid"
   export SPIFFWORKFLOW_BACKEND_AUTH_CONFIGS__0__uri="http://localhost:$port/openid"
-  export SPIFFWORKFLOW_BACKEND_AUTH_CONFIGS__0__client_id="spiffworkflow-backend-HEY"
+  export SPIFFWORKFLOW_BACKEND_AUTH_CONFIGS__0__client_id="spiffworkflow-backend"
   export SPIFFWORKFLOW_BACKEND_AUTH_CONFIGS__0__client_secret="JXeQExm0JhQPLumgHtIIqf52bDalHz0q"
   export SPIFFWORKFLOW_BACKEND_PERMISSIONS_FILE_NAME="example.yml"
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/__init__.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/__init__.py
@@ -234,6 +234,7 @@ def setup_config(app: Flask) -> None:
                 "uri": app.config.get("SPIFFWORKFLOW_BACKEND_OPEN_ID_SERVER_URL"),
                 "client_id": app.config.get("SPIFFWORKFLOW_BACKEND_OPEN_ID_CLIENT_ID"),
                 "client_secret": app.config.get("SPIFFWORKFLOW_BACKEND_OPEN_ID_CLIENT_SECRET_KEY"),
+                "additional_valid_client_ids": app.config.get("SPIFFWORKFLOW_BACKEND_OPEN_ID_ADDITIONAL_VALID_CLIENT_IDS"),
             }
         ]
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
@@ -106,6 +106,15 @@ else:
         SPIFFWORKFLOW_BACKEND_OPEN_ID_SERVER_URL = url_config
         config_from_env("SPIFFWORKFLOW_BACKEND_OPEN_ID_CLIENT_ID", default="spiffworkflow-backend")
         config_from_env("SPIFFWORKFLOW_BACKEND_OPEN_ID_CLIENT_SECRET_KEY", default="JXeQExm0JhQPLumgHtIIqf52bDalHz0q")
+
+        # comma-separated list of client ids that can be successfully validated against.
+        # useful for api users that will login to a different client on the same realm but from something external to backend.
+        # Example:
+        #       client-A is configured as the main client id in backend
+        #       client-B is for api users who will authenticate directly with keycloak
+        #       if client-B is added to this list, then an api user can auth with keycloak
+        #           and use that token successfully with backend
+        config_from_env("SPIFFWORKFLOW_BACKEND_OPEN_ID_ADDITIONAL_VALID_CLIENT_IDS")
     else:
         SPIFFWORKFLOW_BACKEND_AUTH_CONFIGS = [
             {
@@ -114,6 +123,7 @@ else:
                 "uri": "http://localhost:7002/realms/spiffworkflow",
                 "client_id": "spiffworkflow-backend",
                 "client_secret": "JXeQExm0JhQPLumgHtIIqf52bDalHz0q",
+                "additional_valid_client_ids": None,
             }
         ]
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authentication_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authentication_service.py
@@ -1,12 +1,18 @@
 import base64
 import enum
 import json
+import sys
 import time
 from hashlib import sha256
 from hmac import HMAC
 from hmac import compare_digest
-from typing import NotRequired
-from typing import TypedDict
+
+if sys.version_info < (3, 11):
+    from typing_extensions import NotRequired
+    from typing_extensions import TypedDict
+else:
+    from typing import NotRequired
+    from typing import TypedDict
 
 import jwt
 import requests


### PR DESCRIPTION
Added config that will allow users to specify additional valid client ids that will be used when validating the token.

The purpose of this is to allow tokens that were created against the same realm that's configured for an auth config but against a different client id to still work with backend.

Example:
* client-A is configured as the main client id in backend
* client-B is for api users who will authenticate directly with keycloak
* if client-B is added to this list, then an api user can auth with keycloak and use that token successfully with backend


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced authentication system to support additional valid client IDs for OpenID connections.

- **Refactor**
  - Improved authentication service logic for validating access permissions.

- **Chores**
  - Updated local development environment setup with new client ID configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->