### PR TITLE
avoid dup github workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,12 @@
 name: Tests
 
 on:
-  - push
-  - pull_request
+  push:
+    # hitting just main on push suffices to avoid duplicate runs for PRs, since PRs never update main.
+    # more ideas at https://github.com/orgs/community/discussions/26940 including branches-ignore
+    branches:
+      - main
+  pull_request:
 
 defaults:
   run:


### PR DESCRIPTION
jon pointed out that push and pull_request events are basically triggering the same thing to run twice on PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the CI workflow to trigger only on pushes to the `main` branch, reducing duplicate runs for pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->