### PR TITLE
Remove category param

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
@@ -183,7 +183,6 @@ def process_data_show(
 
 
 def process_data_file_download(
-    category: str,
     process_instance_id: int,
     process_data_identifier: str,
     modified_process_model_identifier: str,


### PR DESCRIPTION
Work on #838 - fixes issue #2 mentioned in the ticket. Removed the `category` param which was not needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the `category` parameter from the process data file download functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->