### PR TITLE
try to fix mac build mysql lib install issue with poetry

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -175,8 +175,9 @@ jobs:
 
       - name: Install mysqlclient lib dependencies
         if: matrix.os == 'macos-latest'
+        # mysql 8.3 causes failure in poetry install so pin to 8.0. https://github.com/feast-dev/feast/issues/3916
         run: |
-          brew install mysql pkg-config
+          brew install mysql@8.0 pkg-config
 
       - name: Run Session
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -176,8 +176,9 @@ jobs:
       - name: Install mysqlclient lib dependencies
         if: matrix.os == 'macos-latest'
         # mysql 8.3 causes failure in poetry install so pin to 8.0. https://github.com/feast-dev/feast/issues/3916
+        # 8.0 is keg-only, so we have to force link it in order for pkg-config and everything to find it.
         run: |
-          brew install mysql@8.0 pkg-config
+          brew install mysql@8.0 pkg-config && brew link mysql@8.0
 
       - name: Run Session
         run: |


### PR DESCRIPTION
mysql 8.3 was released in december, and may have broken this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Pinned the MySQL version used in testing workflows to ensure compatibility and prevent installation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->