### PR TITLE
Upsearch api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ IN_FRONTEND ?= $(DOCKER_COMPOSE) run $(FRONTEND_CONTAINER)
 
 SPIFFWORKFLOW_BACKEND_ENV ?= local_development
 
+BACKEND_SQLITE_FILE ?= src/instance/db_$(SPIFFWORKFLOW_BACKEND_ENV).sqlite3
+JUST ?=
+
 YML_FILES := -f docker-compose.yml \
 	-f $(BACKEND_DEV_OVERLAY) \
 	-f $(FRONTEND_DEV_OVERLAY) \
@@ -67,17 +70,17 @@ be-sh:
 	$(IN_BACKEND) /bin/bash
 
 be-sqlite:
-	@if [ ! -f "$(BACKEND_CONTAINER)/src/instance/db_$(SPIFFWORKFLOW_BACKEND_ENV).sqlite3" ]; then \
-		echo "SQLite database file does not exist: $(BACKEND_CONTAINER)/src/instance/db_$(SPIFFWORKFLOW_BACKEND_ENV).sqlite3"; \
+	@if [ ! -f "$(BACKEND_CONTAINER)/$(BACKEND_SQLITE_FILE)" ]; then \
+		echo "SQLite database file does not exist: $(BACKEND_CONTAINER)/$(BACKEND_SQLITE_FILE)"; \
 		exit 1; \
 	fi
-	$(IN_BACKEND) sqlite3 src/instance/db_$(SPIFFWORKFLOW_BACKEND_ENV).sqlite3
+	$(IN_BACKEND) sqlite3 $(BACKEND_SQLITE_FILE)
 
 be-tests: be-clear-log-file
-	$(IN_BACKEND) poetry run pytest
+	$(IN_BACKEND) poetry run pytest tests/spiffworkflow_backend/$(JUST)
 
 be-tests-par: be-clear-log-file
-	$(IN_BACKEND) poetry run pytest -n auto -x --random-order
+	$(IN_BACKEND) poetry run pytest -n auto -x --random-order tests/spiffworkflow_backend/$(JUST)
 
 fe-lint-fix:
 	$(IN_FRONTEND) npm run lint:fix

--- a/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
@@ -457,6 +457,27 @@ paths:
               schema:
                 $ref: "#/components/schemas/ProcessGroup"
 
+  /upsearch-locations:
+    parameters:
+      - name: location
+        in: query
+        required: false
+        description: The location to perform the upsearch
+        schema:
+          type: string
+    get:
+      operationId: spiffworkflow_backend.routes.upsearch_controller.upsearch_locations
+      summary: Returns upsearch locations for the given location
+      tags:
+        - Upsearch
+      responses:
+        "200":
+          description: Upsearch Locations.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProcessGroup"
+
   /process-models:
     parameters:
       - name: process_group_identifier

--- a/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
@@ -476,7 +476,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProcessGroup"
+                $ref: "#/components/schemas/Locations"
 
   /process-models:
     parameters:
@@ -3143,6 +3143,10 @@ components:
         ok:
           type: boolean
           example: true
+    Locations:
+      properties:
+        locations:
+          type: array
     User:
       properties:
         uid:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/upsearch_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/upsearch_controller.py
@@ -11,4 +11,4 @@ def upsearch_locations(
 ) -> Any:
     upsearch_locations = UpsearchService.upsearch_locations(location)
 
-    return make_response(jsonify(upsearch_locations), 200)
+    return make_response(jsonify({"locations": upsearch_locations}), 200)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/upsearch_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/upsearch_controller.py
@@ -1,0 +1,14 @@
+from typing import Any
+
+from flask import jsonify
+from flask import make_response
+
+from spiffworkflow_backend.services.upsearch_service import UpsearchService
+
+
+def upsearch_locations(
+    location: str | None,
+) -> Any:
+    upsearch_locations = UpsearchService.upsearch_locations(location)
+
+    return make_response(jsonify(upsearch_locations), 200)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
@@ -541,6 +541,8 @@ class AuthorizationService:
         permissions_to_assign.append(PermissionToAssign(permission="read", target_uri="/script-assist/enabled"))
         permissions_to_assign.append(PermissionToAssign(permission="create", target_uri="/script-assist/process-message"))
 
+        permissions_to_assign.append(PermissionToAssign(permission="read", target_uri="/upsearch-locations"))
+
         for permission in ["create", "read", "update", "delete"]:
             permissions_to_assign.append(PermissionToAssign(permission=permission, target_uri="/process-instances/reports/*"))
             permissions_to_assign.append(PermissionToAssign(permission=permission, target_uri="/tasks/*"))

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/upsearch_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/upsearch_service.py
@@ -3,8 +3,8 @@ import os
 
 class UpsearchService:
     @classmethod
-    def upsearch_locations(cls, process_model_identifier: str) -> list[str]:
-        location = process_model_identifier
+    def upsearch_locations(cls, process_model_identifier: str | None) -> list[str]:
+        location = process_model_identifier or ""
         locations = []
 
         while location != "":

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_upsearch_controller.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_upsearch_controller.py
@@ -13,20 +13,19 @@ class TestUpsearchControllerController(BaseTest):
             ("a/b/c/d", ["a/b/c/d", "a/b/c", "a/b", "a", ""]),
             ("a", ["a", ""]),
             ("", [""]),
-
-        ])
+        ],
+    )
     def test_return_upsearch_locations_for_path(
         self,
         app: Flask,
         client: FlaskClient,
         with_db_and_bpmn_file_cleanup: None,
         with_super_admin_user: UserModel,
-            location: str,
-            expected: list[str],
+        location: str,
+        expected: list[str],
     ) -> None:
         response = client.get(
-            f"/v1.0/upsearch-locations?location={location}",
-            headers=self.logged_in_headers(with_super_admin_user)
+            f"/v1.0/upsearch-locations?location={location}", headers=self.logged_in_headers(with_super_admin_user)
         )
 
         assert response.status_code == 200

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_upsearch_controller.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_upsearch_controller.py
@@ -1,0 +1,33 @@
+import pytest
+from flask.app import Flask
+from flask.testing import FlaskClient
+from spiffworkflow_backend.models.user import UserModel
+
+from tests.spiffworkflow_backend.helpers.base_test import BaseTest
+
+
+class TestUpsearchControllerController(BaseTest):
+    @pytest.mark.parametrize(
+        "location,expected",
+        [
+            ("a/b/c/d", ["a/b/c/d", "a/b/c", "a/b", "a", ""]),
+            ("a", ["a", ""]),
+            ("", [""]),
+
+        ])
+    def test_return_upsearch_locations_for_path(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+            location: str,
+            expected: list[str],
+    ) -> None:
+        response = client.get(
+            f"/v1.0/upsearch-locations?location={location}",
+            headers=self.logged_in_headers(with_super_admin_user)
+        )
+
+        assert response.status_code == 200
+        assert response.json == expected

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_upsearch_controller.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_upsearch_controller.py
@@ -1,5 +1,4 @@
 import pytest
-from flask.app import Flask
 from flask.testing import FlaskClient
 from spiffworkflow_backend.models.user import UserModel
 
@@ -17,9 +16,7 @@ class TestUpsearchControllerController(BaseTest):
     )
     def test_return_upsearch_locations_for_path(
         self,
-        app: Flask,
         client: FlaskClient,
-        with_db_and_bpmn_file_cleanup: None,
         with_super_admin_user: UserModel,
         location: str,
         expected: list[str],

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_upsearch_controller.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_upsearch_controller.py
@@ -1,4 +1,5 @@
 import pytest
+from flask.app import Flask
 from flask.testing import FlaskClient
 from spiffworkflow_backend.models.user import UserModel
 
@@ -16,7 +17,9 @@ class TestUpsearchControllerController(BaseTest):
     )
     def test_return_upsearch_locations_for_path(
         self,
+        app: Flask,
         client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
         with_super_admin_user: UserModel,
         location: str,
         expected: list[str],

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_upsearch_controller.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_upsearch_controller.py
@@ -29,4 +29,5 @@ class TestUpsearchControllerController(BaseTest):
         )
 
         assert response.status_code == 200
-        assert response.json == expected
+        assert "locations" in response.json
+        assert response.json["locations"] == expected

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_authorization_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_authorization_service.py
@@ -468,6 +468,7 @@ class TestAuthorizationService(BaseTest):
                 ("/user-groups/for-current-user", "read"),
                 ("/users/exists/by-username", "create"),
                 ("/users/search", "read"),
+                ("/upsearch-locations", "read"),
             ]
         )
 


### PR DESCRIPTION
Adding an api wrapper around the `UpsearchService`. Also added a Makefile var for the sqlite file and the ability to run a subset of the tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Introduced a new API endpoint `/upsearch-locations` for retrieving upsearch locations based on a given location parameter.
- **Refactor**
    - Implemented a `BACKEND_SQLITE_FILE` variable in the Makefile for dynamic SQLite file path definition.
    - Updated `UpsearchService` to accept an optional `process_model_identifier` parameter.
- **Tests**
    - Added integration tests for the new `/upsearch-locations` endpoint to ensure it returns the correct locations for given input paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->