### PR TITLE
commit-once-in-proc-save

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -1072,7 +1072,6 @@ class ProcessInstanceProcessor:
                     self._workflow_completed_handler(self.process_instance_model)
 
         db.session.add(self.process_instance_model)
-        db.session.commit()
 
         human_tasks = HumanTaskModel.query.filter_by(process_instance_id=self.process_instance_model.id, completed=False).all()
         ready_or_waiting_tasks = self.get_all_ready_or_waiting_tasks()
@@ -1136,13 +1135,11 @@ class ProcessInstanceProcessor:
                         human_task_user = HumanTaskUserModel(user_id=potential_owner_id, human_task=human_task)
                         db.session.add(human_task_user)
 
-                    db.session.commit()
-
         if len(human_tasks) > 0:
             for at in human_tasks:
                 at.completed = True
                 db.session.add(at)
-            db.session.commit()
+        db.session.commit()
 
     def serialize_task_spec(self, task_spec: SpiffTask) -> dict:
         """Get a serialized version of a task spec."""


### PR DESCRIPTION
Hopefully fixes #1149 

Commit the db at the end of the save method in ProcessInstanceProcessor. This will hopefully get rid of a potential race condition where in the instance is in one state and the human tasks have not caught up yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Optimized database commit operations in process handling to enhance performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->