### PR TITLE
Makefile changes from the messages branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,11 +52,16 @@ be-mypy:
 be-poetry-i:
 	$(IN_BACKEND) poetry install
 
+be-poetry-lock:
+	$(IN_BACKEND) poetry lock --no-update
+
+be-poetry-rm:
+	@if [ -d "$(BACKEND_CONTAINER)/.venv" ]; then \
+		rm -rf "$(BACKEND_CONTAINER)/.venv"; \
+	fi
+
 be-recreate-db:
 	$(IN_BACKEND) ./bin/recreate_db clean
-
-be-ruff:
-	$(IN_BACKEND) poetry run ruff --fix .
 
 be-sh:
 	$(IN_BACKEND) /bin/bash
@@ -89,10 +94,18 @@ fe-sh:
 poetry-i:
 	$(IN_ARENA) poetry install --no-root
 
+poetry-rm:
+	@if [ -d ".venv" ]; then \
+		rm -rf ".venv"; \
+	fi
+
 pre-commit:
 	$(IN_ARENA) poetry run pre-commit run --verbose --all-files
 
-run-pyl: fe-lint-fix pre-commit be-mypy be-tests-par
+ruff:
+	$(IN_ARENA) poetry run ruff --fix spiffworkflow-backend
+
+run-pyl: fe-lint-fix ruff pre-commit be-mypy be-tests-par
 	@/bin/true
 
 sh:
@@ -103,7 +116,8 @@ take-ownership:
 
 .PHONY: build-images dev-env \
 	start-dev stop-dev \
-	be-clear-log-file be-logs be-mypy be-poetry-i be-recreate-db be-ruff be-sh be-sqlite be-tests be-tests-par \
+	be-clear-log-file be-logs be-mypy be-poetry-i be-poetry-lock be-poetry-rm \
+	be-recreate-db be-sh be-sqlite be-tests be-tests-par \
 	fe-lint-fix fe-logs fe-npm-i fe-sh \
-	poetry-i pre-commit run-pyl \
+	poetry-i poetry-rm pre-commit ruff run-pyl \
 	take-ownership


### PR DESCRIPTION
Added these while working on the messages branch, wanted to get these in to help while working on other branches. Main  change is to allow removing the poetry environments since switching branches can sometimes seem to corrupt the poetry environment. Those targets are a port of `remove_python_poetry_env_dir_from_disk`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new Makefile targets for enhanced management of Poetry dependencies.
- **Refactor**
	- Updated the Makefile to improve the frontend development workflow, including better linting processes.
- **Chores**
	- Removed obsolete Makefile target in favor of a more streamlined approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->