### PR TITLE
Clear caches when deleting a file

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
@@ -14,6 +14,7 @@ from flask import make_response
 from flask.wrappers import Response
 from werkzeug.datastructures import FileStorage
 
+from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.exceptions.api_error import ApiError
 from spiffworkflow_backend.interfaces import IdToProcessGroupMapping
 from spiffworkflow_backend.models.file import FileType
@@ -258,6 +259,7 @@ def process_model_file_delete(modified_process_model_identifier: str, file_name:
 
     try:
         SpecFileService.delete_file(process_model, file_name)
+        db.session.commit()
     except FileNotFoundError as exception:
         raise (
             ApiError(

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
@@ -14,9 +14,9 @@ from flask import make_response
 from flask.wrappers import Response
 from werkzeug.datastructures import FileStorage
 
-from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.exceptions.api_error import ApiError
 from spiffworkflow_backend.interfaces import IdToProcessGroupMapping
+from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.models.file import FileType
 from spiffworkflow_backend.models.process_group import ProcessGroup
 from spiffworkflow_backend.models.process_instance_report import ProcessInstanceReportModel

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/spec_file_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/spec_file_service.py
@@ -230,11 +230,6 @@ class SpecFileService(FileSystemService):
 
     @classmethod
     def delete_file(cls, process_model: ProcessModelInfo, file_name: str) -> None:
-        # Fixme: Remember to remove the lookup files when the process_model file is removed.
-        # lookup_files = session.query(LookupFileModel).filter_by(file_model_id=file_id).all()
-        # for lf in lookup_files:
-        #     session.query(LookupDataModel).filter_by(lookup_file_model_id=lf.id).delete()
-        #     session.query(LookupFileModel).filter_by(id=lf.id).delete()
         cls.clear_caches_for_file(file_name, process_model)
         db.session.commit()
         full_file_path = SpecFileService.full_file_path(process_model, file_name)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/spec_file_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/spec_file_service.py
@@ -231,7 +231,6 @@ class SpecFileService(FileSystemService):
     @classmethod
     def delete_file(cls, process_model: ProcessModelInfo, file_name: str) -> None:
         cls.clear_caches_for_file(file_name, process_model)
-        db.session.commit()
         full_file_path = SpecFileService.full_file_path(process_model, file_name)
         os.remove(full_file_path)
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/spec_file_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/spec_file_service.py
@@ -228,13 +228,15 @@ class SpecFileService(FileSystemService):
         full_file_path = SpecFileService.full_file_path(process_model, file_name)
         return FileSystemService._timestamp(full_file_path)
 
-    @staticmethod
-    def delete_file(process_model: ProcessModelInfo, file_name: str) -> None:
+    @classmethod
+    def delete_file(cls, process_model: ProcessModelInfo, file_name: str) -> None:
         # Fixme: Remember to remove the lookup files when the process_model file is removed.
         # lookup_files = session.query(LookupFileModel).filter_by(file_model_id=file_id).all()
         # for lf in lookup_files:
         #     session.query(LookupDataModel).filter_by(lookup_file_model_id=lf.id).delete()
         #     session.query(LookupFileModel).filter_by(id=lf.id).delete()
+        cls.clear_caches_for_file(file_name, process_model)
+        db.session.commit()
         full_file_path = SpecFileService.full_file_path(process_model, file_name)
         os.remove(full_file_path)
 


### PR DESCRIPTION
Work on #822 - this partially fixes the issues by making sure that the reference cache is cleared for the file that is being deleted. If you delete a file and re-upload it there will only be one option when adding a called element. There is still an issue with allowing duplicate process ids on upload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the file deletion process to enhance performance and reliability.

- **Chores**
  - Improved internal caching mechanisms to ensure data consistency after file operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->