### PR TITLE
docker compose overlay file for running `run_pyl` equivalents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ MY_USER := $(shell id -u)
 MY_GROUP := $(shell id -g)
 ME := $(MY_USER):$(MY_GROUP)
 
+SUDO ?= sudo
+
 ARENA_CONTAINER ?= spiff-arena
 ARENA_DEV_OVERLAY ?= dev.docker-compose.yml
 
@@ -76,7 +78,7 @@ sh:
 	$(IN_ARENA) /bin/bash
 
 take-ownership:
-	sudo chown -R $(ME) .
+	$(SUDO) chown -R $(ME) .
 
 .PHONY: build-images dev-env \
 	start-dev stop-dev \

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ fe-sh:
 pre-commit:
 	$(IN_ARENA) poetry run pre-commit run --verbose --all-files
 
-run-pyl: pre-commit be-mypy be-tests-par
+run-pyl: fe-lint-fix pre-commit be-mypy be-tests-par
 	@/bin/true
 
 sh:

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ MY_USER := $(shell id -u)
 MY_GROUP := $(shell id -g)
 ME := $(MY_USER):$(MY_GROUP)
 
+ARENA_CONTAINER ?= spiff-arena
+ARENA_DEV_OVERLAY ?= dev.docker-compose.yml
+
 BACKEND_CONTAINER ?= spiffworkflow-backend
 BACKEND_DEV_OVERLAY ?= spiffworkflow-backend/dev.docker-compose.yml
 
@@ -13,10 +16,11 @@ IN_BACKEND ?= $(DOCKER_COMPOSE) run $(BACKEND_CONTAINER)
 IN_FRONTEND ?= $(DOCKER_COMPOSE) run $(FRONTEND_CONTAINER)
 
 YML_FILES := -f docker-compose.yml \
-		-f $(BACKEND_DEV_OVERLAY) \
-		-f $(FRONTEND_DEV_OVERLAY)
+	-f $(BACKEND_DEV_OVERLAY) \
+	-f $(FRONTEND_DEV_OVERLAY) \
+	-f $(ARENA_DEV_OVERLAY)
 
-all: dev-env start-dev be-tests-par
+all: dev-env start-dev run-pyl
 	@/bin/true
 
 build-images:
@@ -31,16 +35,25 @@ start-dev: stop-dev
 stop-dev:
 	$(DOCKER_COMPOSE) down
 
+be-clear-log-file:
+	$(IN_BACKEND) rm -f log/unit_testing.log
+
+be-mypy:
+	$(IN_BACKEND) poetry run mypy src tests
+
 be-recreate-db:
 	$(IN_BACKEND) ./bin/recreate_db clean
+
+be-ruff:
+	$(IN_BACKEND) poetry run ruff --fix .
 
 be-sh:
 	$(IN_BACKEND) /bin/bash
 
-be-tests:
+be-tests: be-clear-log-file
 	$(IN_BACKEND) poetry run pytest
 
-be-tests-par:
+be-tests-par: be-clear-log-file
 	$(IN_BACKEND) poetry run pytest -n auto -x --random-order
 
 fe-lint-fix:
@@ -52,11 +65,15 @@ fe-npm-i:
 fe-sh:
 	$(IN_FRONTEND) /bin/bash
 
+run-pyl: be-mypy be-tests-par
+	@/bin/true
+
 take-ownership:
 	sudo chown -R $(ME) .
 
 .PHONY: build-images dev-env \
 	start-dev stop-dev \
-	be-recreate-db be-sh be-tests be-tests-par \
+	be-clear-log-file be-recreate-db be-ruff be-sh be-tests be-tests-par \
 	fe-lint-fix fe-npm-i fe-sh \
+	run-pyl \
 	take-ownership

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,8 @@ YML_FILES := -f docker-compose.yml \
 	-f $(FRONTEND_DEV_OVERLAY) \
 	-f $(ARENA_DEV_OVERLAY)
 
-all: dev-env allow-git-in-docker start-dev run-pyl
+all: dev-env start-dev run-pyl
 	@/bin/true
-
-allow-git-in-docker:
-	git config --global --add safe.directory /app
 
 build-images:
 	$(DOCKER_COMPOSE) build
@@ -81,7 +78,7 @@ sh:
 take-ownership:
 	sudo chown -R $(ME) .
 
-.PHONY: allow-git-in-docker build-images dev-env \
+.PHONY: build-images dev-env \
 	start-dev stop-dev \
 	be-clear-log-file be-recreate-db be-ruff be-sh be-tests be-tests-par \
 	fe-lint-fix fe-npm-i fe-sh \

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12.1-slim-bookworm
+
+WORKDIR /app
+
+RUN pip install --upgrade pip
+RUN pip install poetry==1.6.1
+
+COPY pyproject.toml poetry.lock .
+RUN poetry install --no-root
+
+CMD ["/bin/true"]

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -14,5 +14,3 @@ RUN pip install poetry==1.6.1
 
 COPY pyproject.toml poetry.lock .
 RUN poetry install --no-root
-
-CMD ["/bin/true"]

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -2,6 +2,12 @@ FROM python:3.12.1-slim-bookworm
 
 WORKDIR /app
 
+RUN apt-get update \
+ && apt-get install -y -q \
+    git-core curl
+
+RUN git config --global --add safe.directory /app
+
 RUN pip install --upgrade pip
 RUN pip install poetry==1.6.1
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -3,8 +3,9 @@ FROM python:3.12.1-slim-bookworm
 WORKDIR /app
 
 RUN apt-get update \
- && apt-get install -y -q \
-    git-core curl
+ && apt-get install -y -q git-core curl \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 RUN git config --global --add safe.directory /app
 

--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -4,6 +4,9 @@ services:
     build:
       context: .
       dockerfile: dev.Dockerfile
-    user: "${RUN_AS}"
+    #
+    # TODO: would like to figure out the permissions issue that is preventing this
+    #
+    #user: "${RUN_AS}"
     volumes:
       - ./:/app

--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -1,0 +1,9 @@
+
+services:
+  spiff-arena:
+    build:
+      context: .
+      dockerfile: dev.Dockerfile
+    user: "${RUN_AS}"
+    volumes:
+      - ./:/app


### PR DESCRIPTION
Allows running the commands performed by `run_pyl` in an arena level docker container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Enhanced flexibility by introducing the `SUDO` variable for `sudo` command usage.
    - Added new environment variables `ARENA_CONTAINER` and `ARENA_DEV_OVERLAY` for improved development setup.
    - Implemented `IN_ARENA` command for specialized container operations.
    - Introduced new backend operation commands (`be-clear-log-file`, `be-mypy`, `be-ruff`) and `pre-commit` for enhanced code quality checks.
    - Launched the `dev.Dockerfile` to streamline Python environment setup with Poetry for dependency management.
    - Introduced `dev.docker-compose.yml` for the `spiff-arena` service to resolve permissions issues and enhance development setup.

- **Chores**
    - Updated `take-ownership` command to utilize the `SUDO` variable for improved flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->