### PR TITLE
Allow updating task data via a dictionary

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/scripts/update_task_data_with_dictionary.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/scripts/update_task_data_with_dictionary.py
@@ -1,9 +1,5 @@
 from typing import Any
 
-from spiffworkflow_backend.data_stores.crud import DataStoreCRUD
-from spiffworkflow_backend.models.db import db
-from spiffworkflow_backend.models.kkv_data_store import KKVDataStoreModel
-from spiffworkflow_backend.models.kkv_data_store_entry import KKVDataStoreEntryModel
 from spiffworkflow_backend.models.script_attributes_context import ScriptAttributesContext
 from spiffworkflow_backend.scripts.script import Script
 
@@ -15,12 +11,11 @@ class UpdateTaskDataWithDictionary(Script):
         return False
 
     def get_description(self) -> str:
-        return (
-            "Updates task data, creating or updating variables named 'key' with 'value' from the given dictionary."
-        )
+        return "Updates task data, creating or updating variables named 'key' with 'value' from the given dictionary."
 
     def run(self, script_attributes_context: ScriptAttributesContext, *args: Any, **kwargs: Any) -> Any:
         updates = args[0]
         spiff_task = script_attributes_context.task
 
-        spiff_task.data.update(updates)
+        if spiff_task:
+            spiff_task.data.update(updates)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/scripts/update_task_data_with_dictionary.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/scripts/update_task_data_with_dictionary.py
@@ -14,6 +14,8 @@ class UpdateTaskDataWithDictionary(Script):
         return "Updates task data, creating or updating variables named 'key' with 'value' from the given dictionary."
 
     def run(self, script_attributes_context: ScriptAttributesContext, *args: Any, **kwargs: Any) -> Any:
+        if not args or not isinstance(args[0], dict):
+            raise ValueError("Expected a dictionary as the first argument.")
         updates = args[0]
         spiff_task = script_attributes_context.task
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/scripts/update_task_data_with_dictionary.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/scripts/update_task_data_with_dictionary.py
@@ -1,0 +1,26 @@
+from typing import Any
+
+from spiffworkflow_backend.data_stores.crud import DataStoreCRUD
+from spiffworkflow_backend.models.db import db
+from spiffworkflow_backend.models.kkv_data_store import KKVDataStoreModel
+from spiffworkflow_backend.models.kkv_data_store_entry import KKVDataStoreEntryModel
+from spiffworkflow_backend.models.script_attributes_context import ScriptAttributesContext
+from spiffworkflow_backend.scripts.script import Script
+
+
+class UpdateTaskDataWithDictionary(Script):
+    @staticmethod
+    def requires_privileged_permissions() -> bool:
+        """We have deemed this function safe to run without elevated permissions."""
+        return False
+
+    def get_description(self) -> str:
+        return (
+            "Updates task data, creating or updating variables named 'key' with 'value' from the given dictionary."
+        )
+
+    def run(self, script_attributes_context: ScriptAttributesContext, *args: Any, **kwargs: Any) -> Any:
+        updates = args[0]
+        spiff_task = script_attributes_context.task
+
+        spiff_task.data.update(updates)


### PR DESCRIPTION
Adds support for a script:

```
update_task_data_with_dictionary({
    "x": 1,
    "y": 2,
    "z": [{"a": [1, 2, 3]}]
})
```

that when run results in `x`, `y` and `z` being variables in task data. Initially for the Iplicit use case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a script that updates task data by creating or updating variables from a provided dictionary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->