### PR TITLE
remove the collapse option from task show instructions

### DIFF
--- a/spiffworkflow-frontend/src/routes/TaskShow.tsx
+++ b/spiffworkflow-frontend/src/routes/TaskShow.tsx
@@ -466,7 +466,6 @@ export default function TaskShow() {
       component: (
         <InstructionsForEndUser
           task={taskWithTaskData}
-          allowCollapse
           className="with-bottom-margin"
         />
       ),


### PR DESCRIPTION
Supports #1425 #1434 

Remove this option and if it is desired in the future we will work a better design with the ui redesign.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the task display UI to no longer allow collapsing instructions for clarity and consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->