### PR TITLE
feature/interstitial-instruction-fix

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/jinja_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/jinja_service.py
@@ -48,9 +48,7 @@ class JinjaService:
         if extensions and "instructionsForEndUser" in extensions:
             if extensions["instructionsForEndUser"]:
                 try:
-                    instructions = cls.render_jinja_template(extensions["instructionsForEndUser"], task)
-                    extensions["instructionsForEndUser"] = instructions
-                    return instructions
+                    return cls.render_jinja_template(extensions["instructionsForEndUser"], task)
                 except TaskModelError as wfe:
                     wfe.add_note("Failed to render instructions for end user.")
                     raise ApiError.from_workflow_exception("instructions_error", str(wfe), exp=wfe) from wfe


### PR DESCRIPTION
Fixes #1061.

This removes code to add the rendered instructions back onto the task spec. This causes issues when looping over a task an instruction that needs to be rendered with fresh data each time.

Testing notes:
* use the xml post by burnettk in #1061 and makes sure it prints "Got info for BBB" at some point and not just "Got info for AAA"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the logic for rendering end-user instructions, enhancing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->