### PR TITLE
Update secrets programmatically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ IN_ARENA ?= $(DOCKER_COMPOSE) run $(ARENA_CONTAINER)
 IN_BACKEND ?= $(DOCKER_COMPOSE) run $(BACKEND_CONTAINER)
 IN_FRONTEND ?= $(DOCKER_COMPOSE) run $(FRONTEND_CONTAINER)
 
+SPIFFWORKFLOW_BACKEND_ENV ?= local_development
+
 YML_FILES := -f docker-compose.yml \
 	-f $(BACKEND_DEV_OVERLAY) \
 	-f $(FRONTEND_DEV_OVERLAY) \
@@ -56,6 +58,9 @@ be-ruff:
 be-sh:
 	$(IN_BACKEND) /bin/bash
 
+be-sqlite:
+	$(IN_BACKEND) sqlite3 src/instance/db_$(SPIFFWORKFLOW_BACKEND_ENV).sqlite3
+
 be-tests: be-clear-log-file
 	$(IN_BACKEND) poetry run pytest
 
@@ -88,7 +93,7 @@ take-ownership:
 
 .PHONY: build-images dev-env \
 	start-dev stop-dev \
-	be-clear-log-file be-logs be-mypy be-recreate-db be-ruff be-sh be-tests be-tests-par \
+	be-clear-log-file be-logs be-mypy be-sqlite be-recreate-db be-ruff be-sh be-tests be-tests-par \
 	fe-lint-fix fe-logs fe-npm-i fe-sh \
 	pre-commit run-pyl \
 	take-ownership

--- a/spiffworkflow-backend/dev.Dockerfile
+++ b/spiffworkflow-backend/dev.Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 RUN apt-get update \
  && apt-get install -y -q \
     gcc libssl-dev libpq-dev default-libmysqlclient-dev \
-    pkg-config libffi-dev git-core curl
+    pkg-config libffi-dev git-core curl sqlite3
 
 RUN pip install --upgrade pip
 RUN pip install poetry==1.8.1 pytest-xdist==3.5.0

--- a/spiffworkflow-backend/dev.docker-compose.yml
+++ b/spiffworkflow-backend/dev.docker-compose.yml
@@ -11,7 +11,7 @@ services:
     environment:
       FLASK_DEBUG: "1"
       SPIFFWORKFLOW_BACKEND_DATABASE_URI: ""
-      SPIFFWORKFLOW_BACKEND_ENV: "local_development"
+      SPIFFWORKFLOW_BACKEND_ENV: "${SPIFFWORKFLOW_BACKEND_ENV:-local_development}"
       SPIFFWORKFLOW_BACKEND_LOAD_FIXTURE_DATA: ""
     volumes:
       - ./spiffworkflow-backend:/app

--- a/spiffworkflow-backend/src/spiffworkflow_backend/scripts/set_secret.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/scripts/set_secret.py
@@ -1,0 +1,16 @@
+from typing import Any
+
+from flask import g
+from spiffworkflow_backend.models.script_attributes_context import ScriptAttributesContext
+from spiffworkflow_backend.scripts.script import Script
+from spiffworkflow_backend.services.secret_service import SecretService
+
+
+class SetSecret(Script):
+    def get_description(self) -> str:
+        return "Allows setting a secret value programmatically."
+
+    def run(self, script_attributes_context: ScriptAttributesContext, *args: Any, **kwargs: Any) -> Any:
+        secret_key = args[0]
+        secret_value = args[1]
+        SecretService.update_secret(secret_key, secret_value, g.user.id, True)


### PR DESCRIPTION
Work on #1044  - allows processes run with admin permissions to create/update a secret from a script task. Current use case is setting the session token for Iplict api calls. Also added a make target to load the current sqlitedb to help with debugging.