### PR TITLE
feature/handle-empty-forms

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
@@ -503,11 +503,8 @@ def task_show(
                 process_model=process_model_with_form,
                 revision=process_instance.bpmn_version_control_identifier,
             )
-
             _update_form_schema_with_task_data_as_needed(form_dict, task_model.data)
-
-            if form_dict:
-                task_model.form_schema = form_dict
+            task_model.form_schema = form_dict
 
             if form_ui_schema_file_name:
                 ui_form_contents = _prepare_form_data(
@@ -516,8 +513,7 @@ def task_show(
                     process_model=process_model_with_form,
                     revision=process_instance.bpmn_version_control_identifier,
                 )
-                if ui_form_contents is not None:
-                    task_model.form_ui_schema = ui_form_contents
+                task_model.form_ui_schema = ui_form_contents
             else:
                 task_model.form_ui_schema = {}
             _munge_form_ui_schema_based_on_hidden_fields_in_task_data(task_model.form_ui_schema, task_model.data)


### PR DESCRIPTION
This changes the backend to return the form even if it is a blank dict. This allows frontend to pass a blank object to the rjsf form which displays a blank form instead and operates much more like a manual task.

Implements #691 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the update process for task forms within the application, ensuring that form schemas are consistently refreshed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->