### PR TITLE
Updates for using vite in the dev containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ IN_FRONTEND ?= $(DOCKER_COMPOSE) run $(FRONTEND_CONTAINER)
 SPIFFWORKFLOW_BACKEND_ENV ?= local_development
 
 BACKEND_SQLITE_FILE ?= src/instance/db_$(SPIFFWORKFLOW_BACKEND_ENV).sqlite3
+NODE_MODULES_DIR ?= spiffworkflow-frontend/node_modules
 JUST ?=
 
 YML_FILES := -f docker-compose.yml \
@@ -94,6 +95,11 @@ fe-logs:
 fe-npm-i:
 	$(IN_FRONTEND) npm i && git checkout -- spiffworkflow-frontend/package-lock.json
 
+fe-npm-rm:
+	@if [ -d "$(NODE_MODULES_DIR)" ]; then \
+		rm -rf "$(NODE_MODULES_DIR)"; \
+	fi
+
 fe-sh:
 	$(IN_FRONTEND) /bin/bash
 
@@ -127,6 +133,6 @@ take-ownership:
 	start-dev stop-dev \
 	be-clear-log-file be-logs be-mypy be-poetry-i be-poetry-lock be-poetry-rm \
 	be-db-clean be-db-migrate be-sh be-sqlite be-tests be-tests-par \
-	fe-lint-fix fe-logs fe-npm-i fe-sh fe-unimported  \
+	fe-lint-fix fe-logs fe-npm-i fe-npm-rm fe-sh fe-unimported  \
 	poetry-i poetry-rm pre-commit ruff run-pyl \
 	take-ownership

--- a/spiffworkflow-frontend/dev.Dockerfile
+++ b/spiffworkflow-frontend/dev.Dockerfile
@@ -2,4 +2,4 @@ FROM node:20.8.1-bookworm-slim AS base
 
 WORKDIR /app
 
-CMD ["npm", "run", "docker:start"]
+CMD ["npm", "run", "start"]

--- a/spiffworkflow-frontend/vite.config.ts
+++ b/spiffworkflow-frontend/vite.config.ts
@@ -6,6 +6,9 @@ import { defineConfig } from 'vite';
 
 import viteTsconfigPaths from 'vite-tsconfig-paths';
 
+let host = process.env.HOST ?? 'localhost';
+let port = process.env.PORT ? parseInt(process.env.PORT) : 7001;
+
 export default defineConfig({
   // depending on your application, base can also be "/"
   base: '/',
@@ -25,10 +28,12 @@ export default defineConfig({
   server: {
     // this ensures that the browser DOES NOT open upon server start
     open: false,
-    port: 7001,
+    host,
+    port,
   },
   preview: {
-    port: 7001,
+    host,
+    port,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Updates to get the frontend dev container back to working post vite. After pulling this fix you will need to `make stop-dev fe-npm-rm build-images fe-npm-i start-dev` - this change requires more make commands than usual.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved management of frontend node modules in build scripts.

- **New Features**
	- Enhanced server configurability with new environment variable-based settings.

- **Refactor**
	- Updated Dockerfile command to streamline container startup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->