### PR TITLE
Task show toggle instructions

### DIFF
--- a/spiffworkflow-frontend/src/components/InstructionsForEndUser.tsx
+++ b/spiffworkflow-frontend/src/components/InstructionsForEndUser.tsx
@@ -14,6 +14,8 @@ type OwnProps = {
   taskInstructionForEndUser?: TaskInstructionForEndUser;
   defaultMessage?: string;
   allowCollapse?: boolean;
+  expandedByDefault?: boolean;
+  className?: string;
 };
 
 export default function InstructionsForEndUser({
@@ -21,6 +23,8 @@ export default function InstructionsForEndUser({
   taskInstructionForEndUser,
   defaultMessage = '',
   allowCollapse = false,
+  expandedByDefault = false,
+  className,
 }: OwnProps) {
   const [collapsed, setCollapsed] = useState<boolean>(false);
   const [collapsable, setCollapsable] = useState<boolean>(false);
@@ -62,12 +66,16 @@ export default function InstructionsForEndUser({
         wordCount(instructions) > maxWordCount)
     ) {
       setCollapsable(true);
-      setCollapsed(true);
+      if (expandedByDefault) {
+        setCollapsed(false);
+      } else {
+        setCollapsed(true);
+      }
     } else {
       setCollapsable(false);
       setCollapsed(false);
     }
-  }, [allowCollapse, instructions]);
+  }, [allowCollapse, instructions, expandedByDefault]);
 
   const toggleCollapse = () => {
     setCollapsed(!collapsed);
@@ -79,6 +87,7 @@ export default function InstructionsForEndUser({
         <Toggle
           labelA="Show More"
           labelB="Show Less"
+          defaultToggled={!collapsed}
           onToggle={toggleCollapse}
           id="toggle-collapse"
         />
@@ -87,15 +96,15 @@ export default function InstructionsForEndUser({
     return null;
   };
 
-  let className = 'markdown';
+  let mdClassName = 'markdown';
   if (collapsed) {
-    className += ' markdown-collapsed';
+    mdClassName += ' markdown-collapsed';
   }
 
   if (instructions) {
     return (
-      <div>
-        <div className={className}>
+      <div className={className}>
+        <div className={mdClassName}>
           {/*
           https://www.npmjs.com/package/@uiw/react-md-editor switches to dark mode by default by respecting @media (prefers-color-scheme: dark)
           This makes it look like our site is broken, so until the rest of the site supports dark mode, turn off dark mode for this component.

--- a/spiffworkflow-frontend/src/components/InstructionsForEndUser.tsx
+++ b/spiffworkflow-frontend/src/components/InstructionsForEndUser.tsx
@@ -14,7 +14,6 @@ type OwnProps = {
   taskInstructionForEndUser?: TaskInstructionForEndUser;
   defaultMessage?: string;
   allowCollapse?: boolean;
-  expandedByDefault?: boolean;
   className?: string;
 };
 
@@ -23,7 +22,6 @@ export default function InstructionsForEndUser({
   taskInstructionForEndUser,
   defaultMessage = '',
   allowCollapse = false,
-  expandedByDefault = false,
   className,
 }: OwnProps) {
   const [collapsed, setCollapsed] = useState<boolean>(false);
@@ -66,16 +64,12 @@ export default function InstructionsForEndUser({
         wordCount(instructions) > maxWordCount)
     ) {
       setCollapsable(true);
-      if (expandedByDefault) {
-        setCollapsed(false);
-      } else {
-        setCollapsed(true);
-      }
+      setCollapsed(true);
     } else {
       setCollapsable(false);
       setCollapsed(false);
     }
-  }, [allowCollapse, instructions, expandedByDefault]);
+  }, [allowCollapse, instructions]);
 
   const toggleCollapse = () => {
     setCollapsed(!collapsed);
@@ -87,7 +81,6 @@ export default function InstructionsForEndUser({
         <Toggle
           labelA="Show More"
           labelB="Show Less"
-          defaultToggled={!collapsed}
           onToggle={toggleCollapse}
           id="toggle-collapse"
         />

--- a/spiffworkflow-frontend/src/routes/TaskShow.tsx
+++ b/spiffworkflow-frontend/src/routes/TaskShow.tsx
@@ -463,7 +463,14 @@ export default function TaskShow() {
   if (basicTask && taskData) {
     pageElements.push({
       key: 'instructions-for-end-user',
-      component: <InstructionsForEndUser task={taskWithTaskData} />,
+      component: (
+        <InstructionsForEndUser
+          task={taskWithTaskData}
+          allowCollapse
+          expandedByDefault
+          className="with-bottom-margin"
+        />
+      ),
     });
     pageElements.push({ key: 'main-form', component: formElement() });
   } else if (!atLeastOneTaskFetchHasError) {

--- a/spiffworkflow-frontend/src/routes/TaskShow.tsx
+++ b/spiffworkflow-frontend/src/routes/TaskShow.tsx
@@ -467,7 +467,6 @@ export default function TaskShow() {
         <InstructionsForEndUser
           task={taskWithTaskData}
           allowCollapse
-          expandedByDefault
           className="with-bottom-margin"
         />
       ),


### PR DESCRIPTION
Implements #1425 

This adds the `allowCollapse` to the TaskShow InstructionsForEndUser component so the user can expand and collapse the instructions.