### PR TITLE
added swagger docs to exclusion list

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
@@ -273,9 +273,7 @@ class AuthorizationService:
                 and controller_name
                 and controller_name in AUTHENTICATION_EXCLUSION_LIST[api_function_name]
             )
-            or (
-                module == openid_blueprint or module == scaffold  # don't check permissions for static assets
-            )
+            or (module == openid_blueprint or module == scaffold)  # don't check permissions for static assets
         ):
             return True
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
@@ -93,6 +93,10 @@ AUTHENTICATION_EXCLUSION_LIST = {
     "test_raise_error": "spiffworkflow_backend.routes.debug_controller",
     "url_info": "spiffworkflow_backend.routes.debug_controller",
     "webhook": "spiffworkflow_backend.routes.webhooks_controller",
+    # swagger api calls
+    "console_ui_home": "connexion.apis.flask_api",
+    "console_ui_static_files": "connexion.apis.flask_api",
+    "get_json_spec": "connexion.apis.flask_api",
 }
 
 
@@ -248,7 +252,6 @@ class AuthorizationService:
 
     @classmethod
     def should_disable_auth_for_request(cls) -> bool:
-        swagger_functions = ["get_json_spec"]
         if request.method == "OPTIONS":
             return True
 
@@ -271,9 +274,7 @@ class AuthorizationService:
                 and controller_name in AUTHENTICATION_EXCLUSION_LIST[api_function_name]
             )
             or (
-                api_function_name in swagger_functions
-                or module == openid_blueprint
-                or module == scaffold  # don't check permissions for static assets
+                module == openid_blueprint or module == scaffold  # don't check permissions for static assets
             )
         ):
             return True

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_swagger_docs.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_swagger_docs.py
@@ -1,0 +1,14 @@
+from flask.app import Flask
+from flask.testing import FlaskClient
+from tests.spiffworkflow_backend.helpers.base_test import BaseTest
+
+
+class TestSwaggerDocs(BaseTest):
+    def test_can_retrieve_swagger_docs_without_auth(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+    ) -> None:
+        response = client.get("/v1.0/ui/")
+        assert response.status_code == 200

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_swagger_docs.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_swagger_docs.py
@@ -1,5 +1,6 @@
 from flask.app import Flask
 from flask.testing import FlaskClient
+
 from tests.spiffworkflow_backend.helpers.base_test import BaseTest
 
 
@@ -8,7 +9,6 @@ class TestSwaggerDocs(BaseTest):
         self,
         app: Flask,
         client: FlaskClient,
-        with_db_and_bpmn_file_cleanup: None,
     ) -> None:
         response = client.get("/v1.0/ui/")
         assert response.status_code == 200


### PR DESCRIPTION
This adds swagger endpoints to the auth exclusion list and adds a test to make sure swagger can keep working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved Swagger API documentation accessibility.

- **Refactor**
	- Simplified authorization logic for certain API requests.

- **Tests**
	- Added a new test case for accessing Swagger documentation without authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->