### PR TITLE
Dev containers now work with "run as me"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ UNKNOWN.egg-info/
 process_models/
 .ipynb_checkpoints
 .env*
+.cache

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ all: dev-env start-dev run-pyl
 build-images:
 	$(DOCKER_COMPOSE) build
 
-dev-env: stop-dev build-images poetry-i be-recreate-db fe-npm-i
+dev-env: stop-dev build-images poetry-i be-poetry-i be-recreate-db fe-npm-i
 	@/bin/true
 
 start-dev: stop-dev
@@ -46,6 +46,9 @@ be-logs:
 
 be-mypy:
 	$(IN_BACKEND) poetry run mypy src tests
+
+be-poetry-i:
+	$(IN_BACKEND) poetry install
 
 be-recreate-db:
 	$(IN_BACKEND) ./bin/recreate_db clean
@@ -75,7 +78,7 @@ fe-sh:
 	$(IN_FRONTEND) /bin/bash
 
 poetry-i:
-	$(IN_ARENA) poetry install
+	$(IN_ARENA) poetry install --no-root
 
 pre-commit:
 	$(IN_ARENA) poetry run pre-commit run --verbose --all-files
@@ -91,7 +94,7 @@ take-ownership:
 
 .PHONY: build-images dev-env \
 	start-dev stop-dev \
-	be-clear-log-file be-logs be-mypy be-recreate-db be-ruff be-sh be-tests be-tests-par \
+	be-clear-log-file be-logs be-mypy be-poetry-i be-recreate-db be-ruff be-sh be-tests be-tests-par \
 	fe-lint-fix fe-logs fe-npm-i fe-sh \
 	poetry-i pre-commit run-pyl \
 	take-ownership

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ all: dev-env start-dev run-pyl
 build-images:
 	$(DOCKER_COMPOSE) build
 
-dev-env: stop-dev build-images fe-npm-i be-recreate-db
+dev-env: stop-dev build-images poetry-i be-recreate-db fe-npm-i
 	@/bin/true
 
 start-dev: stop-dev
@@ -74,6 +74,9 @@ fe-npm-i:
 fe-sh:
 	$(IN_FRONTEND) /bin/bash
 
+poetry-i:
+	$(IN_ARENA) poetry install
+
 pre-commit:
 	$(IN_ARENA) poetry run pre-commit run --verbose --all-files
 
@@ -90,5 +93,5 @@ take-ownership:
 	start-dev stop-dev \
 	be-clear-log-file be-logs be-mypy be-recreate-db be-ruff be-sh be-tests be-tests-par \
 	fe-lint-fix fe-logs fe-npm-i fe-sh \
-	pre-commit run-pyl \
+	poetry-i pre-commit run-pyl \
 	take-ownership

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -10,7 +10,4 @@ RUN apt-get update \
 RUN git config --global --add safe.directory /app
 
 RUN pip install --upgrade pip
-RUN pip install poetry==1.6.1
-
-COPY pyproject.toml poetry.lock .
-RUN poetry install --no-root
+RUN pip install poetry==1.8.1

--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -4,9 +4,9 @@ services:
     build:
       context: .
       dockerfile: dev.Dockerfile
-    #
-    # TODO: would like to figure out the permissions issue that is preventing this
-    #
-    #user: "${RUN_AS}"
+    user: "${RUN_AS}"
+    environment:
+      POETRY_VIRTUALENVS_IN_PROJECT: "true"
+      PRE_COMMIT_HOME: "/app/.cache/pre-commit"
     volumes:
       - ./:/app

--- a/spiffworkflow-backend/dev.Dockerfile
+++ b/spiffworkflow-backend/dev.Dockerfile
@@ -5,15 +5,11 @@ WORKDIR /app
 RUN apt-get update \
  && apt-get install -y -q \
     gcc libssl-dev libpq-dev default-libmysqlclient-dev \
-    pkg-config libffi-dev git-core curl
+    pkg-config libffi-dev git-core curl \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 RUN pip install --upgrade pip
 RUN pip install poetry==1.8.1 pytest-xdist==3.5.0
-
-COPY pyproject.toml poetry.lock .
-RUN poetry install --no-root
-
-COPY ./ ./
-RUN poetry install --only-root
 
 CMD ["./bin/run_server_locally"]

--- a/spiffworkflow-backend/dev.docker-compose.yml
+++ b/spiffworkflow-backend/dev.docker-compose.yml
@@ -4,12 +4,11 @@ services:
     build:
       context: spiffworkflow-backend
       dockerfile: dev.Dockerfile
-    #
-    # TODO: would like to figure out the permissions issue that is preventing this
-    #
-    #user: "${RUN_AS}"
+    user: "${RUN_AS}"
     environment:
       FLASK_DEBUG: "1"
+      POETRY_VIRTUALENVS_IN_PROJECT: "true"
+      POETRY_CACHE_DIR: "/app/.cache/poetry"
       SPIFFWORKFLOW_BACKEND_DATABASE_URI: ""
       SPIFFWORKFLOW_BACKEND_ENV: "local_development"
       SPIFFWORKFLOW_BACKEND_LOAD_FIXTURE_DATA: ""


### PR DESCRIPTION
Removed poetry install commands from the arena/backend images and perform the poetry installs via the volume mount after the images are built. Along with some environment variables to control where cache/venv directories, we can now run commands on the arena/backend containers "as me" (me being the current user on the host system not root). This is the same way the frontend dev container currently works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `.gitignore` to ignore `.cache` directory.
	- Enhanced `Makefile` with new targets for managing Python dependencies using Poetry.
	- Updated Dockerfiles to use Poetry version 1.8.1 for package management and improved cleanup procedures.
	- Adjusted Docker Compose configurations to set environment variables for better Poetry and Pre-Commit handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->