### PR TITLE
turn-off-events-in-migration

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_migrations/version_4.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_migrations/version_4.py
@@ -20,7 +20,10 @@ class Version4(DataMigrationBase):
             bpmn_process_dict = processor.serialize()
             update_data_objects(bpmn_process_dict)
             ProcessInstanceProcessor.persist_bpmn_process_dict(
-                bpmn_process_dict, bpmn_definition_to_task_definitions_mappings={}, process_instance_model=process_instance
+                bpmn_process_dict,
+                bpmn_definition_to_task_definitions_mappings={},
+                process_instance_model=process_instance,
+                store_process_instance_events=False,
             )
 
         except Exception as ex:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -498,6 +498,7 @@ class ProcessInstanceProcessor:
         bpmn_process_dict: dict,
         bpmn_definition_to_task_definitions_mappings: dict,
         process_instance_model: ProcessInstanceModel,
+        store_process_instance_events: bool = True,
     ) -> None:
         cls._add_bpmn_process_definitions(
             bpmn_process_dict,
@@ -516,7 +517,9 @@ class ProcessInstanceProcessor:
         bpmn_process_instance = cls._serializer.from_dict(process_copy)
         bpmn_process_instance.script_engine = cls._default_script_engine
         for spiff_task in bpmn_process_instance.get_tasks():
-            task_service.update_task_model_with_spiff_task(spiff_task)
+            task_service.update_task_model_with_spiff_task(
+                spiff_task, store_process_instance_events=store_process_instance_events
+            )
         task_service.save_objects_to_database()
         db.session.commit()
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/task_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/task_service.py
@@ -187,6 +187,7 @@ class TaskService:
         self,
         spiff_task: SpiffTask,
         start_and_end_times: StartAndEndTimes | None = None,
+        store_process_instance_events: bool = True,
     ) -> TaskModel:
         new_bpmn_process = None
         if str(spiff_task.id) in self.task_models:
@@ -216,8 +217,10 @@ class TaskService:
 
         # let failed tasks raise and we will log the event then.
         # avoid creating events for the same state transition multiple times to avoid multiple cancelled events
-        if task_model.state in ["COMPLETED", "CANCELLED"] and (
-            self.run_started_at is None or spiff_task.last_state_change >= self.run_started_at
+        if (
+            store_process_instance_events
+            and task_model.state in ["COMPLETED", "CANCELLED"]
+            and (self.run_started_at is None or spiff_task.last_state_change >= self.run_started_at)
         ):
             event_type = ProcessInstanceEventType.task_completed.value
             if task_model.state == "CANCELLED":

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_migrator.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_migrator.py
@@ -11,6 +11,7 @@ from spiffworkflow_backend.data_migrations.version_4 import Version4
 from spiffworkflow_backend.models.bpmn_process import BpmnProcessModel
 from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.models.process_instance import ProcessInstanceModel
+from spiffworkflow_backend.models.process_instance_event import ProcessInstanceEventModel
 from spiffworkflow_backend.models.task import TaskModel  # noqa: F401
 from spiffworkflow_backend.models.task_definition import TaskDefinitionModel
 from spiffworkflow_backend.services.process_instance_processor import ProcessInstanceProcessor
@@ -119,6 +120,8 @@ class TestProcessInstanceMigrator(BaseTest):
             "bpmn_process_id": process_instance.bpmn_process_id,
         }
 
+        process_instance_events = ProcessInstanceEventModel.query.filter_by(process_instance_id=process_instance.id).all()
+        pi_events_count_before = len(process_instance_events)
         Version4.run(process_instance)
         update_data_objects(bpmn_process_dict_version_4_from_spiff)
         process_instance = ProcessInstanceModel.query.filter_by(id=process_instance.id).first()
@@ -152,3 +155,7 @@ class TestProcessInstanceMigrator(BaseTest):
         for bpmn_process in bpmn_processes:
             for task_model in bpmn_process.tasks:
                 assert task_model.task_definition.bpmn_process_definition_id == bpmn_process.bpmn_process_definition_id
+
+        process_instance_events = ProcessInstanceEventModel.query.filter_by(process_instance_id=process_instance.id).all()
+        pi_events_count_after = len(process_instance_events)
+        assert pi_events_count_before == pi_events_count_after


### PR DESCRIPTION
Fixes #1307 

This adds an option in task service to not store events when updating a tasks. The version 4 data migration will also use this option since it is not necessary to store events in this case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an option to control the storage of process instance events, enhancing the flexibility of event management.

- **Tests**
	- Added tests to verify the correct behavior of process instance events storage during data migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->