### PR TITLE
end-event-instruction-fix

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/jinja_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/jinja_service.py
@@ -38,7 +38,9 @@ class JinjaHelpers:
 
 class JinjaService:
     @classmethod
-    def render_instructions_for_end_user(cls, task: TaskModel | SpiffTask | None = None, extensions: dict | None = None) -> str:
+    def render_instructions_for_end_user(
+        cls, task: TaskModel | SpiffTask | None = None, extensions: dict | None = None, task_data: dict | None = None
+    ) -> str:
         """Assure any instructions for end user are processed for jinja syntax."""
         if extensions is None:
             if isinstance(task, TaskModel):
@@ -48,7 +50,7 @@ class JinjaService:
         if extensions and "instructionsForEndUser" in extensions:
             if extensions["instructionsForEndUser"]:
                 try:
-                    return cls.render_jinja_template(extensions["instructionsForEndUser"], task)
+                    return cls.render_jinja_template(extensions["instructionsForEndUser"], task, task_data=task_data)
                 except TaskModelError as wfe:
                     wfe.add_note("Failed to render instructions for end user.")
                     raise ApiError.from_workflow_exception("instructions_error", str(wfe), exp=wfe) from wfe


### PR DESCRIPTION
Fixes #1435

This updates the interstitial endpoint to go to the db if the expected task with instructions does not have data. This is to work around the fact that we do not load task data for completed tasks anymore so the task data will not be there when we render the instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced task instructions rendering to include task-specific data, improving the clarity and relevance of instructions for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->