### PR TITLE
feature/detached-instance-error

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_lock_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_lock_service.py
@@ -49,16 +49,6 @@ class ProcessInstanceLockService:
         ctx["locks"][process_instance_id] = queue_entry.id
 
     @classmethod
-    def lock_many(
-        cls, queue_entries: list[ProcessInstanceQueueModel], additional_processing_identifier: str | None = None
-    ) -> list[int]:
-        ctx = cls.get_thread_local_locking_context(additional_processing_identifier=additional_processing_identifier)
-        new_locks = {entry.process_instance_id: entry.id for entry in queue_entries}
-        new_lock_ids = list(new_locks.keys())
-        ctx["locks"].update(new_locks)
-        return new_lock_ids
-
-    @classmethod
     def unlock(cls, process_instance_id: int, additional_processing_identifier: str | None = None) -> int:
         queue_model_id = cls.try_unlock(process_instance_id, additional_processing_identifier=additional_processing_identifier)
         if queue_model_id is None:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_queue_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_queue_service.py
@@ -7,6 +7,7 @@ from spiffworkflow_backend.models.process_instance import ProcessInstanceModel
 from spiffworkflow_backend.models.process_instance_event import ProcessInstanceEventType
 from spiffworkflow_backend.models.process_instance_queue import ProcessInstanceQueueModel
 from spiffworkflow_backend.services.error_handling_service import ErrorHandlingService
+from spiffworkflow_backend.services.process_instance_lock_service import ExpectedLockNotFoundError
 from spiffworkflow_backend.services.process_instance_lock_service import ProcessInstanceLockService
 from spiffworkflow_backend.services.process_instance_tmp_service import ProcessInstanceTmpService
 from spiffworkflow_backend.services.workflow_execution_service import WorkflowExecutionServiceError
@@ -44,6 +45,8 @@ class ProcessInstanceQueueService:
             process_instance.id, additional_processing_identifier=additional_processing_identifier
         )
         queue_entry = ProcessInstanceQueueModel.query.filter_by(id=queue_entry_id).first()
+        if queue_entry is None:
+            raise ExpectedLockNotFoundError(f"Could not find a lock for process instance: {process_instance.id}")
         current_time = round(time.time())
         if current_time > queue_entry.run_at_in_seconds:
             queue_entry.run_at_in_seconds = current_time

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_queue_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_queue_service.py
@@ -40,9 +40,10 @@ class ProcessInstanceQueueService:
 
     @classmethod
     def _enqueue(cls, process_instance: ProcessInstanceModel, additional_processing_identifier: str | None = None) -> None:
-        queue_entry = ProcessInstanceLockService.unlock(
+        queue_entry_id = ProcessInstanceLockService.unlock(
             process_instance.id, additional_processing_identifier=additional_processing_identifier
         )
+        queue_entry = ProcessInstanceQueueModel.query.filter_by(id=queue_entry_id).first()
         current_time = round(time.time())
         if current_time > queue_entry.run_at_in_seconds:
             queue_entry.run_at_in_seconds = current_time


### PR DESCRIPTION
Possibly fixes #794 

Attempt to store the ids of the process instance queue entries instead of the db object. This should help with DetachedInstanceError by getting a new db record object instead of using an old one that could possibly be on an old session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced process instance locking mechanism for improved management and clarity.

- **Bug Fixes**
  - Improved reliability of process instance handling by ensuring correct retrieval of process instances in the queue after unlocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->