### PR TITLE
Demonstrate east deployment to cloud.gov

### DIFF
--- a/.github/workflows/docker_image_for_main_builds.yml
+++ b/.github/workflows/docker_image_for_main_builds.yml
@@ -32,6 +32,7 @@ on:
       - main
       - spiffdemo
       - feature/update-extension-docs
+      - deploy-to-cloud-gov
 
 jobs:
   create_frontend_docker_image:

--- a/.github/workflows/docker_image_for_main_builds.yml
+++ b/.github/workflows/docker_image_for_main_builds.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REGISTRY: ghcr.io
-      IMAGE_NAME: sartography/spiffworkflow-frontend
+      IMAGE_NAME: gsa-tts/spiffworkflow-frontend
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
     permissions:
       contents: read
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REGISTRY: ghcr.io
-      IMAGE_NAME: sartography/spiffworkflow-backend
+      IMAGE_NAME: gsa-tts/spiffworkflow-backend
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
     permissions:
       contents: read
@@ -147,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REGISTRY: ghcr.io
-      IMAGE_NAME: sartography/connector-proxy-demo
+      IMAGE_NAME: gsa-tts/connector-proxy-demo
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
     permissions:

--- a/.github/workflows/docker_image_for_main_builds.yml
+++ b/.github/workflows/docker_image_for_main_builds.yml
@@ -30,9 +30,9 @@ on:
   push:
     branches:
       - main
-      - spiffdemo
-      - feature/update-extension-docs
-      - deploy-to-cloud-gov
+      # - spiffdemo
+      # - feature/update-extension-docs
+      # - deploy-to-cloud-gov
 
 jobs:
   create_frontend_docker_image:

--- a/.github/workflows/docker_image_for_main_builds.yml
+++ b/.github/workflows/docker_image_for_main_builds.yml
@@ -32,7 +32,7 @@ on:
       - main
       # - spiffdemo
       # - feature/update-extension-docs
-      # - deploy-to-cloud-gov
+      - deploy-to-cloud-gov
 
 jobs:
   create_frontend_docker_image:

--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -1,9 +1,9 @@
 name: Slack Notification
 
-on:
-  workflow_run:
-    workflows: ["Tests", "Docker Image For Main Builds", "Release Builds", "Build Docs"]
-    types: [completed]
+# on:
+#   workflow_run:
+#     workflows: ["Tests", "Docker Image For Main Builds", "Release Builds", "Build Docs"]
+#     types: [completed]
 
 jobs:
   send_notification:

--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -1,9 +1,9 @@
 name: Slack Notification
 
-# on:
-#   workflow_run:
-#     workflows: ["Tests", "Docker Image For Main Builds", "Release Builds", "Build Docs"]
-#     types: [completed]
+on:
+  workflow_run:
+    workflows: ["Tests", "Docker Image For Main Builds", "Release Builds", "Build Docs"]
+    types: [completed]
 
 jobs:
   send_notification:

--- a/manifest.yml
+++ b/manifest.yml
@@ -11,7 +11,8 @@ applications:
 ################################
 - name: spiffworkflow-frontend
   <<: *defaults
-  route: spiffworkflow-((randomish-route)).app.cloud.gov
+  routes:
+    - route: spiffworkflow-((randomish-route)).app.cloud.gov
   docker:
     image: ((frontend-image))
   env:
@@ -36,7 +37,8 @@ applications:
   <<: *defaults
   disk_quota: 3G
   health_check_type: process
-  route: spiffworkflow-((randomish-route)).app.cloud.gov/api
+  routes:
+    - route: spiffworkflow-((randomish-route)).app.cloud.gov/api
 
   # With buildpack:
   # path: spiffworkflow-backend

--- a/manifest.yml
+++ b/manifest.yml
@@ -19,7 +19,8 @@ applications:
     APPLICATION_ROOT: "/"
     PORT0: "8080"
     SPIFFWORKFLOW_FRONTEND_RUNTIME_CONFIG_APP_ROUTING_STRATEGY: "path_based"
-
+    SPIFFWORKFLOW_FRONTEND_RUNTIME_CONFIG_BACKEND_BASE_URL: "https://spiffworkflow-((randomish-route)).app.cloud.gov/api"
+    BACKEND_BASE_URL: "https://spiffworkflow-((randomish-route)).app.cloud.gov/api"
     # We may need to set BACKEND_URL; see spiffworkflow-frontend/src/config/tsx:15-72
 
     # Other vars this image understands:
@@ -64,7 +65,7 @@ applications:
     # Hardcoded
     FLASK_DEBUG: "0"
     APPLICATION_ROOT: "/"
-    SPIFFWORKFLOW_BACKEND_APPLICATION_ROOT: "/"
+    SPIFFWORKFLOW_BACKEND_APPLICATION_ROOT: "/api"
     SPIFFWORKFLOW_BACKEND_BPMN_SPEC_ABSOLUTE_DIR: "/app/process_models"
     # spiffworkflow_backend.config.ConfigurationError: SPIFFWORKFLOW_BACKEND_URL_FOR_FRONTEND and SPIFFWORKFLOW_BACKEND_URL are incompatible. We need backend to set cookies for frontend, so they need to be on the same domain. A common setup is to have frontend on example.com and backend on api.example.com. If you do not need this functionality, you can avoid this check by setting environment variable SPIFFWORKFLOW_BACKEND_CHECK_FRONTEND_AND_BACKEND_URL_COMPATIBILITY=false
     SPIFFWORKFLOW_BACKEND_CHECK_FRONTEND_AND_BACKEND_URL_COMPATIBILITY: "false"
@@ -83,7 +84,7 @@ applications:
     SPIFFWORKFLOW_BACKEND_OPEN_ID_CLIENT_SECRET_KEY: "((openid-secret))"
     SPIFFWORKFLOW_BACKEND_OPEN_ID_SERVER_URL: "https://spiffworkflow-((randomish-route)).app.cloud.gov/api/openid"
     SPIFFWORKFLOW_BACKEND_URL: "https://spiffworkflow-((randomish-route)).app.cloud.gov/api"
-    SPIFFWORKFLOW_BACKEND_URL_FOR_FRONTEND: "https://spiffworkflow-((randomish-route)).app.cloud.gov"
+    SPIFFWORKFLOW_BACKEND_URL_FOR_FRONTEND: "https://spiffworkflow-((randomish-route)).app.cloud.gov/api"
     SPIFFWORKFLOW_BACKEND_CONNECTOR_PROXY_URL: "https://spiffworkflow-connector-((randomish-route)).app.cloud.gov"
 
     #   - SPIFFWORKFLOW_BACKEND_DATABASE_URI=mysql+mysqldb://root:${SPIFFWORKFLOW_BACKEND_MYSQL_ROOT_DATABASE:-my-secret-pw}@127.0.0.1:7003/${SPIFFWORKFLOW_BACKEND_DATABASE_NAME:-spiffworkflow_backend_development}

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,5 @@
 ---
 defaults: &defaults
-  random-route: true
   services:
     - ((db-instance))
   disk_quota: 3G
@@ -12,12 +11,12 @@ applications:
 ################################
 - name: spiffworkflow-frontend
   <<: *defaults
+  route: spiffworkflow-((randomish-route)).app.cloud.gov
   docker:
     image: ((frontend-image))
   env:
     APPLICATION_ROOT: "/"
-
-    # Look for the backend on subpath "/api" of the app... I think.
+    PORT0: "8080"
     SPIFFWORKFLOW_FRONTEND_RUNTIME_CONFIG_APP_ROUTING_STRATEGY: "path_based"
 
     # We may need to set BACKEND_URL; see spiffworkflow-frontend/src/config/tsx:15-72
@@ -35,43 +34,56 @@ applications:
 
 - name: spiffworkflow-backend
   <<: *defaults
-  command: DATABASE_URL="$(echo $VCAP_SERVICES | jq --raw-output --arg service_name "((db-instance))" ".[][] | select(.name == \$service_name) | .credentials.uri")?sslmode=require" /app/bin/boot_server_in_docker
   disk_quota: 3G
+  health_check_type: process
+  route: spiffworkflow-((randomish-route)).app.cloud.gov/api
 
   # With buildpack:
-  path: spiffworkflow-backend
-  buildpacks:
-    - python_buildpack
+  # path: spiffworkflow-backend
+  # buildpacks:
+  #   - python_buildpack
+  # command: DATABASE_URL="$(echo $VCAP_SERVICES | jq --raw-output --arg service_name "((db-instance))" ".[][] | select(.name == \$service_name) | .credentials.uri")?sslmode=require" bin/boot_server_in_docker
 
   # With Docker:
-  # docker:
-  #   image: ((backend-image))
+  docker:
+    image: ((backend-image))
+  command: /app/bin/boot_server_in_docker
+  # command: sleep 6000
 
   env:
-    APPLICATION_ROOT: "/"
-    SPIFFWORKFLOW_BACKEND_DATABASE_TYPE: "postgres"
-    
-    
-
-# SPIFFWORKFLOW_BACKEND_PERMISSIONS_FILE_NAME=example.yml SPIFFWORKFLOW_BACKEND_DATABASE_TYPE=sqlite SPIFFWORKFLOW_BACKEND_ENV=local_docker SPIFFWORKFLOW_BACKEND_RUN_BACKGROUND_SCHEDULER_IN_CREATE_APP=true FLASK_DEBUG=0 FLASK_SESSION_SECRET_KEY=HEY SPIFFWORKFLOW_BACKEND_BPMN_SPEC_ABSOLUTE_DIR="${HOME}/projects/github/sartography/sample-process-models/" ./bin/boot_server_in_docker
-
-    # environment:
-    #   - FLASK_DEBUG=0
-    #   - FLASK_SESSION_SECRET_KEY=${FLASK_SESSION_SECRET_KEY:-e7711a3ba96c46c68e084a86952de16f}
-    #   - SPIFFWORKFLOW_BACKEND_APPLICATION_ROOT=/
-    #   - SPIFFWORKFLOW_BACKEND_BPMN_SPEC_ABSOLUTE_DIR=/app/process_models
-    #   - SPIFFWORKFLOW_BACKEND_DATABASE_URI=mysql+mysqldb://root:${SPIFFWORKFLOW_BACKEND_MYSQL_ROOT_DATABASE:-my-secret-pw}@127.0.0.1:7003/${SPIFFWORKFLOW_BACKEND_DATABASE_NAME:-spiffworkflow_backend_development}
-    #   - SPIFFWORKFLOW_BACKEND_ENV=${SPIFFWORKFLOW_BACKEND_ENV:-local_development}
-    #   - SPIFFWORKFLOW_BACKEND_LOAD_FIXTURE_DATA=${SPIFFWORKFLOW_BACKEND_LOAD_FIXTURE_DATA:-false}
-    #   - SPIFFWORKFLOW_BACKEND_OPEN_ID_SERVER_URL=${SPIFFWORKFLOW_BACKEND_OPEN_ID_SERVER_URL:-http://localhost:7002/realms/spiffworkflow}
-    #   - SPIFFWORKFLOW_BACKEND_PERMISSIONS_FILE_NAME=${SPIFFWORKFLOW_BACKEND_PERMISSIONS_FILE_NAME:-acceptance_tests.yml}
-    #   - SPIFFWORKFLOW_BACKEND_PORT=7000
-    #     # the background scheduler picks up process instances that we set in a certain state and then runs them like running not_started instances
-    #     # that are required for the process instance filter test. So for now do not run it. we may want to find another way around in the future
-    #   - SPIFFWORKFLOW_BACKEND_RUN_BACKGROUND_SCHEDULER_IN_CREATE_APP=false
-    #   - SPIFFWORKFLOW_BACKEND_URL_FOR_FRONTEND=${SPIFFWORKFLOW_BACKEND_URL_FOR_FRONTEND:-http://localhost:7001}
-    #   - SPIFFWORKFLOW_BACKEND_UPGRADE_DB=true
-    #   - SPIFFWORKFLOW_BACKEND_URL=${SPIFFWORKFLOW_BACKEND_URL:-http://localhost:7000}
-
     # All of the configuration variables are documented here:
     # https://github.com/sartography/spiff-arena/blob/main/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
+    
+    ### Requires VCAP env vars
+
+    # VCAP_SERVICES
+    SPIFFWORKFLOW_BACKEND_DATABASE_URI: "sqlite:///db.sqlite3"
+
+    # Hardcoded
+    FLASK_DEBUG: "0"
+    APPLICATION_ROOT: "/"
+    SPIFFWORKFLOW_BACKEND_APPLICATION_ROOT: "/"
+    SPIFFWORKFLOW_BACKEND_BPMN_SPEC_ABSOLUTE_DIR: "/app/process_models"
+    # spiffworkflow_backend.config.ConfigurationError: SPIFFWORKFLOW_BACKEND_URL_FOR_FRONTEND and SPIFFWORKFLOW_BACKEND_URL are incompatible. We need backend to set cookies for frontend, so they need to be on the same domain. A common setup is to have frontend on example.com and backend on api.example.com. If you do not need this functionality, you can avoid this check by setting environment variable SPIFFWORKFLOW_BACKEND_CHECK_FRONTEND_AND_BACKEND_URL_COMPATIBILITY=false
+    SPIFFWORKFLOW_BACKEND_CHECK_FRONTEND_AND_BACKEND_URL_COMPATIBILITY: "false"
+    SPIFFWORKFLOW_BACKEND_ENV: "local_docker"
+    SPIFFWORKFLOW_BACKEND_DATABASE_TYPE: "sqlite"
+    SPIFFWORKFLOW_BACKEND_LOAD_FIXTURE_DATA: "false"
+    SPIFFWORKFLOW_BACKEND_LOG_LEVEL: "DEBUG"
+    SPIFFWORKFLOW_BACKEND_OPEN_ID_CLIENT_ID: "spiffworkflow-backend"
+    SPIFFWORKFLOW_BACKEND_PERMISSIONS_FILE_NAME: "example.yml"
+    SPIFFWORKFLOW_BACKEND_PORT: "8080"
+    SPIFFWORKFLOW_BACKEND_RUN_BACKGROUND_SCHEDULER_IN_CREATE_APP: "true"
+    SPIFFWORKFLOW_BACKEND_UPGRADE_DB: "true"
+    
+    # vars.yml (or CLI)
+    FLASK_SESSION_SECRET_KEY: ((flask-session-key))
+    SPIFFWORKFLOW_BACKEND_OPEN_ID_CLIENT_SECRET_KEY: "((openid-secret))"
+    SPIFFWORKFLOW_BACKEND_OPEN_ID_SERVER_URL: "https://spiffworkflow-((randomish-route)).app.cloud.gov/api/openid"
+    SPIFFWORKFLOW_BACKEND_URL: "https://spiffworkflow-((randomish-route)).app.cloud.gov/api"
+    SPIFFWORKFLOW_BACKEND_URL_FOR_FRONTEND: "https://spiffworkflow-((randomish-route)).app.cloud.gov"
+    SPIFFWORKFLOW_BACKEND_CONNECTOR_PROXY_URL: "https://spiffworkflow-connector-((randomish-route)).app.cloud.gov"
+
+    #   - SPIFFWORKFLOW_BACKEND_DATABASE_URI=mysql+mysqldb://root:${SPIFFWORKFLOW_BACKEND_MYSQL_ROOT_DATABASE:-my-secret-pw}@127.0.0.1:7003/${SPIFFWORKFLOW_BACKEND_DATABASE_NAME:-spiffworkflow_backend_development}
+    #   - SPIFFWORKFLOW_BACKEND_OPEN_ID_SERVER_URL=http://localhost:7002/realms/spiffworkflow
+

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,77 @@
+---
+defaults: &defaults
+  random-route: true
+  services:
+    - ((db-instance))
+  disk_quota: 3G
+  memory: 256M
+  instances: 2  
+
+applications:
+
+################################
+- name: spiffworkflow-frontend
+  <<: *defaults
+  docker:
+    image: ((frontend-image))
+  env:
+    APPLICATION_ROOT: "/"
+
+    # Look for the backend on subpath "/api" of the app... I think.
+    SPIFFWORKFLOW_FRONTEND_RUNTIME_CONFIG_APP_ROUTING_STRATEGY: "path_based"
+
+    # We may need to set BACKEND_URL; see spiffworkflow-frontend/src/config/tsx:15-72
+
+    # Other vars this image understands:
+    # CYPRESS_RECORD_KEY
+    # SPIFFWORKFLOW_FRONTEND_PORT
+    # SPIFFWORKFLOW_FRONTEND_URL
+    # CYPRESS_RECORD_KEY
+    # REACT_APP_BACKEND_BASE_URL
+    # PUBLIC_URL
+    # NODE_ENV
+
+#################################
+
+- name: spiffworkflow-backend
+  <<: *defaults
+  command: DATABASE_URL="$(echo $VCAP_SERVICES | jq --raw-output --arg service_name "((db-instance))" ".[][] | select(.name == \$service_name) | .credentials.uri")?sslmode=require" /app/bin/boot_server_in_docker
+  disk_quota: 3G
+
+  # With buildpack:
+  path: spiffworkflow-backend
+  buildpacks:
+    - python_buildpack
+
+  # With Docker:
+  # docker:
+  #   image: ((backend-image))
+
+  env:
+    APPLICATION_ROOT: "/"
+    SPIFFWORKFLOW_BACKEND_DATABASE_TYPE: "postgres"
+    
+    
+
+# SPIFFWORKFLOW_BACKEND_PERMISSIONS_FILE_NAME=example.yml SPIFFWORKFLOW_BACKEND_DATABASE_TYPE=sqlite SPIFFWORKFLOW_BACKEND_ENV=local_docker SPIFFWORKFLOW_BACKEND_RUN_BACKGROUND_SCHEDULER_IN_CREATE_APP=true FLASK_DEBUG=0 FLASK_SESSION_SECRET_KEY=HEY SPIFFWORKFLOW_BACKEND_BPMN_SPEC_ABSOLUTE_DIR="${HOME}/projects/github/sartography/sample-process-models/" ./bin/boot_server_in_docker
+
+    # environment:
+    #   - FLASK_DEBUG=0
+    #   - FLASK_SESSION_SECRET_KEY=${FLASK_SESSION_SECRET_KEY:-e7711a3ba96c46c68e084a86952de16f}
+    #   - SPIFFWORKFLOW_BACKEND_APPLICATION_ROOT=/
+    #   - SPIFFWORKFLOW_BACKEND_BPMN_SPEC_ABSOLUTE_DIR=/app/process_models
+    #   - SPIFFWORKFLOW_BACKEND_DATABASE_URI=mysql+mysqldb://root:${SPIFFWORKFLOW_BACKEND_MYSQL_ROOT_DATABASE:-my-secret-pw}@127.0.0.1:7003/${SPIFFWORKFLOW_BACKEND_DATABASE_NAME:-spiffworkflow_backend_development}
+    #   - SPIFFWORKFLOW_BACKEND_ENV=${SPIFFWORKFLOW_BACKEND_ENV:-local_development}
+    #   - SPIFFWORKFLOW_BACKEND_LOAD_FIXTURE_DATA=${SPIFFWORKFLOW_BACKEND_LOAD_FIXTURE_DATA:-false}
+    #   - SPIFFWORKFLOW_BACKEND_OPEN_ID_SERVER_URL=${SPIFFWORKFLOW_BACKEND_OPEN_ID_SERVER_URL:-http://localhost:7002/realms/spiffworkflow}
+    #   - SPIFFWORKFLOW_BACKEND_PERMISSIONS_FILE_NAME=${SPIFFWORKFLOW_BACKEND_PERMISSIONS_FILE_NAME:-acceptance_tests.yml}
+    #   - SPIFFWORKFLOW_BACKEND_PORT=7000
+    #     # the background scheduler picks up process instances that we set in a certain state and then runs them like running not_started instances
+    #     # that are required for the process instance filter test. So for now do not run it. we may want to find another way around in the future
+    #   - SPIFFWORKFLOW_BACKEND_RUN_BACKGROUND_SCHEDULER_IN_CREATE_APP=false
+    #   - SPIFFWORKFLOW_BACKEND_URL_FOR_FRONTEND=${SPIFFWORKFLOW_BACKEND_URL_FOR_FRONTEND:-http://localhost:7001}
+    #   - SPIFFWORKFLOW_BACKEND_UPGRADE_DB=true
+    #   - SPIFFWORKFLOW_BACKEND_URL=${SPIFFWORKFLOW_BACKEND_URL:-http://localhost:7000}
+
+    # All of the configuration variables are documented here:
+    # https://github.com/sartography/spiff-arena/blob/main/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py

--- a/manifest.yml
+++ b/manifest.yml
@@ -22,6 +22,15 @@ applications:
     SPIFFWORKFLOW_FRONTEND_RUNTIME_CONFIG_BACKEND_BASE_URL: "https://spiffworkflow-((randomish-route)).app.cloud.gov/api"
     BACKEND_BASE_URL: "https://spiffworkflow-((randomish-route)).app.cloud.gov/api"
     # We may need to set BACKEND_URL; see spiffworkflow-frontend/src/config/tsx:15-72
+    
+    # WHERE WE STOPPED:
+    #   spiffworkflow-backend/src/spiffworkflow_backend/routes/authentication_controller.py#L111-L112
+    # We are hitting: https://spiffworkflow-flamingo-stardust.app.cloud.gov/api/v1.0/login?redirect_url=https://spiffworkflow-flamingo-stardust.app.cloud.gov/&authentication_identifier=default
+    # We are seeing: {
+    #   "error_code": "internal_server_error",
+    #   "message": "InvalidRedirectUrlError: Invalid redirect url was given: 'https://spiffworkflow-flamingo-stardust.app.cloud.gov/'. It must match the domain the frontend is running on.",
+    #   "status_code": 500
+    # }
 
     # Other vars this image understands:
     # CYPRESS_RECORD_KEY

--- a/spiffworkflow-backend/.profile
+++ b/spiffworkflow-backend/.profile
@@ -1,0 +1,5 @@
+#!/bin/bash
+export POETRY_HOME=poetry
+python3 -m venv $POETRY_HOME
+$POETRY_HOME/bin/pip install poetry==1.2.0
+export PATH=${PATH}:$POETRY_HOME/bin

--- a/spiffworkflow-backend/Dockerfile
+++ b/spiffworkflow-backend/Dockerfile
@@ -25,10 +25,12 @@ RUN apt-get update \
  && apt-get install -y -q git-core curl procps gunicorn3 default-mysql-client vim-tiny \
  && rm -rf /var/lib/apt/lists/*
 
+# install jq so we can get values from vcap
+RUN pip install jq
+
 # keep pip up to date
 RUN pip install --upgrade pip
 RUN pip install poetry==1.8.1
-
 
 ######################## - SETUP
 
@@ -42,9 +44,6 @@ FROM base AS setup
 # Pinnning to 1.3.2 to attempt to avoid it.
 RUN pip install poetry==1.6.1
 RUN useradd _gunicorn --no-create-home --user-group
-
-# install jq so we can get values from vcap
-RUN pip install jq
 
 # default-libmysqlclient-dev for mysqlclient lib
 RUN apt-get update \

--- a/spiffworkflow-backend/Dockerfile
+++ b/spiffworkflow-backend/Dockerfile
@@ -43,6 +43,9 @@ FROM base AS setup
 RUN pip install poetry==1.6.1
 RUN useradd _gunicorn --no-create-home --user-group
 
+# install jq so we can get values from vcap
+RUN pip install jq
+
 # default-libmysqlclient-dev for mysqlclient lib
 RUN apt-get update \
  && apt-get install -y -q gcc libssl-dev libpq-dev default-libmysqlclient-dev pkg-config libffi-dev

--- a/spiffworkflow-backend/Procfile
+++ b/spiffworkflow-backend/Procfile
@@ -1,0 +1,1 @@
+web: bin/boot_server_in_docker

--- a/vars.yml
+++ b/vars.yml
@@ -1,0 +1,3 @@
+frontend-image: ghcr.io/sartography/spiffworkflow-frontend:latest
+backend-image: ghcr.io/sartography/spiffworkflow-backend:latest
+db-instance: spiffworkflow-db

--- a/vars.yml
+++ b/vars.yml
@@ -1,3 +1,4 @@
-frontend-image: ghcr.io/sartography/spiffworkflow-frontend:latest
-backend-image: ghcr.io/sartography/spiffworkflow-backend:latest
+frontend-image: ghcr.io/gsa-tts/spiffworkflow-frontend:deploy-to-cloud-gov-latest
+backend-image: ghcr.io/gsa-tts/spiffworkflow-backend:deploy-to-cloud-gov-latest
 db-instance: spiffworkflow-db
+flask-testing-key: 66eef9e98a3f4e6f85258154e4a1bdce

--- a/vars.yml
+++ b/vars.yml
@@ -1,4 +1,7 @@
-frontend-image: ghcr.io/gsa-tts/spiffworkflow-frontend:deploy-to-cloud-gov-latest
 backend-image: ghcr.io/gsa-tts/spiffworkflow-backend:deploy-to-cloud-gov-latest
+frontend-image: ghcr.io/gsa-tts/spiffworkflow-frontend:deploy-to-cloud-gov-latest
+
 db-instance: spiffworkflow-db
-flask-testing-key: 66eef9e98a3f4e6f85258154e4a1bdce
+flask-session-key: 66eef9e98a3f4e6f85258154e4a1bdce
+openid-secret: flarblegarble
+randomish-route: flamingo-stardust


### PR DESCRIPTION
In order to demonstrate a fast compliance path to production and justify more spike stories (and win over skeptics on diagram-as-config), government Python coders want to see a demonstration of spiff-arena running easily on [cloud.gov](https://cloud.gov).

## Acceptance Criteria

- GIVEN  I have logged into cloud.gov from the CLI
    AND  I have cloned this repository
    WHEN I copy `vars.yml-template` to `vars.yml`
    AND  I replace `randomish-route` with a custom value
    AND  I run `cf push --vars-file vars.yml`
    AND  I open the URL `https://spiffworkflow-[[randomish-route]].app.cloud.gov`
    THEN I see the SpiffWorkflow login screen

