### PR TITLE
Fix two issues related to the data store type selection

### DIFF
--- a/spiffworkflow-frontend/src/components/DataStoreForm.tsx
+++ b/spiffworkflow-frontend/src/components/DataStoreForm.tsx
@@ -155,8 +155,10 @@ export default function DataStoreForm({
   const onTypeChanged = (newType: any) => {
     setTypeInvalid(false);
     const newTypeSelection = newType.selectedItem;
-    const updateDict = { type: newTypeSelection.type };
-    updateDataStore(updateDict);
+    if (newTypeSelection) {
+      const updateDict = { type: newTypeSelection.type };
+      updateDataStore(updateDict);
+    }
     setSelectedDataStoreType(newTypeSelection);
   };
 
@@ -164,6 +166,16 @@ export default function DataStoreForm({
     setSchemaInvalid(false);
     const updateDict = { schema: newSchema };
     updateDataStore(updateDict);
+  };
+
+  const dataStoreTypeDisplayString = (dataStoreType: DataStoreType | null) => {
+    if (dataStoreType) {
+      return `${dataStoreType.name} (${truncateString(
+        dataStoreType.description,
+        75
+      )})`;
+    }
+    return null;
   };
 
   const formElements = () => {
@@ -200,28 +212,33 @@ export default function DataStoreForm({
       />
     );
 
-    textInputs.push(
-      <ComboBox
-        onChange={onTypeChanged}
-        id="data-store-type-select"
-        data-qa="data-store-type-selection"
-        items={dataStoreTypes}
-        itemToString={(dataStoreType: DataStoreType) => {
-          if (dataStoreType) {
-            return `${dataStoreType.name} (${truncateString(
-              dataStoreType.description,
-              75
-            )})`;
-          }
-          return null;
-        }}
-        titleText="Type*"
-        invalidText="Type is required."
-        invalid={typeInvalid}
-        placeholder="Choose the data store type"
-        selectedItem={selectedDataStoreType}
-      />
-    );
+    if (mode === 'edit') {
+      textInputs.push(
+        <TextInput
+          id="data-store-type"
+          name="data-store-type"
+          readonly
+          labelText="Type*"
+          value={dataStoreTypeDisplayString(selectedDataStoreType)}
+        />
+      );
+    } else {
+      textInputs.push(
+        <ComboBox
+          onChange={onTypeChanged}
+          id="data-store-type-select"
+          data-qa="data-store-type-selection"
+          disabled={mode === 'edit'}
+          items={dataStoreTypes}
+          itemToString={dataStoreTypeDisplayString}
+          titleText="Type*"
+          invalidText="Type is required."
+          invalid={typeInvalid}
+          placeholder="Choose the data store type"
+          selectedItem={selectedDataStoreType}
+        />
+      );
+    }
 
     textInputs.push(
       <TextArea

--- a/spiffworkflow-frontend/src/components/DataStoreForm.tsx
+++ b/spiffworkflow-frontend/src/components/DataStoreForm.tsx
@@ -155,7 +155,11 @@ export default function DataStoreForm({
   const onTypeChanged = (newType: any) => {
     setTypeInvalid(false);
     const newTypeSelection = newType.selectedItem;
-    if (newTypeSelection) {
+    if (
+      newTypeSelection &&
+      typeof newTypeSelection === 'object' &&
+      'type' in newTypeSelection
+    ) {
       const updateDict = { type: newTypeSelection.type };
       updateDataStore(updateDict);
     }
@@ -168,14 +172,16 @@ export default function DataStoreForm({
     updateDataStore(updateDict);
   };
 
-  const dataStoreTypeDisplayString = (dataStoreType: DataStoreType | null) => {
+  const dataStoreTypeDisplayString = (
+    dataStoreType: DataStoreType | null
+  ): string => {
     if (dataStoreType) {
       return `${dataStoreType.name} (${truncateString(
         dataStoreType.description,
         75
       )})`;
     }
-    return null;
+    return '';
   };
 
   const formElements = () => {

--- a/spiffworkflow-frontend/src/components/DataStoreForm.tsx
+++ b/spiffworkflow-frontend/src/components/DataStoreForm.tsx
@@ -228,7 +228,6 @@ export default function DataStoreForm({
           onChange={onTypeChanged}
           id="data-store-type-select"
           data-qa="data-store-type-selection"
-          disabled={mode === 'edit'}
           items={dataStoreTypes}
           itemToString={dataStoreTypeDisplayString}
           titleText="Type*"


### PR DESCRIPTION
Noticed these locally, but first was the form would crash when clearing the data store type combo box. Second was changing the type of the data store by editing an existing data store really shouldn't be supported. I'd argue this because migrating the data in a generic fashion that always makes sense is going to be quite difficult. If you change a `JSONDataStore` to a `KKVDataStore` - what are the logical top/second level keys? To simplify the type is a readonly textbox while editing. If you want to migrate the type of your data store, add the second one and create a process to migrate the data. I tried to set the combo box to readOnly but that just made it white but you could still change the values which was odd.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced data store selection with dynamic display strings based on the type of data store chosen.
- **Improvements**
	- Improved data store update logic to ensure changes are only made with a new type selection.
	- Updated form behavior to render different input components tailored to the user's current mode for a more intuitive interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->