### PR TITLE
rjsf-radio-button-spacing

### DIFF
--- a/spiffworkflow-frontend/src/rjsf/carbon_theme/RadioWidget/RadioWidget.tsx
+++ b/spiffworkflow-frontend/src/rjsf/carbon_theme/RadioWidget/RadioWidget.tsx
@@ -61,6 +61,7 @@ function RadioWidget({
       onBlur={_onBlur}
       onFocus={_onFocus}
       orientation={row ? 'horizontal' : 'vertical'}
+      className="radio-button-group"
     >
       {Array.isArray(enumOptions) &&
         enumOptions.map((option) => {

--- a/spiffworkflow-frontend/src/rjsf/carbon_theme/index.css
+++ b/spiffworkflow-frontend/src/rjsf/carbon_theme/index.css
@@ -122,3 +122,7 @@
   /* justify-content: center; */
   align-items: center;
 }
+
+.rjsf .radio-button-group {
+  padding-top: 0.5rem;
+}


### PR DESCRIPTION
Added a class to the rjsf radio button group to add spacing above it.

![image](https://github.com/sartography/spiff-arena/assets/2487833/b099fe38-92f0-40da-8996-49564e483e00)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the radio button group with additional styling for better visual appeal and usability.

- **Style**
	- Updated the padding of the radio button group for improved layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->