### PR TITLE
Only show data stores from upsearch in the properties panel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,9 @@ stop-dev:
 be-clear-log-file:
 	$(IN_BACKEND) rm -f log/unit_testing.log
 
+be-logs:
+	docker logs -f $(BACKEND_CONTAINER)
+
 be-mypy:
 	$(IN_BACKEND) poetry run mypy src tests
 
@@ -62,6 +65,9 @@ be-tests-par: be-clear-log-file
 fe-lint-fix:
 	$(IN_FRONTEND) npm run lint:fix
 
+fe-logs:
+	docker logs -f $(FRONTEND_CONTAINER)
+
 fe-npm-i:
 	$(IN_FRONTEND) npm i
 
@@ -82,7 +88,7 @@ take-ownership:
 
 .PHONY: build-images dev-env \
 	start-dev stop-dev \
-	be-clear-log-file be-recreate-db be-ruff be-sh be-tests be-tests-par \
-	fe-lint-fix fe-npm-i fe-sh \
+	be-clear-log-file be-logs be-recreate-db be-ruff be-sh be-tests be-tests-par \
+	fe-lint-fix fe-logs fe-npm-i fe-sh \
 	pre-commit run-pyl \
 	take-ownership

--- a/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
@@ -2785,6 +2785,12 @@ paths:
         description: Optional parameter to filter by a single group
         schema:
           type: string
+      - name: upsearch
+        in: query
+        required: false
+        description: Optional parameter to indicate if an upsearch should be performed
+        schema:
+          type: boolean
       - name: page
         in: query
         required: false

--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/crud.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/crud.py
@@ -24,7 +24,7 @@ class DataStoreCRUD:
         raise Exception("must implement")
 
     @staticmethod
-    def existing_data_stores(process_group_identifier: str | None = None) -> list[dict[str, Any]]:
+    def existing_data_stores(process_group_identifiers: list[str] | None = None) -> list[dict[str, Any]]:
         raise Exception("must implement")
 
     @staticmethod

--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/json.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/json.py
@@ -35,7 +35,7 @@ class JSONDataStore(BpmnDataStoreSpecification, DataStoreCRUD):  # type: ignore
 
         query = db.session.query(JSONDataStoreModel.name, JSONDataStoreModel.identifier, JSONDataStoreModel.location)
         if process_group_identifiers:
-            query = query.filter(JSONDataStoreModel.location.in_(process_group_identifiers))
+            query = query.filter(JSONDataStoreModel.location.in_(process_group_identifiers))  # type: ignore
         keys = query.order_by(JSONDataStoreModel.name).all()
         for key in keys:
             data_stores.append({"name": key[0], "type": "json", "id": key[1], "clz": "JSONDataStore", "location": key[2]})

--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/json.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/json.py
@@ -30,12 +30,12 @@ class JSONDataStore(BpmnDataStoreSpecification, DataStoreCRUD):  # type: ignore
         return db.session.query(JSONDataStoreModel).filter_by(identifier=identifier, location=location).first()
 
     @staticmethod
-    def existing_data_stores(process_group_identifier: str | None = None) -> list[dict[str, Any]]:
+    def existing_data_stores(process_group_identifiers: list[str] | None = None) -> list[dict[str, Any]]:
         data_stores = []
 
         query = db.session.query(JSONDataStoreModel.name, JSONDataStoreModel.identifier, JSONDataStoreModel.location)
         if process_group_identifier is not None:
-            query = query.filter_by(location=process_group_identifier)
+            query = query.filter(location.in_(process_group_identifiers))
         keys = query.order_by(JSONDataStoreModel.name).all()
         for key in keys:
             data_stores.append({"name": key[0], "type": "json", "id": key[1], "clz": "JSONDataStore", "location": key[2]})

--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/json.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/json.py
@@ -34,8 +34,8 @@ class JSONDataStore(BpmnDataStoreSpecification, DataStoreCRUD):  # type: ignore
         data_stores = []
 
         query = db.session.query(JSONDataStoreModel.name, JSONDataStoreModel.identifier, JSONDataStoreModel.location)
-        if process_group_identifier is not None:
-            query = query.filter(location.in_(process_group_identifiers))
+        if process_group_identifiers:
+            query = query.filter(JSONDataStoreModel.location.in_(process_group_identifiers))
         keys = query.order_by(JSONDataStoreModel.name).all()
         for key in keys:
             data_stores.append({"name": key[0], "type": "json", "id": key[1], "clz": "JSONDataStore", "location": key[2]})

--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/kkv.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/kkv.py
@@ -33,7 +33,7 @@ class KKVDataStore(BpmnDataStoreSpecification, DataStoreCRUD):  # type: ignore
 
         query = db.session.query(KKVDataStoreModel)
         if process_group_identifiers:
-            query = query.filter(KKVDataStoreModel.location.in_(process_group_identifiers))
+            query = query.filter(KKVDataStoreModel.location.in_(process_group_identifiers))  # type: ignore
         models = query.order_by(KKVDataStoreModel.name).all()
         for model in models:
             data_stores.append(

--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/kkv.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/kkv.py
@@ -32,8 +32,8 @@ class KKVDataStore(BpmnDataStoreSpecification, DataStoreCRUD):  # type: ignore
         data_stores = []
 
         query = db.session.query(KKVDataStoreModel)
-        if process_group_identifier is not None:
-            query = query.filter(location.in_(process_group_identifiers))
+        if process_group_identifiers:
+            query = query.filter(KKVDataStoreModel.location.in_(process_group_identifiers))
         models = query.order_by(KKVDataStoreModel.name).all()
         for model in models:
             data_stores.append(

--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/kkv.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/kkv.py
@@ -28,12 +28,12 @@ class KKVDataStore(BpmnDataStoreSpecification, DataStoreCRUD):  # type: ignore
         return db.session.query(KKVDataStoreModel).filter_by(identifier=identifier, location=location).first()
 
     @staticmethod
-    def existing_data_stores(process_group_identifier: str | None = None) -> list[dict[str, Any]]:
+    def existing_data_stores(process_group_identifiers: list[str] | None = None) -> list[dict[str, Any]]:
         data_stores = []
 
         query = db.session.query(KKVDataStoreModel)
         if process_group_identifier is not None:
-            query = query.filter_by(location=process_group_identifier)
+            query = query.filter(location.in_(process_group_identifiers))
         models = query.order_by(KKVDataStoreModel.name).all()
         for model in models:
             data_stores.append(

--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/typeahead.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/typeahead.py
@@ -14,7 +14,7 @@ class TypeaheadDataStore(BpmnDataStoreSpecification, DataStoreCRUD):  # type: ig
     """TypeaheadDataStore."""
 
     @staticmethod
-    def existing_data_stores(process_group_identifier: str | None = None) -> list[dict[str, Any]]:
+    def existing_data_stores(process_group_identifiers: list[str] | None = None) -> list[dict[str, Any]]:
         data_stores: list[dict[str, Any]] = []
 
         if process_group_identifier is not None:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/typeahead.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/typeahead.py
@@ -17,7 +17,7 @@ class TypeaheadDataStore(BpmnDataStoreSpecification, DataStoreCRUD):  # type: ig
     def existing_data_stores(process_group_identifiers: list[str] | None = None) -> list[dict[str, Any]]:
         data_stores: list[dict[str, Any]] = []
 
-        if process_group_identifier is not None:
+        if process_group_identifiers:
             # temporary until this data store gets location support
             return data_stores
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
@@ -21,13 +21,18 @@ DATA_STORES = {
 }
 
 
-def data_store_list(process_group_identifier: str | None = None, page: int = 1, per_page: int = 100) -> flask.wrappers.Response:
+def data_store_list(
+    process_group_identifier: str | None = None, upsearch: bool = False, page: int = 1, per_page: int = 100
+) -> flask.wrappers.Response:
     """Returns a list of the names of all the data stores."""
     data_stores = []
     locations_to_upsearch = []
 
     if process_group_identifier is not None:
-        locations_to_upsearch = UpsearchService.upsearch_locations(process_group_identifier)
+        if upsearch:
+            locations_to_upsearch = UpsearchService.upsearch_locations(process_group_identifier)
+        else:
+            locations_to_upsearch.append(process_group_identifier)
 
     # Right now the only data stores we support are type ahead, kkv, json
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
@@ -12,6 +12,7 @@ from spiffworkflow_backend.data_stores.typeahead import TypeaheadDataStore
 from spiffworkflow_backend.exceptions.api_error import ApiError
 from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.services.process_model_service import ProcessModelService
+from spiffworkflow_backend.services.upsearch_service import UpsearchService
 
 DATA_STORES = {
     "json": (JSONDataStore, "JSON Data Store"),
@@ -23,12 +24,16 @@ DATA_STORES = {
 def data_store_list(process_group_identifier: str | None = None, page: int = 1, per_page: int = 100) -> flask.wrappers.Response:
     """Returns a list of the names of all the data stores."""
     data_stores = []
+    locations_to_upsearch = []
+
+    if process_group_identifier is not None:
+        locations_to_upsearch = UpsearchService.upsearch_locations(process_group_identifier)
 
     # Right now the only data stores we support are type ahead, kkv, json
 
-    data_stores.extend(JSONDataStore.existing_data_stores(process_group_identifier))
-    data_stores.extend(TypeaheadDataStore.existing_data_stores(process_group_identifier))
-    data_stores.extend(KKVDataStore.existing_data_stores(process_group_identifier))
+    data_stores.extend(JSONDataStore.existing_data_stores(locations_to_upsearch))
+    data_stores.extend(TypeaheadDataStore.existing_data_stores(locations_to_upsearch))
+    data_stores.extend(KKVDataStore.existing_data_stores(locations_to_upsearch))
 
     return make_response(jsonify(data_stores), 200)
 

--- a/spiffworkflow-frontend/src/routes/ProcessModelEditDiagram.tsx
+++ b/spiffworkflow-frontend/src/routes/ProcessModelEditDiagram.tsx
@@ -383,7 +383,7 @@ export default function ProcessModelEditDiagram() {
     const processGroupIdentifier =
       processModel?.parent_groups?.slice(-1).pop()?.id ?? '';
     HttpService.makeCallToBackend({
-      path: `/data-stores?process_group_identifier=${processGroupIdentifier}`,
+      path: `/data-stores?upsearch=true&process_group_identifier=${processGroupIdentifier}`,
       successCallback: makeDataStoresApiHandler(event),
     });
   };

--- a/spiffworkflow-frontend/src/routes/ProcessModelEditDiagram.tsx
+++ b/spiffworkflow-frontend/src/routes/ProcessModelEditDiagram.tsx
@@ -380,8 +380,10 @@ export default function ProcessModelEditDiagram() {
   };
 
   const onDataStoresRequested = (event: any) => {
+    const processGroupIdentifier =
+      processModel?.parent_groups?.slice(-1).pop()?.id ?? '';
     HttpService.makeCallToBackend({
-      path: `/data-stores`,
+      path: `/data-stores?process_group_identifier=${processGroupIdentifier}`,
       successCallback: makeDataStoresApiHandler(event),
     });
   };


### PR DESCRIPTION
Work on #1041 - previous all data stores in the system were displayed in the properties panel. This fix passes in the location of the parent process group for upsearching. Also added a couple make targets for easier access to the front/backend logs when running via the dev docker containers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added log display commands for backend and frontend containers.
	- Enhanced data store retrieval to support multiple process group identifiers, improving data querying flexibility.
	- Improved the process model editing interface to dynamically include process group identifiers in API calls, enhancing user experience.

- **Refactor**
	- Updated methods across various data stores to accept lists of process group identifiers, streamlining data filtering and access.
	- Simplified condition checks in data store retrieval methods for better code clarity.

- **Chores**
	- Updated the Makefile to include new log display targets for better development and debugging experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->