### PR TITLE
Support syncing data stores in the DB with those defined in process_group.json files

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/data_setup_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/data_setup_service.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any
 
 from flask import current_app
 
@@ -28,7 +29,7 @@ class DataSetupService:
         files = FileSystemService.walk_files_from_root_path(True, None)
         reference_objects: dict[str, ReferenceCacheModel] = {}
         all_data_store_specifications: dict[str, Any] = {}
-        
+
         for file in files:
             if FileSystemService.is_process_model_json_file(file):
                 process_model = ProcessModelService.get_process_model_from_path(file)
@@ -74,7 +75,7 @@ class DataSetupService:
             elif FileSystemService.is_process_group_json_file(file):
                 try:
                     process_group = ProcessModelService.find_or_create_process_group(os.path.dirname(file))
-                except Exception as e:
+                except Exception:
                     current_app.logger.debug(f"Failed to load process group from file @ '{file}'")
                     continue
 
@@ -86,7 +87,9 @@ class DataSetupService:
                     for identifier, specification in specs_by_id.items():
                         location = specification.get("location")
                         if location is None:
-                            current_app.logger.debug(f"Location missing from data store specification '{identifier}' in file @ '{file}'")
+                            current_app.logger.debug(
+                                f"Location missing from data store specification '{identifier}' in file @ '{file}'"
+                            )
                             continue
                         if location not in specs_by_location:
                             specs_by_location[location] = {}

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/data_setup_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/data_setup_service.py
@@ -149,7 +149,12 @@ class DataSetupService:
             db.session.add(model)
 
         for key in keys_to_update:
-            model = all_data_store_models[key]
+            model = all_data_store_models.get(key)
+            if model is None:
+                current_app.logger.debug(
+                    f"DataSetupService: was expecting key '{key}' to point to a data store model for model updating."
+                )
+                continue
             update_model_from_specification(model, key)
 
         for key in keys_to_delete:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/data_setup_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/data_setup_service.py
@@ -69,6 +69,8 @@ class DataSetupService:
                     False,
                 )
                 ReferenceCacheService.add_unique_reference_cache_object(reference_objects, reference_cache)
+            elif FileSystemService.is_process_group_json_file(file):
+                print(f"--------------- {file}")
 
         current_app.logger.debug("DataSetupService.save_all_process_models() end")
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/data_setup_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/data_setup_service.py
@@ -121,6 +121,17 @@ class DataSetupService:
         specification_keys = set(all_data_store_specifications.keys())
         model_keys = set(all_data_store_models.keys())
 
+        #
+        # At this point we have a dictionary of all data store specifications from all the process_group.json files and
+        # a dictionary of all data store models. These two dictionaries use the same key format of (type, location, identifier)
+        # which allows checking to see if a given data store has a specification and/or a model.
+        #
+        # With this we can perform set operations on the keys of the two dictionaries to figure out what needs to be
+        # inserted, updated or deleted. If a key has a specification but not a model, an insert needs to happen. If a key
+        # has a specification and a model, an update needs to happen. If a key has a model but no specification, a delete
+        # needs to happen.
+        #
+
         keys_to_insert = specification_keys - model_keys
         keys_to_update = specification_keys & model_keys
         keys_to_delete = model_keys - specification_keys

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/data_setup_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/data_setup_service.py
@@ -138,8 +138,19 @@ class DataSetupService:
                     f"DataSetupService: was expecting key '{key}' to point to a data store specification for model updating."
                 )
                 return
-            model.name = specification["name"]
-            model.schema = specification["schema"]
+
+            name = specification.get("name")
+            schema = specification.get("schema")
+
+            if name is None or schema is None:
+                current_app.logger.debug(
+                    f"DataSetupService: was expecting key '{key}' to point to a valid data store specification for model"
+                    " updating."
+                )
+                return
+
+            model.name = name
+            model.schema = schema
             model.description = specification.get("description")
 
         for key in keys_to_insert:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/file_system_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/file_system_service.py
@@ -63,6 +63,10 @@ class FileSystemService:
         return file.endswith(cls.PROCESS_MODEL_JSON_FILE)
 
     @classmethod
+    def is_process_group_json_file(cls, file: str) -> bool:
+        return file.endswith(cls.PROCESS_GROUP_JSON_FILE)
+
+    @classmethod
     def is_data_store_json_file(cls, file: str) -> bool:
         return file.endswith("_datastore.json")
 


### PR DESCRIPTION
Work on #1037 - this adds the support for syncing the data store data base tables with the data store specifications found in various process_group.json files on disk. During a run of `save_all_process_models` the data store specifications are aggregated by a compound key of `(type, location, identifier)`, then existing models are aggregated by the same compound key. From there set operations are used to identify what needs to be inserted, updated or deleted. As noted before data does not migrate, just the specifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved data synchronization capabilities in the backend.
	- Enhanced support for identifying specific file types in the system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->