### PR TITLE
Allow ruff to --fix during pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,6 @@ repos:
         language: system
         files: ^spiffworkflow-backend/
         types: [python]
-        line-length: 130
         require_serial: true
         # exclude: ^migrations/
         exclude: "/migrations/"
@@ -46,6 +45,7 @@ repos:
         types: [text]
         stages: [commit, push, manual]
       - id: ruff
+        args: [ --fix ]
         files: ^spiffworkflow-backend/
         name: ruff
         entry: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
         language: system
         files: ^spiffworkflow-backend/
         types: [python]
+        line-length: 130
         require_serial: true
         # exclude: ^migrations/
         exclude: "/migrations/"


### PR DESCRIPTION
Ran into an issue during pre-commit when ruff would fail on unsorted/unformatted imports - was difficult to see how to fix it. This enables the --fix mode during pre-commit so ruff can fix it when possible.