### PR TITLE
Drop __annotations__ from task data

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -160,6 +160,7 @@ class MissingProcessInfoError(Exception):
 class TaskDataBasedScriptEngineEnvironment(TaskDataEnvironment):  # type: ignore
     def __init__(self, environment_globals: dict[str, Any]):
         self._last_result: dict[str, Any] = {}
+        self._non_user_defined_keys = {"__annotations__"}
         super().__init__(environment_globals)
 
     def execute(
@@ -169,6 +170,9 @@ class TaskDataBasedScriptEngineEnvironment(TaskDataEnvironment):  # type: ignore
         external_context: dict[str, Any] | None = None,
     ) -> bool:
         super().execute(script, context, external_context)
+        for key in self._non_user_defined_keys:
+            if key in context:
+                context.pop(key)
         self._last_result = context
         return True
 
@@ -199,7 +203,7 @@ class NonTaskDataBasedScriptEngineEnvironment(BasePythonScriptEngineEnvironment)
 
     def __init__(self, environment_globals: dict[str, Any]):
         self.state: dict[str, Any] = {}
-        self.non_user_defined_keys = set([*environment_globals.keys()] + ["__builtins__"])
+        self.non_user_defined_keys = set([*environment_globals.keys()] + ["__builtins__", "__annotations__"])
         super().__init__(environment_globals)
 
     def evaluate(


### PR DESCRIPTION
If you add type hints within a script, the python interpreter leaves behind an empty dictionary in task data called `__annotations__`. Popping that from the context if it exists. I didn't go as far as popping everything that the non task data based environment does since that seemed like a more risky change and we haven't experienced any issues not popping those keys so far.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved script execution environments to exclude specific system-defined keys, enhancing data handling during task processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->