### PR TITLE
Dev Container Tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ version_info.json
 UNKNOWN.egg-info/
 process_models/
 .ipynb_checkpoints
+.env*

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ all: dev-env start-dev run-pyl
 build-images:
 	$(DOCKER_COMPOSE) build
 
-dev-env: build-images fe-npm-i be-recreate-db
+dev-env: stop-dev build-images fe-npm-i be-recreate-db
 	@/bin/true
 
 start-dev: stop-dev
@@ -63,7 +63,7 @@ fe-lint-fix:
 	$(IN_FRONTEND) npm run lint:fix
 
 fe-npm-i:
-	$(IN_FRONTEND) npm i
+	$(IN_FRONTEND) npm i && git checkout -- spiffworkflow-frontend/package-lock.json
 
 fe-sh:
 	$(IN_FRONTEND) /bin/bash
@@ -82,7 +82,7 @@ take-ownership:
 
 .PHONY: build-images dev-env \
 	start-dev stop-dev \
-	be-clear-log-file be-recreate-db be-ruff be-sh be-tests be-tests-par \
+	be-clear-log-file be-mypy be-recreate-db be-ruff be-sh be-tests be-tests-par \
 	fe-lint-fix fe-npm-i fe-sh \
 	pre-commit run-pyl \
 	take-ownership

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ If you have `docker` and `docker compose`, as an alternative to locally installi
 
 After the containers are set up, you can run `make start-dev` and `make stop-dev` to start and stop the servers. If the frontend or backend lock file changes, `make dev-env` will recreate the containers with the new dependencies.
 
-Please refer to the [Makefile](Makefile) as the source of truth, but for a summary of the available `make` targets.
+Please refer to the [Makefile](Makefile) as the source of truth, but for a summary of the available `make` targets:
 
 | Target | Action |
 |----|----|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     ports:
       - "${SPIFF_BACKEND_PORT:-8000}:${SPIFF_BACKEND_PORT:-8000}/tcp"
     volumes:
-      - ./process_models:/app/process_models
+      - ${SPIFFWORKFLOW_BACKEND_LOCAL_BPMN_SPEC_DIR:-./process_models}:/app/process_models
       - spiffworkflow_backend_db:/app/db_volume
     healthcheck:
       test: "curl localhost:${SPIFF_BACKEND_PORT:-8000}/v1.0/status --fail"

--- a/spiffworkflow-backend/Dockerfile
+++ b/spiffworkflow-backend/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
 
 # keep pip up to date
 RUN pip install --upgrade pip
-RUN pip install poetry==1.6.1
+RUN pip install poetry==1.8.1
 
 
 ######################## - SETUP

--- a/spiffworkflow-backend/dev.Dockerfile
+++ b/spiffworkflow-backend/dev.Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update \
     pkg-config libffi-dev git-core curl
 
 RUN pip install --upgrade pip
-RUN pip install poetry==1.6.1 pytest-xdist
+RUN pip install poetry==1.8.1 pytest-xdist==3.5.0
 
 COPY pyproject.toml poetry.lock .
 RUN poetry install --no-root

--- a/spiffworkflow-frontend/dev.Dockerfile
+++ b/spiffworkflow-frontend/dev.Dockerfile
@@ -2,8 +2,4 @@ FROM node:20.8.1-bookworm-slim AS base
 
 WORKDIR /app
 
-COPY package.json package-lock.json .
-
-RUN npm i
-
 CMD ["npm", "run", "docker:start"]


### PR DESCRIPTION
1. Realized the frontend dev container does not need to `npm i` since we do that on the outside now via the mounted volume. This same approach should work for the backend and arena dev containers once the permission issue preventing "run as me" is fixed.
2. Revert package-lock.json when doing an `npm i` to remove a manual step
3. Allow overriding the process models location via `SPIFFWORKFLOW_BACKEND_LOCAL_BPMN_SPEC_DIR`
4. Add support for having a `.env`* file that is gititgnored to allow another level of local customization that won't be committed to git.
5. Bumped backend containers to use poetry 1.8.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `.gitignore` to exclude files starting with `.env`.
	- Modified the `Makefile` to enhance the development environment setup process.
	- Updated Docker configurations for backend and frontend to use newer dependencies and simplify the build process.
- **Documentation**
	- Enhanced the `README.md` to provide detailed summaries of available `make` targets.
- **Refactor**
	- Improved flexibility in specifying local BPMN spec directory path in `docker-compose.yml`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->