### PR TITLE
Support db migrations when using dev containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,12 @@ stop-dev:
 be-clear-log-file:
 	$(IN_BACKEND) rm -f log/unit_testing.log
 
+be-db-clean:
+	$(IN_BACKEND) ./bin/recreate_db clean
+
+be-db-migrate:
+	$(IN_BACKEND) ./bin/recreate_db migrate
+
 be-logs:
 	docker logs -f $(BACKEND_CONTAINER)
 
@@ -62,9 +68,6 @@ be-poetry-rm:
 	@if [ -d "$(BACKEND_CONTAINER)/.venv" ]; then \
 		rm -rf "$(BACKEND_CONTAINER)/.venv"; \
 	fi
-
-be-recreate-db:
-	$(IN_BACKEND) ./bin/recreate_db clean
 
 be-sh:
 	$(IN_BACKEND) /bin/bash
@@ -120,7 +123,7 @@ take-ownership:
 .PHONY: build-images dev-env \
 	start-dev stop-dev \
 	be-clear-log-file be-logs be-mypy be-poetry-i be-poetry-lock be-poetry-rm \
-	be-recreate-db be-sh be-sqlite be-tests be-tests-par \
+	be-db-clean be-db-migrate be-sh be-sqlite be-tests be-tests-par \
 	fe-lint-fix fe-logs fe-npm-i fe-sh \
 	poetry-i poetry-rm pre-commit ruff run-pyl \
 	take-ownership

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ all: dev-env start-dev run-pyl
 build-images:
 	$(DOCKER_COMPOSE) build
 
-dev-env: stop-dev build-images poetry-i be-poetry-i be-recreate-db fe-npm-i
+dev-env: stop-dev build-images poetry-i be-poetry-i be-db-clean fe-npm-i
 	@/bin/true
 
 start-dev: stop-dev


### PR DESCRIPTION
Pulling a change from the messages branch, this supports running the db migrations when using the dev containers. There used to be just one target to clean the db, split that out into two.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Enhanced database management with new scripts for cleaning and migrating the database.
	- Removed outdated database recreation script.
	- Updated the `.PHONY` target list to include `be-db-clean` and `be-db-migrate`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->