### PR TITLE
Disable upload button if filesToUpload is null

### DIFF
--- a/spiffworkflow-frontend/src/routes/ProcessModelShow.tsx
+++ b/spiffworkflow-frontend/src/routes/ProcessModelShow.tsx
@@ -492,6 +492,7 @@ export default function ProcessModelShow() {
         open={showFileUploadModal}
         modalHeading="Upload File"
         primaryButtonText="Upload"
+        primaryButtonDisabled={filesToUpload === null}
         secondaryButtonText="Cancel"
         onSecondarySubmit={handleFileUploadCancel}
         onRequestClose={handleFileUploadCancel}


### PR DESCRIPTION
Fixes #825. This disables the upload button if a file has not been selected for upload during the current presentation of the modal. I have no idea how to remove the previously uploaded file from the modal - it is a ghost entry, there is text and an X but no data to upload backing it. Once merged the upload button will be disabled in this scenario as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Implemented a feature to conditionally disable the primary button based on pending file uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->