### PR TITLE
feature/support-google-oauth

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authentication_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authentication_service.py
@@ -151,6 +151,31 @@ class AuthenticationService:
         return json_key_configs
 
     @classmethod
+    def public_key_from_rsa_public_numbers(cls, json_key_configs: dict) -> Any:
+        modulus = base64.urlsafe_b64decode(json_key_configs["n"] + "===")
+        exponent = base64.urlsafe_b64decode(json_key_configs["e"] + "===")
+        public_key_numbers = rsa.RSAPublicNumbers(
+            int.from_bytes(exponent, byteorder="big"), int.from_bytes(modulus, byteorder="big")
+        )
+        return public_key_numbers.public_key(backend=default_backend())
+
+    @classmethod
+    def public_key_from_x5c(cls, key_id: str, json_key_configs: dict) -> Any:
+        x5c = json_key_configs["x5c"][0]
+        decoded_certificate = base64.b64decode(x5c)
+
+        # our backend-based openid provider implementation (which you should never use in prod)
+        # uses a public/private key pair. we played around with adding an x509 cert so we could
+        # follow the exact same mechanism for getting the public key that we use for keycloak,
+        # but using an x509 cert for no reason seemed a little overboard for this toy-openid use case,
+        # when we already have the public key that can work hardcoded in our config.
+        if key_id == SPIFF_OPEN_ID_KEY_ID:
+            return decoded_certificate
+        else:
+            x509_cert = load_der_x509_certificate(decoded_certificate, default_backend())
+            return x509_cert.public_key()
+
+    @classmethod
     def parse_jwt_token(cls, authentication_identifier: str, token: str) -> dict:
         header = jwt.get_unverified_header(token)
         key_id = str(header.get("kid"))
@@ -170,26 +195,9 @@ class AuthenticationService:
             public_key: Any = None
 
             if "x5c" not in json_key_configs:
-                modulus = base64.urlsafe_b64decode(json_key_configs["n"] + "===")
-                exponent = base64.urlsafe_b64decode(json_key_configs["e"] + "===")
-                public_key_numbers = rsa.RSAPublicNumbers(
-                    int.from_bytes(exponent, byteorder="big"), int.from_bytes(modulus, byteorder="big")
-                )
-                public_key = public_key_numbers.public_key(backend=default_backend())
+                public_key = cls.public_key_from_rsa_public_numbers(json_key_configs)
             else:
-                x5c = json_key_configs["x5c"][0]
-                decoded_certificate = base64.b64decode(x5c)
-
-                # our backend-based openid provider implementation (which you should never use in prod)
-                # uses a public/private key pair. we played around with adding an x509 cert so we could
-                # follow the exact same mechanism for getting the public key that we use for keycloak,
-                # but using an x509 cert for no reason seemed a little overboard for this toy-openid use case,
-                # when we already have the public key that can work hardcoded in our config.
-                if key_id == SPIFF_OPEN_ID_KEY_ID:
-                    public_key = decoded_certificate
-                else:
-                    x509_cert = load_der_x509_certificate(decoded_certificate, default_backend())
-                    public_key = x509_cert.public_key()
+                public_key = cls.public_key_from_x5c(key_id, json_key_configs)
 
             # tokens generated from the cli have an aud like: [ "realm-management", "account" ]
             # while tokens generated from frontend have an aud like: "spiffworkflow-backend."

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authentication_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authentication_service.py
@@ -9,6 +9,7 @@ from hmac import compare_digest
 from typing import Any
 
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509 import load_der_x509_certificate
 
 from spiffworkflow_backend.models.user import SPIFF_GENERATED_JWT_ALGORITHM
@@ -164,22 +165,31 @@ class AuthenticationService:
                 options={"verify_exp": False},
             )
         else:
-            json_key_configs = cls.jwks_public_key_for_key_id(authentication_identifier, key_id)
-            x5c = json_key_configs["x5c"][0]
             algorithm = str(header.get("alg"))
-            decoded_certificate = base64.b64decode(x5c)
-
-            # our backend-based openid provider implementation (which you should never use in prod)
-            # uses a public/private key pair. we played around with adding an x509 cert so we could
-            # follow the exact same mechanism for getting the public key that we use for keycloak,
-            # but using an x509 cert for no reason seemed a little overboard for this toy-openid use case,
-            # when we already have the public key that can work hardcoded in our config.
+            json_key_configs = cls.jwks_public_key_for_key_id(authentication_identifier, key_id)
             public_key: Any = None
-            if key_id == SPIFF_OPEN_ID_KEY_ID:
-                public_key = decoded_certificate
+
+            if "x5c" not in json_key_configs:
+                modulus = base64.urlsafe_b64decode(json_key_configs["n"] + "===")
+                exponent = base64.urlsafe_b64decode(json_key_configs["e"] + "===")
+                public_key_numbers = rsa.RSAPublicNumbers(
+                    int.from_bytes(exponent, byteorder="big"), int.from_bytes(modulus, byteorder="big")
+                )
+                public_key = public_key_numbers.public_key(backend=default_backend())
             else:
-                x509_cert = load_der_x509_certificate(decoded_certificate, default_backend())
-                public_key = x509_cert.public_key()
+                x5c = json_key_configs["x5c"][0]
+                decoded_certificate = base64.b64decode(x5c)
+
+                # our backend-based openid provider implementation (which you should never use in prod)
+                # uses a public/private key pair. we played around with adding an x509 cert so we could
+                # follow the exact same mechanism for getting the public key that we use for keycloak,
+                # but using an x509 cert for no reason seemed a little overboard for this toy-openid use case,
+                # when we already have the public key that can work hardcoded in our config.
+                if key_id == SPIFF_OPEN_ID_KEY_ID:
+                    public_key = decoded_certificate
+                else:
+                    x509_cert = load_der_x509_certificate(decoded_certificate, default_backend())
+                    public_key = x509_cert.public_key()
 
             # tokens generated from the cli have an aud like: [ "realm-management", "account" ]
             # while tokens generated from frontend have an aud like: "spiffworkflow-backend."


### PR DESCRIPTION
Fixes #1103 

This add the ability to backend to decode google auth jwt tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved security by dynamically handling RSA keys in the authentication service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->