### PR TITLE
allow looping back in a process to create more messages 

### DIFF
--- a/spiffworkflow-backend/bin/local_development_environment_setup
+++ b/spiffworkflow-backend/bin/local_development_environment_setup
@@ -33,7 +33,7 @@ if [[ "$process_model_dir" == "acceptance" ]]; then
   export SPIFFWORKFLOW_BACKEND_PERMISSIONS_FILE_NAME=acceptance_tests.yml
 elif [[ "$process_model_dir" == "localopenid" ]]; then
   export SPIFFWORKFLOW_BACKEND_AUTH_CONFIGS__0__identifier="default"
-  export SPIFFWORKFLOW_BACKEND_AUTH_CONFIGS__0__label="inernal openid"
+  export SPIFFWORKFLOW_BACKEND_AUTH_CONFIGS__0__label="internal openid"
   export SPIFFWORKFLOW_BACKEND_AUTH_CONFIGS__0__uri="http://localhost:$port/openid"
   export SPIFFWORKFLOW_BACKEND_AUTH_CONFIGS__0__client_id="spiffworkflow-backend"
   export SPIFFWORKFLOW_BACKEND_AUTH_CONFIGS__0__client_secret="JXeQExm0JhQPLumgHtIIqf52bDalHz0q"

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
@@ -522,12 +522,13 @@ class WorkflowExecutionService:
         waiting_events = self.bpmn_process_instance.waiting_events()
         waiting_message_events = filter(lambda e: e.event_type == "MessageEventDefinition", waiting_events)
         for event in waiting_message_events:
-            # Ensure we are only creating one message instance for each waiting message
+            # Ensure we are only creating one active message instance for each waiting message
             if (
                 MessageInstanceModel.query.filter_by(
                     process_instance_id=self.process_instance_model.id,
                     message_type="receive",
                     name=event.name,
+                    status="ready",
                 ).count()
                 > 0
             ):


### PR DESCRIPTION
 minor bug fix - didn't add what would be a complex test to this, as it was a one line change that seems an oversight in the original code.  But I did confirm that this works manually and doesn't seem to create new bugs.

You can test the fix by assuring this process can complete a second loop and generate a second message wait event on the same task:
 
https://dev.app.spiff.status.im/process-models/misc:message-example:process-1b-looping-messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the label for authentication configuration to "internal openid" for clarity.
- **New Features**
	- Implemented a check to prevent multiple active instances of the same message in workflow executions, enhancing system efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->