### PR TITLE
Handle pi lock from message service

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/background_processing_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/background_processing_service.py
@@ -13,7 +13,6 @@ from spiffworkflow_backend.models.process_instance import ProcessInstanceStatus
 from spiffworkflow_backend.models.task import TaskModel  # noqa: F401
 from spiffworkflow_backend.services.message_service import MessageService
 from spiffworkflow_backend.services.process_instance_lock_service import ProcessInstanceLockService
-from spiffworkflow_backend.services.process_instance_queue_service import ProcessInstanceIsAlreadyLockedError
 from spiffworkflow_backend.services.process_instance_service import ProcessInstanceService
 
 
@@ -50,11 +49,8 @@ class BackgroundProcessingService:
     def process_message_instances_with_app_context(self) -> None:
         """Since this runs in a scheduler, we need to specify the app context as well."""
         with self.app.app_context():
-            try:
-                ProcessInstanceLockService.set_thread_local_locking_context("bg:messages")
-                MessageService.correlate_all_message_instances()
-            except ProcessInstanceIsAlreadyLockedError:
-                return
+            ProcessInstanceLockService.set_thread_local_locking_context("bg:messages")
+            MessageService.correlate_all_message_instances()
 
     def remove_stale_locks(self) -> None:
         """If something has been locked for a certain amount of time it is probably stale so unlock it."""

--- a/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/background_processing_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/background_processing_service.py
@@ -13,6 +13,7 @@ from spiffworkflow_backend.models.process_instance import ProcessInstanceStatus
 from spiffworkflow_backend.models.task import TaskModel  # noqa: F401
 from spiffworkflow_backend.services.message_service import MessageService
 from spiffworkflow_backend.services.process_instance_lock_service import ProcessInstanceLockService
+from spiffworkflow_backend.services.process_instance_queue_service import ProcessInstanceIsAlreadyLockedError
 from spiffworkflow_backend.services.process_instance_service import ProcessInstanceService
 
 
@@ -49,8 +50,11 @@ class BackgroundProcessingService:
     def process_message_instances_with_app_context(self) -> None:
         """Since this runs in a scheduler, we need to specify the app context as well."""
         with self.app.app_context():
-            ProcessInstanceLockService.set_thread_local_locking_context("bg:messages")
-            MessageService.correlate_all_message_instances()
+            try:
+                ProcessInstanceLockService.set_thread_local_locking_context("bg:messages")
+                MessageService.correlate_all_message_instances()
+            except ProcessInstanceIsAlreadyLockedError:
+                return
 
     def remove_stale_locks(self) -> None:
         """If something has been locked for a certain amount of time it is probably stale so unlock it."""

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_message_instance.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_message_instance.py
@@ -10,7 +10,7 @@ from tests.spiffworkflow_backend.helpers.test_data import load_test_spec
 
 
 class TestMessageInstance(BaseTest):
-    def setup_message_tests(self, client: FlaskClient) -> ProcessModelInfo:
+    def setup_message_tests(self) -> ProcessModelInfo:
         process_model_id = "testk_group/hello_world"
         bpmn_file_name = "hello_world.bpmn"
         bpmn_file_location = "hello_world"
@@ -28,7 +28,7 @@ class TestMessageInstance(BaseTest):
         with_db_and_bpmn_file_cleanup: None,
     ) -> None:
         message_name = "Message Model One"
-        process_model = self.setup_message_tests(client)
+        process_model = self.setup_message_tests()
         process_instance = self.create_process_instance_from_process_model(process_model, "waiting")
 
         queued_message = MessageInstanceModel(
@@ -54,7 +54,7 @@ class TestMessageInstance(BaseTest):
         with_db_and_bpmn_file_cleanup: None,
     ) -> None:
         message_name = "message_model_one"
-        process_model = self.setup_message_tests(client)
+        process_model = self.setup_message_tests()
         process_instance = self.create_process_instance_from_process_model(process_model, "waiting")
 
         with pytest.raises(ValueError) as exception:
@@ -87,7 +87,7 @@ class TestMessageInstance(BaseTest):
         with_db_and_bpmn_file_cleanup: None,
     ) -> None:
         message_name = "message_model_one"
-        process_model = self.setup_message_tests(client)
+        process_model = self.setup_message_tests()
         process_instance = self.create_process_instance_from_process_model(process_model, "waiting")
 
         with pytest.raises(ValueError) as exception:
@@ -119,7 +119,7 @@ class TestMessageInstance(BaseTest):
         with_db_and_bpmn_file_cleanup: None,
     ) -> None:
         message_name = "message_model_one"
-        process_model = self.setup_message_tests(client)
+        process_model = self.setup_message_tests()
         process_instance = self.create_process_instance_from_process_model(process_model, "waiting")
 
         queued_message = MessageInstanceModel(


### PR DESCRIPTION
Fixes #1239 

This adds logic to handle locking of a process instance from within the message service. This is to avoid already locked errors when competing with background processing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for locked process instances in background processing and message services.
- **Bug Fixes**
	- Improved reliability in message correlation and process instance locking scenarios.
- **Tests**
	- Added new unit tests for background processing and message services to ensure graceful handling of locked process instances.
	- Updated existing tests for better coverage and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->