### PR TITLE
/task-show-on-error-fix

### DIFF
--- a/spiffworkflow-frontend/src/routes/TaskShow.tsx
+++ b/spiffworkflow-frontend/src/routes/TaskShow.tsx
@@ -52,6 +52,15 @@ export default function TaskShow() {
 
   const { addError, removeError } = useAPIError();
 
+  const addErrorCallback = useCallback(
+    (error: ErrorForDisplay) => {
+      addError(error);
+      // FIXME: not sure what to do about addError. adding it to this array causes the page to endlessly reload
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    },
+    [addError]
+  );
+
   // if a user can complete a task then the for-me page should
   // always work for them so use that since it will work in all cases
   const navigateToInterstitial = useCallback(
@@ -112,7 +121,7 @@ export default function TaskShow() {
     };
     const handleTaskFetchError = (error: ErrorForDisplay) => {
       setAtLeastOneTaskFetchHasError(true);
-      addError(error);
+      addErrorCallback(error);
     };
 
     HttpService.makeCallToBackend({
@@ -125,9 +134,12 @@ export default function TaskShow() {
       successCallback: processTaskWithDataResult,
       failureCallback: handleTaskFetchError,
     });
-    // FIXME: not sure what to do about addError. adding it to this array causes the page to endlessly reload
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [params, processBasicTaskResult]);
+  }, [
+    params.task_id,
+    params.process_instance_id,
+    processBasicTaskResult,
+    addErrorCallback,
+  ]);
 
   // Before we auto-saved form data, we remembered what data was in the form, and then created a synthetic submit event
   // in order to implement a "Save and close" button. That button no longer saves (since we have auto-save), but the crazy

--- a/spiffworkflow-frontend/src/routes/TaskShow.tsx
+++ b/spiffworkflow-frontend/src/routes/TaskShow.tsx
@@ -52,14 +52,11 @@ export default function TaskShow() {
 
   const { addError, removeError } = useAPIError();
 
-  const addErrorCallback = useCallback(
-    (error: ErrorForDisplay) => {
-      addError(error);
-      // FIXME: not sure what to do about addError. adding it to this array causes the page to endlessly reload
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    },
-    [addError]
-  );
+  const addErrorCallback = useCallback((error: ErrorForDisplay) => {
+    addError(error);
+    // FIXME: not sure what to do about addError. adding it to this array causes the page to endlessly reload
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // if a user can complete a task then the for-me page should
   // always work for them so use that since it will work in all cases


### PR DESCRIPTION
Updates the useEffect on the TaskShow page to watch only the 2 attributes from params that we actually need. This helps to avoid constantly re-rendering the page on error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
    - Enhanced error handling in task display functionality for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->