### PR TITLE
feature/urlsafe-base64decode

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/authentication_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/authentication_controller.py
@@ -456,7 +456,9 @@ def _parse_id_token(token: str) -> Any:
 
     payload = parts[1]
     padded = payload + "=" * (4 - len(payload) % 4)
-    decoded = base64.b64decode(padded)
+
+    # https://lists.jboss.org/pipermail/keycloak-user/2016-April/005758.html
+    decoded = base64.urlsafe_b64decode(padded)
     return json.loads(decoded)
 
 


### PR DESCRIPTION
Fixes #600 

This changes the way we parse the id token from keycloak to use the urlsafe_base64decode method to support a wider range of unicode characters and correctly implement the openid specification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of URL-safe base64 encoded tokens during authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->