### PR TITLE
Reset task in call activity fix

### DIFF
--- a/spiffworkflow-backend/bin/get_bpmn_json_for_process_instance.py
+++ b/spiffworkflow-backend/bin/get_bpmn_json_for_process_instance.py
@@ -6,7 +6,6 @@ from spiffworkflow_backend.services.process_instance_processor import ProcessIns
 
 
 def main(process_instance_id: str) -> None:
-    """Main."""
     app = create_app()
     with app.app_context():
         process_instance = ProcessInstanceModel.query.filter_by(id=process_instance_id).first()
@@ -15,7 +14,9 @@ def main(process_instance_id: str) -> None:
         if not process_instance:
             raise Exception(f"Could not find a process instance with id: {process_instance_id}")
 
-        processor = ProcessInstanceProcessor(process_instance)
+        processor = ProcessInstanceProcessor(
+            process_instance, include_completed_subprocesses=True, include_task_data_for_completed_tasks=True
+        )
         processor.dump_to_disk(file_path)
         print(f"Saved to {file_path}")
 

--- a/spiffworkflow-backend/tests/data/service-task-with-data-obj/main.bpmn
+++ b/spiffworkflow-backend/tests/data/service-task-with-data-obj/main.bpmn
@@ -34,7 +34,8 @@
       <bpmn:dataOutputAssociation id="DataOutputAssociation_1fxfphs">
         <bpmn:targetRef>DataObjectReference_0qfbjfj</bpmn:targetRef>
       </bpmn:dataOutputAssociation>
-      <bpmn:script>top_level_data_object = "a"</bpmn:script>
+      <bpmn:script>top_level_data_object = "a"
+top_level_var = "b"</bpmn:script>
     </bpmn:scriptTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_processor.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_processor.py
@@ -918,7 +918,9 @@ class TestProcessInstanceProcessor(BaseTest):
             process_model_source_directory="service-task-with-data-obj",
         )
         process_instance = self.create_process_instance_from_process_model(process_model=process_model)
-        processor = ProcessInstanceProcessor(process_instance)
+        processor = ProcessInstanceProcessor(
+            process_instance, include_completed_subprocesses=True, include_task_data_for_completed_tasks=True
+        )
         processor.do_engine_steps(save=True)
 
         bpmn_process_dict_initial = processor.serialize()
@@ -940,7 +942,9 @@ class TestProcessInstanceProcessor(BaseTest):
         ProcessInstanceProcessor.persist_bpmn_process_dict(
             bpmn_process_dict_initial, process_instance_model=process_instance, bpmn_definition_to_task_definitions_mappings={}
         )
-        processor = ProcessInstanceProcessor(process_instance)
+        processor = ProcessInstanceProcessor(
+            process_instance, include_completed_subprocesses=True, include_task_data_for_completed_tasks=True
+        )
         bpmn_process_dict_after = processor.serialize()
         self.round_last_state_change(bpmn_process_dict_after)
         self.round_last_state_change(bpmn_process_dict_initial)
@@ -958,7 +962,9 @@ class TestProcessInstanceProcessor(BaseTest):
             process_model_source_directory="service-task-with-data-obj",
         )
         process_instance = self.create_process_instance_from_process_model(process_model=process_model)
-        processor = ProcessInstanceProcessor(process_instance)
+        processor = ProcessInstanceProcessor(
+            process_instance, include_completed_subprocesses=True, include_task_data_for_completed_tasks=True
+        )
         processor.do_engine_steps(save=True)
 
         bpmn_process_dict_initial = processor.serialize()
@@ -966,7 +972,9 @@ class TestProcessInstanceProcessor(BaseTest):
         ProcessInstanceProcessor.persist_bpmn_process_dict(
             bpmn_process_dict_initial, process_instance_model=process_instance, bpmn_definition_to_task_definitions_mappings={}
         )
-        processor = ProcessInstanceProcessor(process_instance)
+        processor = ProcessInstanceProcessor(
+            process_instance, include_completed_subprocesses=True, include_task_data_for_completed_tasks=True
+        )
         bpmn_process_dict_after = processor.serialize()
         self.round_last_state_change(bpmn_process_dict_after)
         self.round_last_state_change(bpmn_process_dict_initial)


### PR DESCRIPTION
Some fixes to import / export of process instances. The main issue was we were not loading all completed tasks and data from the tests and script.