### PR TITLE
always sort group members to fix flaky test in postgres

### DIFF
--- a/spiffworkflow-backend/.gitignore
+++ b/spiffworkflow-backend/.gitignore
@@ -23,3 +23,4 @@ node_modules
 /some_cache_dir
 /process.json
 /spiffworkflow_backend.svg
+/.venv

--- a/spiffworkflow-backend/src/spiffworkflow_backend/scripts/get_group_members.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/scripts/get_group_members.py
@@ -26,5 +26,5 @@ class GetGroupMembers(Script):
         if group is None:
             raise GroupNotFoundError(f"Script 'get_group_members' could not find group with identifier '{group_identifier}'.")
 
-        usernames = [u.username for u in group.users]
+        usernames = sorted([u.username for u in group.users])
         return usernames


### PR DESCRIPTION
and ignore venv that gets created by `make`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `.gitignore` to ignore virtual environment directories.

- **Bug Fixes**
	- Sorted the list of usernames in the group members retrieval script for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->