### PR TITLE
feature/allow-data-stores-in-root-pg-file

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
@@ -123,22 +123,18 @@ def _data_store_upsert(body: dict, insert: bool) -> flask.wrappers.Response:
     model.schema = schema
     model.description = description or ""
 
+    _write_specification_to_process_group(data_store_type, model)
+
     db.session.add(model)
     db.session.commit()
-
-    _write_specification_to_process_group(data_store_type, model)
 
     return make_response(jsonify({"ok": True}), 200)
 
 
 def _write_specification_to_process_group(data_store_type: str, model: Any) -> None:
-    # TODO: once the top level is a process group this check should be removed
-    if model.location == "":
-        return
-
-    process_group = ProcessModelService.get_process_group(model.location, False, False)
-    if not process_group:
-        return
+    process_group = ProcessModelService.get_process_group(
+        model.location, find_direct_nested_items=False, find_all_nested_items=False, create_if_not_exists=True
+    )
 
     if data_store_type not in process_group.data_store_specifications:
         process_group.data_store_specifications[data_store_type] = {}

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_model_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_model_service.py
@@ -456,12 +456,16 @@ class ProcessModelService(FileSystemService):
 
     @classmethod
     def get_process_group(
-        cls, process_group_id: str, find_direct_nested_items: bool = True, find_all_nested_items: bool = True
+        cls,
+        process_group_id: str,
+        find_direct_nested_items: bool = True,
+        find_all_nested_items: bool = True,
+        create_if_not_exists: bool = False,
     ) -> ProcessGroup:
         """Look for a given process_group, and return it."""
         if os.path.exists(FileSystemService.root_path()):
             process_group_path = FileSystemService.full_path_from_id(process_group_id)
-            if cls.is_process_group(process_group_path):
+            if cls.is_process_group(process_group_path) or create_if_not_exists:
                 return cls.find_or_create_process_group(
                     process_group_path,
                     find_direct_nested_items=find_direct_nested_items,

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_reference_cache_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_reference_cache_service.py
@@ -14,6 +14,18 @@ def with_loaded_reference_cache(app: Flask, with_db_and_bpmn_file_cleanup: None)
     ReferenceCacheService.add_unique_reference_cache_object(
         reference_objects,
         ReferenceCacheModel.from_params(
+            "contacts_datastore_root",
+            "Contacts Datastore Root",
+            "data_store",
+            "contacts_datastore.bpmn",
+            "",
+            None,
+            False,
+        ),
+    )
+    ReferenceCacheService.add_unique_reference_cache_object(
+        reference_objects,
+        ReferenceCacheModel.from_params(
             "contacts_datastore",
             "contacts_datastore",
             "data_store",
@@ -56,3 +68,9 @@ class TestReferenceCacheService(BaseTest):
     def test_does_not_find_data_store_in_non_upsearched_location(self, with_loaded_reference_cache: None) -> None:
         location = ReferenceCacheService.upsearch("some/other/place", "contacts_datastore", "data_store")
         assert location is None
+
+    def test_can_find_data_store_in_upsearched_root_location(self, with_loaded_reference_cache: None) -> None:
+        location = ReferenceCacheService.upsearch(
+            "misc/jonjon/generic-data-store-area/test-level-2", "contacts_datastore_root", "data_store"
+        )
+        assert location == ""

--- a/spiffworkflow-frontend/src/components/SpiffTooltip.tsx
+++ b/spiffworkflow-frontend/src/components/SpiffTooltip.tsx
@@ -11,7 +11,7 @@ interface OwnProps {
 
 export default function SpiffTooltip({ title, children }: OwnProps) {
   return (
-    <Tooltip title={title} arrow>
+    <Tooltip title={title} arrow enterDelay={500}>
       {children}
     </Tooltip>
   );


### PR DESCRIPTION
Implements #1038 

This allows for the root of the process model repo to add a process group file if it does not already exist when adding a data store.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data store functionality to ensure specifications are properly associated with process groups before saving.
	- Added a conditional creation feature for process groups in the workflow backend, improving flexibility in process management.
	- Introduced a delay for tooltip appearance in the frontend, enhancing user interface interactions.

- **Refactor**
	- Updated logic for handling process group retrieval and data store specifications, optimizing performance and reliability.

- **Tests**
	- Added new test cases to validate the improved functionality of the reference cache service, ensuring robustness and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->