### PR TITLE
add-force-run-event

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/process_instance_event.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/process_instance_event.py
@@ -15,6 +15,7 @@ from spiffworkflow_backend.models.user import UserModel
 # event types take the form [SUBJECT]_[PAST_TENSE_VERB] since subject is not always the same.
 class ProcessInstanceEventType(SpiffEnum):
     process_instance_error = "process_instance_error"
+    process_instance_force_run = "process_instance_force_run"
     process_instance_resumed = "process_instance_resumed"
     process_instance_rewound_to_task = "process_instance_rewound_to_task"
     process_instance_suspended = "process_instance_suspended"
@@ -40,9 +41,7 @@ class ProcessInstanceEventModel(SpiffworkflowBaseDBModel):
 
     user_id = db.Column(ForeignKey(UserModel.id), nullable=True, index=True)  # type: ignore
 
-    error_details = relationship(
-        "ProcessInstanceErrorDetailModel", back_populates="process_instance_event", cascade="delete"
-    )  # type: ignore
+    error_details = relationship("ProcessInstanceErrorDetailModel", back_populates="process_instance_event", cascade="delete")  # type: ignore
 
     @validates("event_type")
     def validate_event_type(self, key: str, value: Any) -> Any:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_instances_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_instances_controller.py
@@ -55,6 +55,7 @@ from spiffworkflow_backend.services.process_instance_queue_service import Proces
 from spiffworkflow_backend.services.process_instance_queue_service import ProcessInstanceQueueService
 from spiffworkflow_backend.services.process_instance_report_service import ProcessInstanceReportService
 from spiffworkflow_backend.services.process_instance_service import ProcessInstanceService
+from spiffworkflow_backend.services.process_instance_tmp_service import ProcessInstanceTmpService
 from spiffworkflow_backend.services.process_model_service import ProcessModelService
 from spiffworkflow_backend.services.task_service import TaskService
 
@@ -658,6 +659,7 @@ def _process_instance_run(
 
     processor = None
     try:
+        ProcessInstanceTmpService.add_event_to_process_instance(process_instance, "process_instance_force_run")
         if not queue_process_instance_if_appropriate(
             process_instance, execution_mode=execution_mode
         ) and not ProcessInstanceQueueService.is_enqueued_to_run_in_the_future(process_instance):


### PR DESCRIPTION
This adds an event to be used when a process instance is forced to run. That way we can know when / if  it happened.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new event type for force-running process instances.
- **Refactor**
	- Improved data relationship formatting in process instance events for consistency.
- **Chores**
	- Enhanced process instance run functionality with additional event logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->