### PR TITLE
added validation for maximum date w/ burnettk

### DIFF
--- a/spiffworkflow-frontend/src/components/CustomForm.tsx
+++ b/spiffworkflow-frontend/src/components/CustomForm.tsx
@@ -10,7 +10,7 @@ import NumericRangeField from '../rjsf/custom_widgets/NumericRangeField/NumericR
 
 enum DateCheckType {
   minimum = 'minimum',
-  maximuim = 'maximum',
+  maximum = 'maximum',
 }
 
 type OwnProps = {

--- a/spiffworkflow-frontend/src/components/CustomForm.tsx
+++ b/spiffworkflow-frontend/src/components/CustomForm.tsx
@@ -288,7 +288,7 @@ export default function CustomForm({
         }
         if ('maximumDate' in propertyMetadata) {
           checkDateValidations(
-            DateCheckType.maximuim,
+            DateCheckType.maximum,
             formDataToCheck,
             propertyKey,
             propertyMetadata,


### PR DESCRIPTION
Implements #642 

This adds the "maximumDate" option for rjsf fields. It works just like minimumDate but in reverse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new date comparison validations within forms, allowing for minimum and maximum date checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->