### PR TITLE
let us start getting some more dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  # GITHUB-ACTIONSS
+  # GITHUB-ACTIONS
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,18 @@
 version: 2
 updates:
-
   # GITHUB-ACTIONSS
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 1
 
   # PIP
   - package-ecosystem: pip
     directory: "/.github/workflows"
     schedule:
       interval: daily
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 1
   - package-ecosystem: pip
     directory: "/spiffworkflow-backend/docs"
     schedule:
@@ -28,21 +27,16 @@ updates:
     directory: "/spiffworkflow-backend"
     schedule:
       interval: daily
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 1
 
   # NPM
   - package-ecosystem: npm
     directory: "/.github/workflows"
     schedule:
       interval: daily
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 1
   - package-ecosystem: npm
     directory: "/spiffworkflow-frontend"
     schedule:
       interval: daily
-    open-pull-requests-limit: 0
-  - package-ecosystem: npm
-    directory: "/bpmn-js-spiffworkflow"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 1


### PR DESCRIPTION
increases pull request limit from 0 to 1 in various directories and for various package-ecosystems
removes reference to bpmn js spiffworkflow that is no longer in the monorepo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the configuration to allow a maximum of one open pull request per package ecosystem for dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->