### PR TITLE
Added asterisk to title when required and fixed validation errors

### DIFF
--- a/spiffworkflow-frontend/src/rjsf/custom_widgets/NumericRangeField/NumericRangeField.tsx
+++ b/spiffworkflow-frontend/src/rjsf/custom_widgets/NumericRangeField/NumericRangeField.tsx
@@ -6,7 +6,6 @@ import {
 } from '@rjsf/utils';
 import { TextInput } from '@carbon/react';
 import { getCommonAttributes } from '../../helpers';
-import { useEffect } from 'react';
 
 // Example jsonSchema - NOTE: the "min" and "max" properties are special names and must be used:
 //    compensation":{

--- a/spiffworkflow-frontend/src/rjsf/custom_widgets/NumericRangeField/NumericRangeField.tsx
+++ b/spiffworkflow-frontend/src/rjsf/custom_widgets/NumericRangeField/NumericRangeField.tsx
@@ -6,6 +6,7 @@ import {
 } from '@rjsf/utils';
 import { TextInput } from '@carbon/react';
 import { getCommonAttributes } from '../../helpers';
+import { useEffect } from 'react';
 
 // Example jsonSchema - NOTE: the "min" and "max" properties are special names and must be used:
 //    compensation":{
@@ -40,6 +41,7 @@ export default function NumericRangeField({
   rawErrors = [],
   formData,
   registry,
+  required,
 }: FieldProps) {
   const commonAttributes = getCommonAttributes(
     label,
@@ -61,7 +63,7 @@ export default function NumericRangeField({
     if (numberString) {
       return numberString.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
     }
-    return '0';
+    return '';
   };
 
   const parseNumberString = (numberString: string) =>
@@ -102,7 +104,9 @@ export default function NumericRangeField({
   return (
     <div className="numeric--range-field-wrapper">
       <div className="numeric--range-field-label">
-        <h5>{commonAttributes.label}</h5>
+        <h5>
+          {required ? `${commonAttributes.label} *` : commonAttributes.label}
+        </h5>
         {description && (
           <div className="markdown-field-desc-text">
             <DescriptionFieldTemplate
@@ -126,7 +130,6 @@ export default function NumericRangeField({
             onChangeLocal('min', values);
           }}
           invalid={commonAttributes.invalid}
-          defaultValue="0"
           autofocus={autofocus}
         />
         <TextInput
@@ -136,7 +139,6 @@ export default function NumericRangeField({
           readonly={readonly}
           value={formatNumberString(max)}
           onChange={(values: any) => onChangeLocal('max', values)}
-          defaultValue="0"
           invalid={commonAttributes.invalid}
         />
       </div>


### PR DESCRIPTION
Added a check for if the field is required, and if it is there should be an asterisk now. Changed the default value for the min and max inputs so that they are empty by default. If no values are added when the field is required it will cause an error, but if it isn't required it will not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a `required` parameter to enhance the `NumericRangeField` component, ensuring fields can be marked as mandatory for users.

- **Enhancements**
  - Improved label display within the `NumericRangeField` component to reflect whether a field is required.

- **Documentation**
  - Updated function signatures and comments to clearly document the new `required` parameter usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->