### PR TITLE
markdown-date-formatter

### DIFF
--- a/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
+++ b/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
@@ -308,6 +308,13 @@ export default function ProcessInstanceListTable({
     return titleizeString((value || '').replaceAll('_', ' '));
   };
 
+  const formatDurationForDisplayForTable = (_row: any, value: any) => {
+    return DateAndTimeService.formatDurationForDisplay(value);
+  };
+  const formatDateTimeForTable = (_row: any, value: any) => {
+    return DateAndTimeService.formatDateTime(value);
+  };
+
   const formatSecondsForDisplay = (_row: ProcessInstance, seconds: any) => {
     return DateAndTimeService.convertSecondsToFormattedDateTime(seconds) || '-';
   };
@@ -330,8 +337,8 @@ export default function ProcessInstanceListTable({
       last_milestone_bpmn_name: formatLastMilestone,
     };
     const displayTypeFormatters: Record<string, any> = {
-      date_time: DateAndTimeService.formatDateTime,
-      duration: DateAndTimeService.formatDurationForDisplay,
+      date_time: formatDateTimeForTable,
+      duration: formatDurationForDisplayForTable,
     };
     const columnAccessor = column.accessor as keyof ProcessInstance;
     const formatter = column.display_type

--- a/spiffworkflow-frontend/src/services/DateAndTimeService.test.tsx
+++ b/spiffworkflow-frontend/src/services/DateAndTimeService.test.tsx
@@ -6,21 +6,17 @@ test('it can keep the correct date when converting seconds to date', () => {
   expect(dateString).toEqual('2022-10-21');
 });
 test('it can properly format a duration', () => {
-  expect(DateAndTimeService.formatDurationForDisplay(null, '0')).toEqual('0s');
-  expect(DateAndTimeService.formatDurationForDisplay(null, '60')).toEqual('1m');
-  expect(DateAndTimeService.formatDurationForDisplay(null, '65')).toEqual(
-    '1m 5s'
-  );
-  expect(DateAndTimeService.formatDurationForDisplay(null, 65)).toEqual(
-    '1m 5s'
-  );
-  expect(DateAndTimeService.formatDurationForDisplay(null, 86500)).toEqual(
+  expect(DateAndTimeService.formatDurationForDisplay('0')).toEqual('0s');
+  expect(DateAndTimeService.formatDurationForDisplay('60')).toEqual('1m');
+  expect(DateAndTimeService.formatDurationForDisplay('65')).toEqual('1m 5s');
+  expect(DateAndTimeService.formatDurationForDisplay(65)).toEqual('1m 5s');
+  expect(DateAndTimeService.formatDurationForDisplay(86500)).toEqual(
     '1d 1m 40s'
   );
-  expect(DateAndTimeService.formatDurationForDisplay(null, 2629746)).toEqual(
+  expect(DateAndTimeService.formatDurationForDisplay(2629746)).toEqual(
     '30d 10h 29m 6s'
   );
-  expect(DateAndTimeService.formatDurationForDisplay(null, 31536765)).toEqual(
+  expect(DateAndTimeService.formatDurationForDisplay(31536765)).toEqual(
     '365d 12m 45s'
   );
 });

--- a/spiffworkflow-frontend/src/services/DateAndTimeService.tsx
+++ b/spiffworkflow-frontend/src/services/DateAndTimeService.tsx
@@ -147,7 +147,7 @@ const secondsToDuration = (secNum: number) => {
   return duration;
 };
 
-const formatDurationForDisplay = (_row: any, value: any) => {
+const formatDurationForDisplay = (value: any) => {
   if (value === undefined) {
     return undefined;
   }
@@ -171,7 +171,7 @@ const formatDurationForDisplay = (_row: any, value: any) => {
   return durationTimes.join(' ');
 };
 
-const formatDateTime = (_row: any, value: any) => {
+const formatDateTime = (value: any) => {
   if (value === undefined || value === null) {
     return value;
   }

--- a/spiffworkflow-frontend/src/services/FormattingService.test.tsx
+++ b/spiffworkflow-frontend/src/services/FormattingService.test.tsx
@@ -1,0 +1,26 @@
+import FormattingService from './FormattingService';
+
+test('it can convert date string to date for display', () => {
+  const markdown =
+    'HEY SPIFF_FORMAT:::convert_date_to_date_for_display(2024-03-01)';
+  expect(FormattingService.checkForSpiffFormats(markdown)).toEqual(
+    'HEY 2024-03-01'
+  );
+});
+
+// timezones for the lose
+// test('it can convert seconds to date time for display', () => {
+//   const markdown =
+//     'HEY SPIFF_FORMAT:::convert_seconds_to_date_time_for_display(10000)';
+//   expect(FormattingService.checkForSpiffFormats(markdown)).toEqual(
+//     'HEY 1969-12-31 21:46:40'
+//   );
+// });
+
+test('it can convert seconds to duration time for display', () => {
+  const markdown =
+    'HEY SPIFF_FORMAT:::convert_seconds_to_duration_for_display(10000)';
+  expect(FormattingService.checkForSpiffFormats(markdown)).toEqual(
+    'HEY 2h 46m 40s'
+  );
+});

--- a/spiffworkflow-frontend/src/services/FormattingService.tsx
+++ b/spiffworkflow-frontend/src/services/FormattingService.tsx
@@ -4,6 +4,8 @@ const spiffFormatFunctions: { [key: string]: Function } = {
   convert_seconds_to_date_time_for_display: DateAndTimeService.formatDateTime,
   convert_seconds_to_duration_for_display:
     DateAndTimeService.formatDurationForDisplay,
+  convert_date_to_date_for_display:
+    DateAndTimeService.ymdDateStringToConfiguredFormat,
 };
 
 const checkForSpiffFormats = (markdown: string) => {
@@ -13,7 +15,7 @@ const checkForSpiffFormats = (markdown: string) => {
     originalValue: string
   ) => {
     if (spiffFormat in spiffFormatFunctions) {
-      return spiffFormatFunctions[spiffFormat](undefined, originalValue);
+      return spiffFormatFunctions[spiffFormat](originalValue);
     }
     console.warn(
       `attempted: ${match}, but ${spiffFormat} is not a valid conversion function`


### PR DESCRIPTION
Supports #637 

This adds a SPIFF_FORMATTER for markdown to format a date string into the configured date in the frontend.

usage:
`The date is SPIFF_FORMATTER:::convert_date_to_date_for_display(2024-03-01)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced date and time formatting in the `ProcessInstanceListTable` component for improved readability.
	- Introduced comprehensive tests for the `DateAndTimeService` and `FormattingService` to ensure accurate date and duration formatting.

- **Refactor**
	- Simplified the function signatures in `DateAndTimeService` by removing unused parameters.
	- Updated `FormattingService` to more efficiently handle date conversions for display purposes.

- **Tests**
	- Added new test cases for validating the functionality of date and duration formatting services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->