### PR TITLE
Look for bad get_current_user scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ pre-commit:
 	$(IN_ARENA) poetry run pre-commit run --verbose --all-files
 
 ruff:
-	$(IN_ARENA) poetry run ruff --fix spiffworkflow-backend
+	$(IN_ARENA) poetry run ruff check --fix spiffworkflow-backend
 
 run-pyl: fe-lint-fix ruff pre-commit be-mypy be-tests-par
 	@true

--- a/bin/run_pyl
+++ b/bin/run_pyl
@@ -24,7 +24,7 @@ function get_python_dirs() {
 function run_autofixers() {
   python_dirs="$(get_python_dirs) bin"
   # shellcheck disable=2086
-  poetry run ruff --fix $python_dirs || echo ''
+  poetry run ruff check --fix $python_dirs || echo ''
 }
 
 function run_pre_commmit() {

--- a/spiffworkflow-backend/bin/lint_get_current_user_scripts.py
+++ b/spiffworkflow-backend/bin/lint_get_current_user_scripts.py
@@ -25,7 +25,6 @@ def check_script_and_prescript_elements(tree, bpmn_file_path: str) -> None:
     # Find all script tasks and preScript elements
     script_tasks = tree.xpath("//bpmn:scriptTask", namespaces=nsmap)
     pre_scripts = tree.xpath("//spiffworkflow:preScript", namespaces=nsmap)
-    post_scripts = tree.xpath("//spiffworkflow:postScript", namespaces=nsmap)
 
     # Check script tasks for get_current_user() calls
     for task in script_tasks:
@@ -34,20 +33,17 @@ def check_script_and_prescript_elements(tree, bpmn_file_path: str) -> None:
             print(f'Found get_current_user() in script task {task.get("id")} of file {bpmn_file_path}')
 
     # Check preScript elements for get_current_user() calls
-    for pre_script in pre_scripts:
-        if pre_script is not None and pre_script.text is not None and "get_current_user()" in pre_script.text:
-            # Get the parent of the parent to find the actual BPMN element
-            parent = pre_script.getparent().getparent()
-            if parent.tag != "{http://www.omg.org/spec/BPMN/20100524/MODEL}manualTask" and parent.tag != "{http://www.omg.org/spec/BPMN/20100524/MODEL}userTask":
-                print(f'Found get_current_user() in preScript of {parent.tag} with id {parent.get("id")} in file {bpmn_file_path}')
-    # Check postScript elements for get_current_user() calls
-    for post_script in post_scripts:
-        if post_script is not None and post_script.text is not None and "get_current_user()" in post_script.text:
-            # Get the parent of the parent to find the actual BPMN element
-            parent = post_script.getparent().getparent()
-            if parent.tag != "{http://www.omg.org/spec/BPMN/20100524/MODEL}manualTask" and parent.tag != "{http://www.omg.org/spec/BPMN/20100524/MODEL}userTask":
-                print(f'Found get_current_user() in postScript of {parent.tag} with id {parent.get("id")} in file {bpmn_file_path}')
+    check_scripts_for_get_current_user(pre_scripts, bpmn_file_path, "preScript")
+    post_scripts = tree.xpath("//spiffworkflow:postScript", namespaces=nsmap)
+    check_scripts_for_get_current_user(post_scripts, bpmn_file_path, "postScript")
 
+def check_scripts_for_get_current_user(scripts, bpmn_file_path: str, script_type: str) -> None:
+    for script in scripts:
+        if script is not None and script.text is not None and "get_current_user()" in script.text:
+            # Get the parent of the parent to find the actual BPMN element
+            parent = script.getparent().getparent()
+            if parent.tag != "{http://www.omg.org/spec/BPMN/20100524/MODEL}manualTask" and parent.tag != "{http://www.omg.org/spec/BPMN/20100524/MODEL}userTask":
+                print(f'Found get_current_user() in {script_type} of {parent.tag} with id {parent.get("id")} in file {bpmn_file_path}')
 
 def main() -> NoReturn:
     app = create_app()

--- a/spiffworkflow-backend/bin/lint_get_current_user_scripts.py
+++ b/spiffworkflow-backend/bin/lint_get_current_user_scripts.py
@@ -43,9 +43,11 @@ def check_scripts_for_get_current_user(scripts, bpmn_file_path: str, script_type
         if script is not None and script.text is not None and "get_current_user()" in script.text:
             # Get the parent of the parent to find the actual BPMN element
             parent = script.getparent().getparent()
-            if parent.tag != "{http://www.omg.org/spec/BPMN/20100524/MODEL}manualTask" and parent.tag != "{http://www.omg.org/spec/BPMN/20100524/MODEL}userTask":
-                relative_path = os.path.relpath(bpmn_file_path, root_path)
-                print(f'Found get_current_user() in {script_type} of {parent.tag} with id {parent.get("id")} in file {relative_path}')
+            relative_path = os.path.relpath(bpmn_file_path, root_path)
+            tag_without_namespace = etree.QName(parent.tag).localname
+            if tag_without_namespace not in ["manualTask", "userTask"]:
+                print(f'Found get_current_user() in {script_type} of {tag_without_namespace} with id {parent.get("id")} in file {relative_path}')
+
 
 def main() -> NoReturn:
     app = create_app()

--- a/spiffworkflow-backend/bin/lint_get_current_user_scripts.py
+++ b/spiffworkflow-backend/bin/lint_get_current_user_scripts.py
@@ -1,4 +1,5 @@
 import glob
+import os
 from typing import NoReturn
 
 from lxml import etree
@@ -12,21 +13,47 @@ def find_script_tasks_with_get_current_user(bpmn_file_path: str) -> None:
         except etree.XMLSyntaxError:
             print(f"Error parsing XML in file {bpmn_file_path}. Please check for syntax issues.")
             return
-        # Define the namespace map to search for elements
-        nsmap = {"bpmn": "http://www.omg.org/spec/BPMN/20100524/MODEL"}
-        # Find all script tasks
-        script_tasks = tree.xpath("//bpmn:scriptTask", namespaces=nsmap)
-        for task in script_tasks:
-            script = task.find("bpmn:script", namespaces=nsmap)
-            if script is not None and "get_current_user()" in script.text:
-                print(f'Found get_current_user() in script task {task.get("id")} of file {bpmn_file_path}')
+        check_script_and_prescript_elements(tree, bpmn_file_path)
+
+
+def check_script_and_prescript_elements(tree, bpmn_file_path: str) -> None:
+    # Define the namespace map to search for elements
+    nsmap = {
+        "bpmn": "http://www.omg.org/spec/BPMN/20100524/MODEL",
+        "spiffworkflow": "http://spiffworkflow.org/bpmn/schema/1.0/core"
+    }
+    # Find all script tasks and preScript elements
+    script_tasks = tree.xpath("//bpmn:scriptTask", namespaces=nsmap)
+    pre_scripts = tree.xpath("//spiffworkflow:preScript", namespaces=nsmap)
+    post_scripts = tree.xpath("//spiffworkflow:postScript", namespaces=nsmap)
+
+    # Check script tasks for get_current_user() calls
+    for task in script_tasks:
+        script = task.find("bpmn:script", namespaces=nsmap)
+        if script is not None and script.text is not None and "get_current_user()" in script.text:
+            print(f'Found get_current_user() in script task {task.get("id")} of file {bpmn_file_path}')
+
+    # Check preScript elements for get_current_user() calls
+    for pre_script in pre_scripts:
+        if pre_script is not None and pre_script.text is not None and "get_current_user()" in pre_script.text:
+            # Get the parent of the parent to find the actual BPMN element
+            parent = pre_script.getparent().getparent()
+            if parent.tag != "{http://www.omg.org/spec/BPMN/20100524/MODEL}manualTask" and parent.tag != "{http://www.omg.org/spec/BPMN/20100524/MODEL}userTask":
+                print(f'Found get_current_user() in preScript of {parent.tag} with id {parent.get("id")} in file {bpmn_file_path}')
+    # Check postScript elements for get_current_user() calls
+    for post_script in post_scripts:
+        if post_script is not None and post_script.text is not None and "get_current_user()" in post_script.text:
+            # Get the parent of the parent to find the actual BPMN element
+            parent = post_script.getparent().getparent()
+            if parent.tag != "{http://www.omg.org/spec/BPMN/20100524/MODEL}manualTask" and parent.tag != "{http://www.omg.org/spec/BPMN/20100524/MODEL}userTask":
+                print(f'Found get_current_user() in postScript of {parent.tag} with id {parent.get("id")} in file {bpmn_file_path}')
 
 
 def main() -> NoReturn:
     app = create_app()
     with app.app_context():
         # Search for BPMN files and check for get_current_user() calls in script tasks
-        bpmn_files = glob.glob("tests/data/**/*.bpmn", recursive=True)
+        bpmn_files = glob.glob(os.path.expanduser("~/projects/github/status-im/process-models/**/*.bpmn"), recursive=True)
         for bpmn_file in bpmn_files:
             find_script_tasks_with_get_current_user(bpmn_file)
 

--- a/spiffworkflow-backend/bin/lint_get_current_user_scripts.py
+++ b/spiffworkflow-backend/bin/lint_get_current_user_scripts.py
@@ -1,3 +1,4 @@
+from spiffworkflow_backend.services.file_system_service import FileSystemService
 import glob
 import os
 from typing import NoReturn
@@ -6,17 +7,17 @@ from lxml import etree
 from spiffworkflow_backend import create_app
 
 
-def find_script_tasks_with_get_current_user(bpmn_file_path: str) -> None:
+def find_script_tasks_with_get_current_user(bpmn_file_path: str, root_path: str) -> None:
     with open(bpmn_file_path, encoding="utf-8") as bpmn_file:
         try:
             tree = etree.parse(bpmn_file)
         except etree.XMLSyntaxError:
             print(f"Error parsing XML in file {bpmn_file_path}. Please check for syntax issues.")
             return
-        check_script_and_prescript_elements(tree, bpmn_file_path)
+        check_script_and_prescript_elements(tree, bpmn_file_path, root_path)
 
 
-def check_script_and_prescript_elements(tree, bpmn_file_path: str) -> None:
+def check_script_and_prescript_elements(tree, bpmn_file_path: str, root_path: str) -> None:
     # Define the namespace map to search for elements
     nsmap = {
         "bpmn": "http://www.omg.org/spec/BPMN/20100524/MODEL",
@@ -33,25 +34,27 @@ def check_script_and_prescript_elements(tree, bpmn_file_path: str) -> None:
             print(f'Found get_current_user() in script task {task.get("id")} of file {bpmn_file_path}')
 
     # Check preScript elements for get_current_user() calls
-    check_scripts_for_get_current_user(pre_scripts, bpmn_file_path, "preScript")
+    check_scripts_for_get_current_user(pre_scripts, bpmn_file_path, "preScript", root_path)
     post_scripts = tree.xpath("//spiffworkflow:postScript", namespaces=nsmap)
-    check_scripts_for_get_current_user(post_scripts, bpmn_file_path, "postScript")
+    check_scripts_for_get_current_user(post_scripts, bpmn_file_path, "postScript", root_path)
 
-def check_scripts_for_get_current_user(scripts, bpmn_file_path: str, script_type: str) -> None:
+def check_scripts_for_get_current_user(scripts, bpmn_file_path: str, script_type: str, root_path: str) -> None:
     for script in scripts:
         if script is not None and script.text is not None and "get_current_user()" in script.text:
             # Get the parent of the parent to find the actual BPMN element
             parent = script.getparent().getparent()
             if parent.tag != "{http://www.omg.org/spec/BPMN/20100524/MODEL}manualTask" and parent.tag != "{http://www.omg.org/spec/BPMN/20100524/MODEL}userTask":
-                print(f'Found get_current_user() in {script_type} of {parent.tag} with id {parent.get("id")} in file {bpmn_file_path}')
+                relative_path = os.path.relpath(bpmn_file_path, root_path)
+                print(f'Found get_current_user() in {script_type} of {parent.tag} with id {parent.get("id")} in file {relative_path}')
 
 def main() -> NoReturn:
     app = create_app()
     with app.app_context():
+        hot_dir = FileSystemService.root_path()
         # Search for BPMN files and check for get_current_user() calls in script tasks
-        bpmn_files = glob.glob(os.path.expanduser("~/projects/github/status-im/process-models/**/*.bpmn"), recursive=True)
+        bpmn_files = glob.glob(os.path.expanduser(f"{hot_dir}/**/*.bpmn"), recursive=True)
         for bpmn_file in bpmn_files:
-            find_script_tasks_with_get_current_user(bpmn_file)
+            find_script_tasks_with_get_current_user(bpmn_file, hot_dir)
 
 
 if __name__ == "__main__":

--- a/spiffworkflow-backend/bin/lint_get_current_user_scripts.py
+++ b/spiffworkflow-backend/bin/lint_get_current_user_scripts.py
@@ -1,0 +1,35 @@
+import glob
+from typing import NoReturn
+
+from lxml import etree
+from spiffworkflow_backend import create_app
+
+
+def find_script_tasks_with_get_current_user(bpmn_file_path: str) -> None:
+    with open(bpmn_file_path, encoding="utf-8") as bpmn_file:
+        try:
+            tree = etree.parse(bpmn_file)
+        except etree.XMLSyntaxError:
+            print(f"Error parsing XML in file {bpmn_file_path}. Please check for syntax issues.")
+            return
+        # Define the namespace map to search for elements
+        nsmap = {"bpmn": "http://www.omg.org/spec/BPMN/20100524/MODEL"}
+        # Find all script tasks
+        script_tasks = tree.xpath("//bpmn:scriptTask", namespaces=nsmap)
+        for task in script_tasks:
+            script = task.find("bpmn:script", namespaces=nsmap)
+            if script is not None and "get_current_user()" in script.text:
+                print(f'Found get_current_user() in script task {task.get("id")} of file {bpmn_file_path}')
+
+
+def main() -> NoReturn:
+    app = create_app()
+    with app.app_context():
+        # Search for BPMN files and check for get_current_user() calls in script tasks
+        bpmn_files = glob.glob("tests/data/**/*.bpmn", recursive=True)
+        for bpmn_file in bpmn_files:
+            find_script_tasks_with_get_current_user(bpmn_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_model_test_runner_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_model_test_runner_service.py
@@ -29,6 +29,7 @@ from spiffworkflow_backend.scripts.script import Script
 from spiffworkflow_backend.services.custom_parser import MyCustomParser
 from spiffworkflow_backend.services.jinja_service import JinjaHelpers
 from spiffworkflow_backend.services.process_instance_processor import CustomScriptEngineEnvironment
+from spiffworkflow_backend.services.spec_file_service import SpecFileService
 
 DEFAULT_NSMAP = {
     "bpmn": "http://www.omg.org/spec/BPMN/20100524/MODEL",
@@ -283,11 +284,9 @@ class ProcessModelTestRunnerMostlyPureSpiffDelegate(ProcessModelTestRunnerDelega
         parser.add_dmn_files_by_glob(dmn_file_glob)
 
     def _get_etree_from_bpmn_file(self, bpmn_file: str) -> etree._Element:
-        data = None
         with open(bpmn_file, "rb") as f_handle:
             data = f_handle.read()
-        etree_xml_parser = etree.XMLParser(resolve_entities=False)
-        return etree.fromstring(data, parser=etree_xml_parser)  # noqa: S320
+        return SpecFileService.get_etree_from_xml_bytes(data)
 
     def _find_related_bpmn_files(self, bpmn_file: str) -> list[str]:
         related_bpmn_files = []

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/spec_file_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/spec_file_service.py
@@ -56,15 +56,17 @@ class SpecFileService(FileSystemService):
 
     @classmethod
     def get_references_for_file(cls, file: File, process_model_info: ProcessModelInfo) -> list[Reference]:
-        full_file_path = SpecFileService.full_file_path(process_model_info, file.name)
-        file_contents: bytes = b""
-        with open(full_file_path) as f:
-            file_contents = f.read().encode()
+        full_file_path = cls.full_file_path(process_model_info, file.name)
+        with open(full_file_path, "rb") as f:
+            file_contents = f.read()
         return cls.get_references_for_file_contents(process_model_info, file.name, file_contents)
 
+    # This is designed to isolate xml parsing, which is a security issue, and make it as safe as possible.
+    # S320 indicates that xml parsing with lxml is unsafe. To mitigate this, we add options to the parser
+    # to make it as safe as we can. No exploits have been demonstrated with this parser, but we will try to stay alert.
     @classmethod
     def get_etree_from_xml_bytes(cls, binary_data: bytes) -> etree.Element:
-        etree_xml_parser = etree.XMLParser(resolve_entities=False)
+        etree_xml_parser = etree.XMLParser(resolve_entities=False, remove_comments=True, no_network=True)
         return etree.fromstring(binary_data, parser=etree_xml_parser)  # noqa: S320
 
     @classmethod


### PR DESCRIPTION
also puts xml parsing in one place and makes it a little safer.
also uses ruff check to avoid deprecation of `ruff .`
deals with comment on #773 about using get_current_user breaking some instances.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a script to identify uses of `get_current_user()` in BPMN files, enhancing security and compliance checks.

- **Refactor**
	- Improved the autofix process by integrating `check` with `--fix` in the `Makefile` and `run_pyl` script for more comprehensive code quality checks.
	- Enhanced XML parsing security and efficiency in the process model testing service by updating method implementations for better file handling and parser configuration.

- **Chores**
	- Updated internal scripts and services for better performance and security compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->