### PR TITLE
Store data store specifications in process_group.json

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/process_group.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/process_group.py
@@ -17,8 +17,8 @@ from spiffworkflow_backend.models.process_model import ProcessModelInfo
 PROCESS_GROUP_SUPPORTED_KEYS_FOR_DISK_SERIALIZATION = [
     "display_name",
     "description",
+    "data_store_specifications",
 ]
-
 
 @dataclass(order=True)
 class ProcessGroup:
@@ -29,6 +29,7 @@ class ProcessGroup:
     description: str | None = None
     process_models: list[ProcessModelInfo] = field(default_factory=list[ProcessModelInfo])
     process_groups: list[ProcessGroup] = field(default_factory=list["ProcessGroup"])
+    data_store_specifications: dict[str, Any] = field(default_factory=dict)
     parent_groups: list[ProcessGroupLite] | None = None
 
     # TODO: delete these once they no no longer mentioned in current

--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/process_group.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/process_group.py
@@ -20,6 +20,7 @@ PROCESS_GROUP_SUPPORTED_KEYS_FOR_DISK_SERIALIZATION = [
     "data_store_specifications",
 ]
 
+
 @dataclass(order=True)
 class ProcessGroup:
     sort_index: str = field(init=False)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
@@ -126,12 +126,12 @@ def _data_store_upsert(body: dict, insert: bool) -> flask.wrappers.Response:
     db.session.add(model)
     db.session.commit()
 
-    _write_data_store_definition_json(data_store_type, model)
+    _write_specification_to_process_group(data_store_type, model)
 
     return make_response(jsonify({"ok": True}), 200)
 
 
-def _write_data_store_definition_json(data_store_type: str, model: Any) -> None:
+def _write_specification_to_process_group(data_store_type: str, model: Any) -> None:
     # TODO: once the top level is a process group this check should be removed
     if model.location == "":
         return

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
@@ -12,6 +12,7 @@ from spiffworkflow_backend.data_stores.typeahead import TypeaheadDataStore
 from spiffworkflow_backend.exceptions.api_error import ApiError
 from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.services.file_system_service import FileSystemService
+from spiffworkflow_backend.services.process_model_service import ProcessModelService
 
 DATA_STORES = {
     "json": (JSONDataStore, "JSON Data Store"),
@@ -136,16 +137,14 @@ def _write_data_store_definition_json(data_store_type: str, model: Any) -> None:
     if model.location == "":
         return
 
-    contents = FileSystemService.contents_of_json_file_at_relative_path(model.location, FileSystemService.PROCESS_GROUP_JSON_FILE)
-    data_stores_key = "data_stores"
+    process_group = ProcessModelService.get_process_group(model.location, False, False)
+    if not process_group:
+        return
+    
+    if data_store_type not in process_group.data_store_specifications:
+        process_group.data_store_specifications[data_store_type] = {}
 
-    if data_stores_key not in contents:
-        contents[data_stores_key] = {}
-
-    if data_store_type not in contents[data_stores_key]:
-        contents[data_stores_key][data_store_type] = {}
-
-    contents[data_stores_key][data_store_type][model.identifier] = {
+    process_group.data_store_specifications[data_store_type][model.identifier] = {
         "name": model.name,
         "identifier": model.identifier,
         "location": model.location,
@@ -153,7 +152,7 @@ def _write_data_store_definition_json(data_store_type: str, model: Any) -> None:
         "description": model.description,
     }
 
-    FileSystemService.write_to_json_file_at_relative_path(model.location, FileSystemService.PROCESS_GROUP_JSON_FILE, contents)
+    ProcessModelService.update_process_group(process_group)
 
 
 def data_store_show(data_store_type: str, identifier: str, process_group_identifier: str) -> flask.wrappers.Response:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
@@ -11,7 +11,6 @@ from spiffworkflow_backend.data_stores.kkv import KKVDataStore
 from spiffworkflow_backend.data_stores.typeahead import TypeaheadDataStore
 from spiffworkflow_backend.exceptions.api_error import ApiError
 from spiffworkflow_backend.models.db import db
-from spiffworkflow_backend.services.file_system_service import FileSystemService
 from spiffworkflow_backend.services.process_model_service import ProcessModelService
 
 DATA_STORES = {
@@ -140,7 +139,7 @@ def _write_data_store_definition_json(data_store_type: str, model: Any) -> None:
     process_group = ProcessModelService.get_process_group(model.location, False, False)
     if not process_group:
         return
-    
+
     if data_store_type not in process_group.data_store_specifications:
         process_group.data_store_specifications[data_store_type] = {}
 


### PR DESCRIPTION
Work on #1037 - this is the work for saving the data store specifications in the `process_group.json` file when a data store is created or updated from the `Add a data store` button. Currently does not work for data stores at the very top level (see #1038). Next will be syncing the db with the contents of the process_group.json files when a promotion, etc happens. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the data structure of process groups by including data store specifications.
	- Implemented a new functionality to update process group data store specifications based on model information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->