### PR TITLE
feature/fix-pi-all-tab

### DIFF
--- a/spiffworkflow-frontend/src/components/ProcessInstanceListTableWithFilters.tsx
+++ b/spiffworkflow-frontend/src/components/ProcessInstanceListTableWithFilters.tsx
@@ -446,7 +446,15 @@ export default function ProcessInstanceListTableWithFilters({
     };
 
     checkFiltersAndRun();
-  }, [filtersEnabled, getReportMetadataWithReportHash, permissionsLoaded]);
+  }, [
+    filtersEnabled,
+    getReportMetadataWithReportHash,
+    permissionsLoaded,
+
+    // watch the variant prop so when switching between the "For Me" and "All" pi list tables
+    // the api call to find the new process instances is made and the report metadata is updated.
+    variant,
+  ]);
 
   const removeFieldFromReportMetadata = (
     reportMetadataToUse: ReportMetadata,


### PR DESCRIPTION
Fixes #954 

This adds a watch for the variant prop so the process instance list tables are properly updated when switching between the "For Me" and "All" tabs.

to test:
* go to the "Process Instances" page and switch between "For Me" and "All" and ensure data is properly loaded.