### PR TITLE
local-openid-path-based-fix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -124,9 +124,8 @@ jobs:
       - name: Install pip and poetry
         run: |
           pwd
-          ls
+          ls -al
           pip install --constraint=../.github/workflows/constraints.txt pip poetry
-          pip install --upgrade setuptools # https://stackoverflow.com/a/77364602/6090676
           pip --version
           poetry --version
 
@@ -221,8 +220,9 @@ jobs:
       - name: Install Poetry
         run: |
           pwd
-          ls
-          pipx install --pip-args=--constraint=.github/workflows/constraints.txt poetry
+          ls -al
+          pip --version
+          pip install --constraint=../.github/workflows/constraints.txt pip poetry
           poetry --version
       - name: Poetry Install
         run: poetry install
@@ -269,9 +269,8 @@ jobs:
       - name: Install pip and poetry
         run: |
           pwd
-          ls
+          ls -al
           pip install --constraint=../.github/workflows/constraints.txt pip poetry
-          pip install --upgrade setuptools # https://stackoverflow.com/a/77364602/6090676
           pip --version
           poetry --version
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,7 +125,7 @@ jobs:
         run: |
           pwd
           ls -al
-          pip install --constraint=../.github/workflows/constraints.txt pip poetry
+          pip install --constraint=.github/workflows/constraints.txt pip poetry
           pip --version
           poetry --version
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,7 +125,7 @@ jobs:
         run: |
           pwd
           ls -al
-          pip install --constraint=.github/workflows/constraints.txt pip poetry
+          pip install --constraint=../.github/workflows/constraints.txt pip poetry
           pip --version
           poetry --version
 
@@ -222,7 +222,7 @@ jobs:
           pwd
           ls -al
           pip --version
-          pip install --constraint=../.github/workflows/constraints.txt pip poetry
+          pip install --constraint=.github/workflows/constraints.txt pip poetry
           poetry --version
       - name: Poetry Install
         run: poetry install

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/debug_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/debug_controller.py
@@ -20,6 +20,9 @@ def version_info() -> Response:
     return make_response(get_version_info_data(), 200)
 
 
+# this is just to see what the protocol is, primarily. if the site is running on https in the browser, but this says "http://something.example.com",
+# that might be bad, and might require some server configuration to make sure flask knows it is running on https.
+# if using path based routing, the path will probably not be returned from this endpoint.
 def url_info() -> Response:
     return make_response({"url": request.url, "cache": AuthenticationService.ENDPOINT_CACHE}, 200)
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/openid_blueprint/openid_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/openid_blueprint/openid_blueprint.py
@@ -40,7 +40,9 @@ def well_known() -> dict:
 
     These urls can be very different from one openid impl to the next, this is just a small subset.
     """
-    host_url = request.host_url.strip("/")
+
+    # using or instead of setting a default so we can set the env var to None in tests and this will still work
+    host_url = current_app.config.get("SPIFFWORKFLOW_BACKEND_URL") or request.host_url.strip("/")
     return {
         "issuer": f"{host_url}/openid",
         "authorization_endpoint": f"{host_url}{url_for('openid.auth')}",
@@ -108,7 +110,8 @@ def token() -> Response | dict:
     authorization = base64.b64decode(authorization).decode("utf-8")
     client_id = authorization.split(":")
 
-    base_url = request.host_url + "openid"
+    host_url = current_app.config.get("SPIFFWORKFLOW_BACKEND_URL", request.host_url.strip("/"))
+    base_url = f"{host_url}/openid"
     private_key = OpenIdConfigsForDevOnly.private_key
 
     id_token = jwt.encode(

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_openid_blueprint.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_openid_blueprint.py
@@ -7,7 +7,7 @@ from flask.testing import FlaskClient
 from tests.spiffworkflow_backend.helpers.base_test import BaseTest
 
 
-class TestFlaskOpenId(BaseTest):
+class TestOpenidBlueprint(BaseTest):
     """An integrated Open ID that responds to openID requests.
 
     By referencing a build in YAML file.  Useful for
@@ -23,9 +23,17 @@ class TestFlaskOpenId(BaseTest):
         """Test discovery endpoints."""
         response = client.get("/openid/.well-known/openid-configuration")
         discovered_urls = response.json
-        assert "http://localhost/openid" == discovered_urls["issuer"]
-        assert "http://localhost/openid/auth" == discovered_urls["authorization_endpoint"]
-        assert "http://localhost/openid/token" == discovered_urls["token_endpoint"]
+        assert "http://localhost:7000/openid" == discovered_urls["issuer"]
+        assert "http://localhost:7000/openid/auth" == discovered_urls["authorization_endpoint"]
+        assert "http://localhost:7000/openid/token" == discovered_urls["token_endpoint"]
+
+        with self.app_config_mock(app, "SPIFFWORKFLOW_BACKEND_URL", None):
+            response = client.get("/openid/.well-known/openid-configuration")
+            discovered_urls = response.json
+            # in unit tests, request.host_url will not have the port but it will have it in actual localhost flask server
+            assert "http://localhost/openid" == discovered_urls["issuer"]
+            assert "http://localhost/openid/auth" == discovered_urls["authorization_endpoint"]
+            assert "http://localhost/openid/token" == discovered_urls["token_endpoint"]
 
     def test_get_login_page(
         self,


### PR DESCRIPTION
This updates the openid well-known endpoint to use the config rather than `request.host_url` to determine the url. This fixes an issue with path based routing where flask cannot know about the path since it is stripped off before hitting backend but the path is required for anyone receiving the url.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Added explanations for protocol detection and server configuration in the debug controller.

- **Bug Fixes**
	- Improved handling of `None` values for environment variables in OpenID configuration.
	- Enhanced URL handling in OpenID blueprint and integration tests for better reliability across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->