### PR TITLE
Allow data store upsearch to work from within a parallel gateway

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
@@ -115,8 +115,13 @@ class ExecutionStrategy:
         spiff_task: SpiffTask,
         app: flask.app.Flask,
         user: Any | None,
+        process_model_identifier: str | None,
     ) -> SpiffTask:
         with app.app_context():
+            tld = current_app.config.get("THREAD_LOCAL_DATA")
+            if tld:
+                tld.process_model_identifier = process_model_identifier
+
             g.user = user
             spiff_task.run()
             return spiff_task
@@ -159,6 +164,7 @@ class ExecutionStrategy:
                                 spiff_task,
                                 current_app._get_current_object(),
                                 user,
+                                process_instance_model.process_model_identifier,
                             )
                         )
                     for future in concurrent.futures.as_completed(futures):

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
@@ -115,7 +115,7 @@ class ExecutionStrategy:
         spiff_task: SpiffTask,
         app: flask.app.Flask,
         user: Any | None,
-        process_model_identifier: str | None,
+        process_model_identifier: str,
     ) -> SpiffTask:
         with app.app_context():
             tld = current_app.config.get("THREAD_LOCAL_DATA")


### PR DESCRIPTION
One of the issues found yesterday ended up being that data store upsearches did not work properly when the data store was referenced from within a parallel gateway. This was because the spawned thread did not have the process model identifier in thread local data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the workflow execution service by ensuring the `process_model_identifier` is set and passed correctly during task execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->