### PR TITLE
Allow deleting api keys after use.

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/service_account.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/service_account.py
@@ -31,7 +31,7 @@ class ServiceAccountModel(SpiffworkflowBaseDBModel):
 
     api_key_hash: str = db.Column(db.String(255), nullable=False, unique=True, index=True)
 
-    user = relationship("UserModel", uselist=False, cascade="delete", foreign_keys=[user_id])  # type: ignore
+    user = relationship("UserModel", uselist=False, foreign_keys=[user_id])  # type: ignore
 
     updated_at_in_seconds: int = db.Column(db.Integer)
     created_at_in_seconds: int = db.Column(db.Integer)

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_service_accounts.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_service_accounts.py
@@ -2,6 +2,7 @@ import json
 
 from flask.app import Flask
 from flask.testing import FlaskClient
+from spiffworkflow_backend import db
 from spiffworkflow_backend.models.user import UserModel
 from spiffworkflow_backend.services.service_account_service import ServiceAccountService
 from spiffworkflow_backend.services.user_service import UserService
@@ -46,3 +47,49 @@ class TestServiceAccounts(BaseTest):
         assert response.status_code == 201
         assert response.json is not None
         assert response.json["key"] == post_body["key"]
+
+    def test_send_message_with_service_account(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        api_key_name = "heyhey"
+
+        # Create Service Account
+        service_account = ServiceAccountService.create_service_account(api_key_name, with_super_admin_user)
+
+        # ensure process model is loaded
+        process_group_id = "test_message_send"
+        process_model_id = "message_receiver"
+        bpmn_file_name = "message_receiver.bpmn"
+        bpmn_file_location = "message_send_one_conversation"
+        self.create_group_and_model_with_bpmn(
+            client,
+            with_super_admin_user,
+            process_group_id=process_group_id,
+            process_model_id=process_model_id,
+            bpmn_file_name=bpmn_file_name,
+            bpmn_file_location=bpmn_file_location,
+        )
+
+        # Send message with Service Account
+        message_model_identifier = "Request Approval"
+        payload = {
+            "customer_id": "sartography",
+            "po_number": "1001",
+            "amount": "One Billion Dollars! Mwhahahahahaha",
+            "description": "But seriously.",
+        }
+        response = client.post(
+            f"/v1.0/messages/{message_model_identifier}",
+            content_type="application/json",
+            headers={"SpiffWorkflow-Api-Key": service_account.api_key},
+            data=json.dumps(payload),
+        )
+        assert response.status_code == 200
+
+        # It should be possible to delete the service account after starting a process.
+        db.session.delete(service_account)
+        db.session.commit()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the stability of service accounts by adjusting deletion behavior.
- **Tests**
	- Added a new test to verify message sending capabilities using service accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->