### PR TITLE
task-show-render-instructions-fix

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
@@ -545,7 +545,7 @@ def task_show(
                 task_model.form_ui_schema = {}
             _munge_form_ui_schema_based_on_hidden_fields_in_task_data(task_model.form_ui_schema, task_model.data)
 
-        # it should be save to add instructions to the task spec here since we are never commiting it back to the db
+        # it should be safe to add instructions to the task spec here since we are never commiting it back to the db
         extensions["instructionsForEndUser"] = JinjaService.render_instructions_for_end_user(task_model, extensions)
 
     task_model.extensions = extensions

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
@@ -544,7 +544,9 @@ def task_show(
             else:
                 task_model.form_ui_schema = {}
             _munge_form_ui_schema_based_on_hidden_fields_in_task_data(task_model.form_ui_schema, task_model.data)
-        JinjaService.render_instructions_for_end_user(task_model, extensions)
+
+        # it should be save to add instructions to the task spec here since we are never commiting it back to the db
+        extensions["instructionsForEndUser"] = JinjaService.render_instructions_for_end_user(task_model, extensions)
 
     task_model.extensions = extensions
 


### PR DESCRIPTION
relates to fix in #1061 

This is an updated fix that adds the jinja rendered instructions back to the task on the task show page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced task instructions to provide dynamic guidance for end-users without modifying the database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->