### PR TITLE
Numeric range tweaks

### DIFF
--- a/spiffworkflow-frontend/src/components/CustomForm.tsx
+++ b/spiffworkflow-frontend/src/components/CustomForm.tsx
@@ -262,9 +262,7 @@ export default function CustomForm({
       (formDataToCheck[propertyKey].min === undefined ||
         formDataToCheck[propertyKey].max === undefined)
     ) {
-      errors[propertyKey].addError(
-        `must have valid Minimum and Maximum on ${propertyKey}`
-      );
+      errors[propertyKey].addError('must have valid Minimum and Maximum');
     }
     if (
       formDataToCheck[propertyKey].min <

--- a/spiffworkflow-frontend/src/rjsf/custom_widgets/NumericRangeField/NumericRangeField.tsx
+++ b/spiffworkflow-frontend/src/rjsf/custom_widgets/NumericRangeField/NumericRangeField.tsx
@@ -139,7 +139,7 @@ export default function NumericRangeField({
           <div className="markdown-field-desc-text">
             <DescriptionFieldTemplate
               id={descriptionId(idSchema)}
-              description={`${description} OUR DESCR`}
+              description={description}
               schema={schema}
               uiSchema={uiSchema}
               registry={registry}

--- a/spiffworkflow-frontend/src/rjsf/custom_widgets/NumericRangeField/NumericRangeField.tsx
+++ b/spiffworkflow-frontend/src/rjsf/custom_widgets/NumericRangeField/NumericRangeField.tsx
@@ -117,17 +117,19 @@ export default function NumericRangeField({
   };
 
   let minHelperText = '';
-  if (minNumber !== undefined) {
-    minHelperText = `Min: ${formatNumberString(minNumber?.toString() || '')}`;
-  }
   let maxHelperText = '';
-  if (maxNumber !== undefined) {
-    maxHelperText = `Max: ${formatNumberString(maxNumber?.toString() || '')}`;
+  if (minNumber !== undefined || maxNumber !== undefined) {
+    minHelperText = `Min: ${
+      formatNumberString(minNumber?.toString() || '') || '∞'
+    }`;
+    maxHelperText = `Max: ${
+      formatNumberString(maxNumber?.toString() || '') || '∞'
+    }`;
   }
 
   return (
     <div className="numeric--range-field-wrapper">
-      <div className="numeric--range-field-label">
+      <div>
         <h5>
           {required
             ? commonAttributes.labelWithRequiredIndicator
@@ -137,7 +139,7 @@ export default function NumericRangeField({
           <div className="markdown-field-desc-text">
             <DescriptionFieldTemplate
               id={descriptionId(idSchema)}
-              description={description}
+              description={`${description} OUR DESCR`}
               schema={schema}
               uiSchema={uiSchema}
               registry={registry}

--- a/spiffworkflow-frontend/src/rjsf/custom_widgets/NumericRangeField/NumericRangeField.tsx
+++ b/spiffworkflow-frontend/src/rjsf/custom_widgets/NumericRangeField/NumericRangeField.tsx
@@ -120,7 +120,7 @@ export default function NumericRangeField({
   let maxHelperText = '';
   if (minNumber !== undefined || maxNumber !== undefined) {
     minHelperText = `Min: ${
-      formatNumberString(minNumber?.toString() || '') || '∞'
+      formatNumberString(minNumber?.toString() || '') || '-∞'
     }`;
     maxHelperText = `Max: ${
       formatNumberString(maxNumber?.toString() || '') || '∞'


### PR DESCRIPTION
This adds an infinity symbol is either min or max number is specified for a numeric range field but the other is not. This is an easy way to fix the layout issue mentioned in https://github.com/sartography/spiff-arena/issues/647#issuecomment-2071652688.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Simplified error messaging in the `CustomForm` for invalid numeric values.
	- Updated helper text logic in `NumericRangeField` to handle undefined minimum or maximum values, displaying '-∞' for min and '∞' for max when values are not set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->