### PR TITLE
load-parent-task-data

### DIFF
--- a/spiffworkflow-backend/bin/query_tasks
+++ b/spiffworkflow-backend/bin/query_tasks
@@ -13,15 +13,12 @@ db_name=spiffworkflow_backend_local_development
 mysql -uroot "$db_name" -e '
   select * from process_instance;
 
-  select t.guid as task_guid, t.state as task_state, td.bpmn_identifier as task_id, t.properties_json from task t
+  select t.guid as task_guid, t.state as task_state, td.bpmn_identifier as task_id, jad.data
+  from task t
   join task_definition td on td.id = t.task_definition_id
+  join json_data jad on jad.hash = t.json_data_hash
   where process_instance_id=(select max(id) from process_instance);
 
-  select bp.guid as bp_guid, bpd.bpmn_identifier as bp_identifier, bp.properties_json from bpmn_process bp
-  join bpmn_process_definition bpd on bpd.id = bp.bpmn_process_definition_id
-  join bpmn_process bpb on bpb.id = bp.direct_parent_process_id
-  join process_instance pi on bpb.id = pi.bpmn_process_id
-  where pi.id = (select max(id) from process_instance);
 '
 
 # mysql -uroot spiffworkflow_backend_local_development -e '\

--- a/spiffworkflow-backend/bin/query_tasks
+++ b/spiffworkflow-backend/bin/query_tasks
@@ -13,12 +13,15 @@ db_name=spiffworkflow_backend_local_development
 mysql -uroot "$db_name" -e '
   select * from process_instance;
 
-  select t.guid as task_guid, t.state as task_state, td.bpmn_identifier as task_id, jad.data
-  from task t
+  select t.guid as task_guid, t.state as task_state, td.bpmn_identifier as task_id, t.properties_json from task t
   join task_definition td on td.id = t.task_definition_id
-  join json_data jad on jad.hash = t.json_data_hash
   where process_instance_id=(select max(id) from process_instance);
 
+  select bp.guid as bp_guid, bpd.bpmn_identifier as bp_identifier, bp.properties_json from bpmn_process bp
+  join bpmn_process_definition bpd on bpd.id = bp.bpmn_process_definition_id
+  join bpmn_process bpb on bpb.id = bp.direct_parent_process_id
+  join process_instance pi on bpb.id = pi.bpmn_process_id
+  where pi.id = (select max(id) from process_instance);
 '
 
 # mysql -uroot spiffworkflow_backend_local_development -e '\

--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/task.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/task.py
@@ -92,10 +92,14 @@ class TaskModel(SpiffworkflowBaseDBModel):
     def json_data(self) -> dict:
         return JsonDataModel.find_data_dict_by_hash(self.json_data_hash)
 
-    def parent_task_model(self) -> TaskModel | None:
+    def parent_guid(self) -> str | None:
         if "parent" not in self.properties_json:
             return None
-        task_model: TaskModel = self.__class__.query.filter_by(guid=self.properties_json["parent"]).first()
+        parent_guid: str = self.properties_json["parent"]
+        return parent_guid
+
+    def parent_task_model(self) -> TaskModel | None:
+        task_model: TaskModel = self.__class__.query.filter_by(guid=self.parent_guid()).first()
         return task_model
 
     @classmethod


### PR DESCRIPTION
Supports #1359 

This updates task loading to include task data for CANCELLED tasks and the immediate parent of any relevant task. This helps to fix issues with parallel gateways.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data retrieval for tasks related to process instances with more detailed information.
  
- **Bug Fixes**
	- Improved handling of task relationships to ensure accuracy across parallel task branches.
	- Adjusted task state management to better support CANCELLED tasks in Gateways.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->