### PR TITLE
fixes the date picker so it does not change the date after selecting it

### DIFF
--- a/spiffworkflow-frontend/src/services/DateAndTimeService.tsx
+++ b/spiffworkflow-frontend/src/services/DateAndTimeService.tsx
@@ -42,7 +42,7 @@ const convertDateObjectToFormattedString = (dateObject: Date) => {
 
 const dateStringToYMDFormat = (dateString: string) => {
   // if the date looks like it's already in yyyy-MM--dd format then just return it
-  if (dateString.match(/\d{4}-\d{2}-\d{2}/)) {
+  if (dateString.match(/^\d{4}-\d{2}-\d{2}$/)) {
     return dateString;
   }
   const newDate = parse(dateString, DATE_FORMAT, new Date());

--- a/spiffworkflow-frontend/src/services/DateAndTimeService.tsx
+++ b/spiffworkflow-frontend/src/services/DateAndTimeService.tsx
@@ -41,6 +41,10 @@ const convertDateObjectToFormattedString = (dateObject: Date) => {
 };
 
 const dateStringToYMDFormat = (dateString: string) => {
+  // if the date looks like it's already in yyyy-MM--dd format then just return it
+  if (dateString.match(/\d{4}-\d{2}-\d{2}/)) {
+    return dateString;
+  }
   const newDate = parse(dateString, DATE_FORMAT, new Date());
   return format(newDate, 'yyyy-MM-dd');
 };


### PR DESCRIPTION
Fixes bug #853 

This fixes the date picker by fixing the dateStringToYMDFormat function so that it if the date looks to already be in that format then do not touch it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved date handling to recognize and accept dates already in `yyyy-MM-dd` format without additional processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->