### PR TITLE
Fix warning during pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,14 +3,11 @@ repos:
     hooks:
       - id: black
         name: black
-        # entry: bash -c 'cd spiffworkflow-backend && black'
         entry: black
         language: system
         files: ^spiffworkflow-backend/
         types: [python]
-        line-length: 130
         require_serial: true
-        # exclude: ^migrations/
         exclude: "/migrations/"
 
         # --preview because otherwise it will not fix long lines if the long lines contain long strings


### PR DESCRIPTION
Warning was `Unexpected key(s) present on local => black: line-length` believe this is safe since `--line-length` is passed in args already but have _edit: not_ rigorously tested. The entire codebase did not reformat however so i take that as a good sign. Also removed a couple commented out lines while i was in there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated pre-commit hook configurations for improved code formatting and compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->