### PR TITLE
add-retries-on-task-submit

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
@@ -462,7 +462,7 @@ def _task_submit_shared(
     # in the block causes the process instance to go into an error state. for example, when
     # AuthorizationService.assert_user_can_complete_task raises. this would have been solvable, but this seems simpler,
     # and the cost is not huge given that this function is not the most common code path in the world.
-    with ProcessInstanceQueueService.dequeued(process_instance):
+    with ProcessInstanceQueueService.dequeued(process_instance, max_attempts=3):
         ProcessInstanceMigrator.run(process_instance)
 
     processor = ProcessInstanceProcessor(
@@ -487,7 +487,7 @@ def _task_submit_shared(
     )
 
     with sentry_sdk.start_span(op="task", description="complete_form_task"):
-        with ProcessInstanceQueueService.dequeued(process_instance):
+        with ProcessInstanceQueueService.dequeued(process_instance, max_attempts=3):
             ProcessInstanceService.complete_form_task(
                 processor=processor,
                 spiff_task=spiff_task,

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_queue_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_queue_service.py
@@ -93,17 +93,41 @@ class ProcessInstanceQueueService:
         )
 
     @classmethod
+    def _dequeue_with_retries(
+        cls,
+        process_instance: ProcessInstanceModel,
+        additional_processing_identifier: str | None = None,
+        max_attempts: int = 1,
+    ) -> None:
+        attempt = 1
+        backoff_factor = 2
+        while True:
+            try:
+                return cls._dequeue(process_instance, additional_processing_identifier=additional_processing_identifier)
+            except ProcessInstanceIsAlreadyLockedError as exception:
+                if attempt >= max_attempts:
+                    raise exception
+                time.sleep(backoff_factor**attempt)
+                attempt += 1
+
+    @classmethod
     @contextlib.contextmanager
     def dequeued(
-        cls, process_instance: ProcessInstanceModel, additional_processing_identifier: str | None = None
+        cls,
+        process_instance: ProcessInstanceModel,
+        additional_processing_identifier: str | None = None,
+        max_attempts: int = 1,
     ) -> Generator[None, None, None]:
         reentering_lock = ProcessInstanceLockService.has_lock(
             process_instance.id, additional_processing_identifier=additional_processing_identifier
         )
+
         if not reentering_lock:
             # this can blow up with ProcessInstanceIsNotEnqueuedError or ProcessInstanceIsAlreadyLockedError
             # that's fine, let it bubble up. and in that case, there's no need to _enqueue / unlock
-            cls._dequeue(process_instance, additional_processing_identifier=additional_processing_identifier)
+            cls._dequeue_with_retries(
+                process_instance, additional_processing_identifier=additional_processing_identifier, max_attempts=max_attempts
+            )
         try:
             yield
         except Exception as ex:


### PR DESCRIPTION
Fixes #1006 

This introduces max_attempts to dequeued so if it fails to grab a lock the first time, it can attempt to grab one again a given number of times.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a retry mechanism for task dequeuing to enhance process reliability.

- **Tests**
	- Added tests to ensure the new dequeuing retry mechanism works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->