### PR TITLE
use a unique id for radio buttons in rjsf

### DIFF
--- a/spiffworkflow-frontend/src/rjsf/carbon_theme/CheckboxWidget/CheckboxWidget.tsx
+++ b/spiffworkflow-frontend/src/rjsf/carbon_theme/CheckboxWidget/CheckboxWidget.tsx
@@ -42,10 +42,6 @@ function CheckboxWidget(props: WidgetProps) {
     rawErrors
   );
 
-  // if the parent rjsf schema is not of type "object", then rjsf sends "root" through as the id.
-  // this creates issues with the carbon checkbox where it will not accept any clicks to the checkbox
-  // so add fuzz to the id to ensure it is unique.
-  // https://github.com/rjsf-team/react-jsonschema-form/issues/1824
   const uniqueId = makeid(10);
 
   return (

--- a/spiffworkflow-frontend/src/rjsf/carbon_theme/CheckboxWidget/CheckboxWidget.tsx
+++ b/spiffworkflow-frontend/src/rjsf/carbon_theme/CheckboxWidget/CheckboxWidget.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Checkbox } from '@carbon/react';
 import { WidgetProps } from '@rjsf/utils';
 import { getCommonAttributes, makeid } from '../../helpers';
@@ -19,6 +19,11 @@ function CheckboxWidget(props: WidgetProps) {
     rawErrors,
     required,
   } = props;
+
+  const uniqueId: string = useMemo(() => {
+    return makeid(10, 'checkbox-');
+  }, []);
+
   const _onChange = (_: any, newValue: any) => {
     // if this field is required and it is not checked then change the value to undefined
     // otherwise rjsf will not flag this field as invalid
@@ -41,8 +46,6 @@ function CheckboxWidget(props: WidgetProps) {
     uiSchema,
     rawErrors
   );
-
-  const uniqueId = makeid(10);
 
   return (
     <Checkbox

--- a/spiffworkflow-frontend/src/rjsf/carbon_theme/RadioWidget/RadioWidget.tsx
+++ b/spiffworkflow-frontend/src/rjsf/carbon_theme/RadioWidget/RadioWidget.tsx
@@ -44,10 +44,6 @@ function RadioWidget({
     rawErrors
   );
 
-  // if the parent rjsf schema is not of type "object", then rjsf sends "root" through as the id.
-  // this creates issues with the carbon checkbox where it will not accept any clicks to the checkbox
-  // so add fuzz to the id to ensure it is unique.
-  // https://github.com/rjsf-team/react-jsonschema-form/issues/1824
   const uniqueId = makeid(10);
 
   // pass values in as strings so we can support both boolean and string radio buttons

--- a/spiffworkflow-frontend/src/rjsf/carbon_theme/RadioWidget/RadioWidget.tsx
+++ b/spiffworkflow-frontend/src/rjsf/carbon_theme/RadioWidget/RadioWidget.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { RadioButtonGroup, RadioButton } from '@carbon/react';
 import { WidgetProps } from '@rjsf/utils';
 import { getCommonAttributes, makeid } from '../../helpers';
@@ -8,7 +8,6 @@ function RadioWidget({
   schema,
   options,
   value,
-  required,
   disabled,
   readonly,
   label,
@@ -18,7 +17,11 @@ function RadioWidget({
   uiSchema,
   rawErrors,
 }: WidgetProps) {
-  const { enumOptions, enumDisabled } = options;
+  const { enumOptions } = options;
+
+  const uniqueId: string = useMemo(() => {
+    return makeid(10, 'radio-button-');
+  }, []);
 
   const _onChange = (newValue: any, _radioButtonId: any) => {
     if (schema.type === 'boolean') {
@@ -44,8 +47,6 @@ function RadioWidget({
     rawErrors
   );
 
-  const uniqueId = makeid(10);
-
   // pass values in as strings so we can support both boolean and string radio buttons
   return (
     <RadioButtonGroup
@@ -65,7 +66,7 @@ function RadioWidget({
         enumOptions.map((option) => {
           return (
             <RadioButton
-              id={`${id}-${option.value}`}
+              id={`${uniqueId}-${option.value}`}
               labelText={option.label}
               value={`${option.value}`}
             />

--- a/spiffworkflow-frontend/src/rjsf/carbon_theme/RadioWidget/RadioWidget.tsx
+++ b/spiffworkflow-frontend/src/rjsf/carbon_theme/RadioWidget/RadioWidget.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { RadioButtonGroup, RadioButton } from '@carbon/react';
 import { WidgetProps } from '@rjsf/utils';
-import { getCommonAttributes } from '../../helpers';
+import { getCommonAttributes, makeid } from '../../helpers';
 
 function RadioWidget({
   id,
@@ -44,11 +44,17 @@ function RadioWidget({
     rawErrors
   );
 
+  // if the parent rjsf schema is not of type "object", then rjsf sends "root" through as the id.
+  // this creates issues with the carbon checkbox where it will not accept any clicks to the checkbox
+  // so add fuzz to the id to ensure it is unique.
+  // https://github.com/rjsf-team/react-jsonschema-form/issues/1824
+  const uniqueId = makeid(10);
+
   // pass values in as strings so we can support both boolean and string radio buttons
   return (
     <RadioButtonGroup
-      id={id}
-      name={id}
+      id={uniqueId}
+      name={uniqueId}
       legendText={commonAttributes.helperText}
       valueSelected={`${value}`}
       invalid={commonAttributes.invalid}

--- a/spiffworkflow-frontend/src/rjsf/helpers.tsx
+++ b/spiffworkflow-frontend/src/rjsf/helpers.tsx
@@ -58,8 +58,8 @@ export const getCommonAttributes = (
 //    * checkboxes will not accept any clicks to the checkbox
 // https://github.com/rjsf-team/react-jsonschema-form/issues/1824
 // https://stackoverflow.com/a/1349426/6090676
-export const makeid = (length: number) => {
-  let result = '';
+export const makeid = (length: number, prefix: string = '') => {
+  let result = prefix;
   const characters = 'abcdefghijklmnopqrstuvwxyz0123456789';
   const charactersLength = characters.length;
   for (let i = 0; i < length; i += 1) {

--- a/spiffworkflow-frontend/src/rjsf/helpers.tsx
+++ b/spiffworkflow-frontend/src/rjsf/helpers.tsx
@@ -52,6 +52,11 @@ export const getCommonAttributes = (
   };
 };
 
+// this is useful for certain carbon elements where if they do not have a unique id on groups
+// then odd things will happen. Examples:
+//    * radio button groups will deselect the item from a group when selecting one from a different group
+//    * checkboxes will not accept any clicks to the checkbox
+// https://github.com/rjsf-team/react-jsonschema-form/issues/1824
 // https://stackoverflow.com/a/1349426/6090676
 export const makeid = (length: number) => {
   let result = '';


### PR DESCRIPTION
This creates a unique id to add to the RadioButtonGroup in rjs forms. This ensures that carbon can properly select the item from the correct group.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved radio button functionality by ensuring unique identifiers for each instance, addressing issues in scenarios where the parent schema type differs.
	- Removed redundant logic related to unique IDs for checkboxes in the CheckboxWidget component.
- **Documentation**
	- Added a comment in the `makeid` function in `helpers.tsx` explaining the importance of unique IDs for certain elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->