### PR TITLE
use the approach from check_permissions to avoid n plus 1 query issue

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
@@ -29,7 +29,6 @@ from spiffworkflow_backend.models.group import GroupModel
 from spiffworkflow_backend.models.human_task import HumanTaskModel
 from spiffworkflow_backend.models.permission_assignment import PermissionAssignmentModel
 from spiffworkflow_backend.models.permission_target import PermissionTargetModel
-from spiffworkflow_backend.models.principal import MissingPrincipalError
 from spiffworkflow_backend.models.principal import PrincipalModel
 from spiffworkflow_backend.models.service_account import SPIFF_SERVICE_ACCOUNT_AUTH_SERVICE
 from spiffworkflow_backend.models.task import TaskModel  # noqa: F401
@@ -118,17 +117,19 @@ class AuthorizationService:
 
     @classmethod
     def user_has_permission(cls, user: UserModel, permission: str, target_uri: str) -> bool:
-        if user.principal is None:
-            raise MissingPrincipalError(f"Missing principal for user with id: {user.id}")
-
-        principals = [user.principal]
-
-        for group in user.groups:
-            if group.principal is None:
-                raise MissingPrincipalError(f"Missing principal for group with id: {group.id}")
-            principals.append(group.principal)
-
+        principals = UserService.all_principals_for_user(user)
         return cls.has_permission(principals, permission, target_uri)
+
+    @classmethod
+    def all_permission_assignments_for_user(cls, user: UserModel) -> list[PermissionAssignmentModel]:
+        principals = UserService.all_principals_for_user(user)
+        principal_ids = [p.id for p in principals]
+        permission_assignments: list[PermissionAssignmentModel] = (
+            PermissionAssignmentModel.query.filter(PermissionAssignmentModel.principal_id.in_(principal_ids))
+            .options(db.joinedload(PermissionAssignmentModel.permission_target))
+            .all()
+        )
+        return permission_assignments
 
     @classmethod
     def permission_assignments_include(

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_model_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_model_service.py
@@ -267,14 +267,22 @@ class ProcessModelService(FileSystemService):
             permission=permission_to_check,
             target_uri=f"{permission_base_uri}/{guid_of_non_existent_item_to_check_perms_against}",
         )
+
+        # if user has access to uri/* with that permission then there's no reason to check each one individually
         if has_permission:
             return process_model_identifiers
+
+        permission_assignments = AuthorizationService.all_permission_assignments_for_user(user=user)
 
         permitted_process_model_identifiers = []
         for process_model_identifier in process_model_identifiers:
             modified_process_model_id = ProcessModelInfo.modify_process_identifier_for_path_param(process_model_identifier)
             uri = f"{permission_base_uri}/{modified_process_model_id}"
-            has_permission = AuthorizationService.user_has_permission(user=user, permission=permission_to_check, target_uri=uri)
+            has_permission = AuthorizationService.permission_assignments_include(
+                permission_assignments=permission_assignments,
+                permission=permission_to_check,
+                target_uri=uri,
+            )
             if has_permission:
                 permitted_process_model_identifiers.append(process_model_identifier)
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/user_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/user_service.py
@@ -212,6 +212,7 @@ class UserService:
     def all_principals_for_user(cls, user: UserModel) -> list[PrincipalModel]:
         if user.principal is None:
             raise MissingPrincipalError(f"Missing principal for user with id: {user.id}")
+
         principals = [user.principal]
 
         for group in user.groups:


### PR DESCRIPTION
only hit permission_assignment table once when asking about process model permissions
push a bit of controller logic to services

tested locally with a request like this and sqlalchemy logging turned on, and the wall of logs went away:

````
curl 'http://localhost:7000/v1.0/process-models?per_page=1000&recursive=true&include_parent_groups=true' \
  -H "authorization: Bearer $token" \
  -H 'spiffworkflow-authentication-identifier: default'
````

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined permission checking across the application for enhanced performance and maintainability.
- **Bug Fixes**
  - Improved the accuracy of user permission assignments to ensure correct access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->