### PR TITLE
Add identifier and clz fields to the data stores response

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/json.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/json.py
@@ -48,9 +48,10 @@ class JSONDataStore(BpmnDataStoreSpecification, DataStoreCRUD):  # type: ignore
     def existing_data_stores() -> list[dict[str, Any]]:
         data_stores = []
 
-        keys = db.session.query(JSONDataStoreModel.name).distinct().order_by(JSONDataStoreModel.name).all()  # type: ignore
+        query = db.session.query(JSONDataStoreModel.name, JSONDataStoreModel.identifier)
+        keys = query.distinct().order_by(JSONDataStoreModel.name).all()  # type: ignore
         for key in keys:
-            data_stores.append({"name": key[0], "type": "json"})
+            data_stores.append({"name": key[0], "type": "json", "identifier": key[1], "clz": "JSONDataStore"})
 
         return data_stores
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/kkv.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/kkv.py
@@ -23,7 +23,7 @@ class KKVDataStore(BpmnDataStoreSpecification, DataStoreCRUD):  # type: ignore
             .all()
         )
         for key in keys:
-            data_stores.append({"name": key[0], "type": "kkv"})
+            data_stores.append({"name": key[0], "type": "kkv", "identifier": "", "clz": "KKVDataStore"})
 
         return data_stores
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/typeahead.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/typeahead.py
@@ -19,7 +19,7 @@ class TypeaheadDataStore(BpmnDataStoreSpecification, DataStoreCRUD):  # type: ig
 
         keys = db.session.query(TypeaheadModel.category).distinct().order_by(TypeaheadModel.category).all()  # type: ignore
         for key in keys:
-            data_stores.append({"name": key[0], "type": "typeahead"})
+            data_stores.append({"name": key[0], "type": "typeahead", "identifier": key[0], "clz": "TypeaheadDataStore"})
 
         return data_stores
 

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_data_stores.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_data_stores.py
@@ -66,7 +66,10 @@ class TestDataStores(BaseTest):
 
         self.load_data_store(app, client, with_db_and_bpmn_file_cleanup, with_super_admin_user)
         results = client.get("/v1.0/data-stores", headers=self.logged_in_headers(with_super_admin_user))
-        assert results.json == [{"name": "albums", "type": "typeahead"}, {"name": "cereals", "type": "typeahead"}]
+        assert results.json == [
+            {"name": "albums", "type": "typeahead", "identifier": "albums", "clz": "TypeaheadDataStore"},
+            {"name": "cereals", "type": "typeahead", "identifier": "cereals", "clz": "TypeaheadDataStore"},
+        ]
 
     def test_get_data_store_returns_paginated_results(
         self,

--- a/spiffworkflow-frontend/package-lock.json
+++ b/spiffworkflow-frontend/package-lock.json
@@ -50123,7 +50123,7 @@
         "@csstools/postcss-text-decoration-shorthand": "^1.0.0",
         "@csstools/postcss-trigonometric-functions": "^1.0.2",
         "@csstools/postcss-unset-value": "^1.0.2",
-        "autoprefixer": "10.4.5",
+        "autoprefixer": "^10.4.13",
         "browserslist": "^4.21.4",
         "css-blank-pseudo": "^3.0.3",
         "css-has-pseudo": "^3.0.4",
@@ -50161,8 +50161,7 @@
       },
       "dependencies": {
         "autoprefixer": {
-          "version": "10.4.5",
-          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.5.tgz",
+          "version": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.5.tgz",
           "integrity": "sha512-Fvd8yCoA7lNX/OUllvS+aS1I7WRBclGXsepbvT8ZaPgrH24rgXpZzF0/6Hh3ZEkwg+0AES/Osd196VZmYoEFtw==",
           "requires": {
             "browserslist": "^4.20.2",

--- a/spiffworkflow-frontend/package-lock.json
+++ b/spiffworkflow-frontend/package-lock.json
@@ -50123,7 +50123,7 @@
         "@csstools/postcss-text-decoration-shorthand": "^1.0.0",
         "@csstools/postcss-trigonometric-functions": "^1.0.2",
         "@csstools/postcss-unset-value": "^1.0.2",
-        "autoprefixer": "^10.4.13",
+        "autoprefixer": "10.4.5",
         "browserslist": "^4.21.4",
         "css-blank-pseudo": "^3.0.3",
         "css-has-pseudo": "^3.0.4",
@@ -50161,7 +50161,8 @@
       },
       "dependencies": {
         "autoprefixer": {
-          "version": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.5.tgz",
+          "version": "10.4.5",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.5.tgz",
           "integrity": "sha512-Fvd8yCoA7lNX/OUllvS+aS1I7WRBclGXsepbvT8ZaPgrH24rgXpZzF0/6Hh3ZEkwg+0AES/Osd196VZmYoEFtw==",
           "requires": {
             "browserslist": "^4.20.2",


### PR DESCRIPTION
These will be needed by the frontend when data stores are configured in the properties panel so the "id' and "name" attributes of the dataStore xml element can be configured. This will allow selecting from already configured data stores.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved data retrieval queries for enhanced performance and consistency.
- **New Features**
	- Expanded data store information to include unique identifiers and classification types.
- **Tests**
	- Updated integration tests to validate the inclusion of new data attributes in data stores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->