### PR TITLE
Config turn off threads

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
@@ -221,3 +221,6 @@ config_from_env("SPIFFWORKFLOW_BACKEND_DEBUG_TASK_CONSISTENCY", default=False)
 # adds the ProxyFix to Flask on http by processing the 'X-Forwarded-Proto' header
 # to make SpiffWorkflow aware that it should return https for the server urls etc rather than http.
 config_from_env("SPIFFWORKFLOW_BACKEND_USE_WERKZEUG_MIDDLEWARE_PROXY_FIX", default=False)
+
+# for DEUBGGING - turn off thread execution if tasks are possibly getting executed in an odd ordering
+config_from_env("SPIFFWORKFLOW_BACKEND_USE_THREADS_FOR_TASK_EXECUTION", default=True)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
@@ -222,5 +222,5 @@ config_from_env("SPIFFWORKFLOW_BACKEND_DEBUG_TASK_CONSISTENCY", default=False)
 # to make SpiffWorkflow aware that it should return https for the server urls etc rather than http.
 config_from_env("SPIFFWORKFLOW_BACKEND_USE_WERKZEUG_MIDDLEWARE_PROXY_FIX", default=False)
 
-# for DEUBGGING - turn off thread execution if tasks are possibly getting executed in an odd ordering
+# only for DEBUGGING - turn off threaded task execution.
 config_from_env("SPIFFWORKFLOW_BACKEND_USE_THREADS_FOR_TASK_EXECUTION", default=True)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
@@ -190,11 +190,8 @@ class ExecutionStrategy:
         # service tasks at once - many api calls, and then get those responses back without
         # waiting for each individual task to complete.
         futures = []
-        initial_order = []
-        did_complete_order = []
         with concurrent.futures.ThreadPoolExecutor() as executor:
             for spiff_task in engine_steps:
-                initial_order.append(f"{spiff_task.task_spec.bpmn_id}:{str(spiff_task.id)}")
                 self.delegate.will_complete_task(spiff_task)
                 futures.append(
                     executor.submit(
@@ -209,7 +206,6 @@ class ExecutionStrategy:
                 spiff_task = future.result()
 
             for spiff_task in engine_steps:
-                did_complete_order.append(f"{spiff_task.task_spec.bpmn_id}:{str(spiff_task.id)}")
                 self.delegate.did_complete_task(spiff_task)
 
     def _run_engine_steps_without_threads(

--- a/spiffworkflow-backend/tests/data/threads_with_script_timers/threads_with_script_timers.bpmn
+++ b/spiffworkflow-backend/tests/data/threads_with_script_timers/threads_with_script_timers.bpmn
@@ -16,17 +16,17 @@
     <bpmn:sequenceFlow id="Flow_1gjknxb" sourceRef="Gateway_0to34re" targetRef="Activity_0mj64s2" />
     <bpmn:sequenceFlow id="Flow_0cj2tia" sourceRef="Gateway_0to34re" targetRef="Activity_1dlqr5f" />
     <bpmn:sequenceFlow id="Flow_0pjsxm2" sourceRef="Gateway_0to34re" targetRef="Activity_1pndt6s" />
-    <bpmn:sequenceFlow id="Flow_08yg9t5" sourceRef="Activity_1srrljd" targetRef="Gateway_0ee2g9g" />
+    <bpmn:sequenceFlow id="Flow_08yg9t5" sourceRef="Activity_1srrljd" targetRef="Activity_0femqz9" />
     <bpmn:parallelGateway id="Gateway_0ee2g9g">
-      <bpmn:incoming>Flow_08yg9t5</bpmn:incoming>
-      <bpmn:incoming>Flow_03k3kx2</bpmn:incoming>
-      <bpmn:incoming>Flow_1pm1w0h</bpmn:incoming>
-      <bpmn:incoming>Flow_0e2holy</bpmn:incoming>
+      <bpmn:incoming>Flow_11fj5bn</bpmn:incoming>
+      <bpmn:incoming>Flow_02nckfs</bpmn:incoming>
+      <bpmn:incoming>Flow_0s3m7td</bpmn:incoming>
+      <bpmn:incoming>Flow_1nyxldz</bpmn:incoming>
       <bpmn:outgoing>Flow_0kguhla</bpmn:outgoing>
     </bpmn:parallelGateway>
-    <bpmn:sequenceFlow id="Flow_03k3kx2" sourceRef="Activity_0mj64s2" targetRef="Gateway_0ee2g9g" />
-    <bpmn:sequenceFlow id="Flow_1pm1w0h" sourceRef="Activity_1dlqr5f" targetRef="Gateway_0ee2g9g" />
-    <bpmn:sequenceFlow id="Flow_0e2holy" sourceRef="Activity_1pndt6s" targetRef="Gateway_0ee2g9g" />
+    <bpmn:sequenceFlow id="Flow_03k3kx2" sourceRef="Activity_0mj64s2" targetRef="Activity_0tchoum" />
+    <bpmn:sequenceFlow id="Flow_1pm1w0h" sourceRef="Activity_1dlqr5f" targetRef="Activity_0btwzqo" />
+    <bpmn:sequenceFlow id="Flow_0e2holy" sourceRef="Activity_1pndt6s" targetRef="Activity_0ggu1e4" />
     <bpmn:endEvent id="Event_0g4hezy">
       <bpmn:incoming>Flow_0kguhla</bpmn:incoming>
     </bpmn:endEvent>
@@ -55,6 +55,26 @@ c=1</bpmn:script>
       <bpmn:script>time.sleep(0.1)
 d=1</bpmn:script>
     </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_11fj5bn" sourceRef="Activity_0femqz9" targetRef="Gateway_0ee2g9g" />
+    <bpmn:sequenceFlow id="Flow_02nckfs" sourceRef="Activity_0tchoum" targetRef="Gateway_0ee2g9g" />
+    <bpmn:sequenceFlow id="Flow_0s3m7td" sourceRef="Activity_0btwzqo" targetRef="Gateway_0ee2g9g" />
+    <bpmn:sequenceFlow id="Flow_1nyxldz" sourceRef="Activity_0ggu1e4" targetRef="Gateway_0ee2g9g" />
+    <bpmn:scriptTask id="Activity_0ggu1e4" name="PaddingD">
+      <bpmn:incoming>Flow_0e2holy</bpmn:incoming>
+      <bpmn:outgoing>Flow_1nyxldz</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_0btwzqo" name="PaddingC">
+      <bpmn:incoming>Flow_1pm1w0h</bpmn:incoming>
+      <bpmn:outgoing>Flow_0s3m7td</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_0tchoum" name="PaddingB">
+      <bpmn:incoming>Flow_03k3kx2</bpmn:incoming>
+      <bpmn:outgoing>Flow_02nckfs</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_0femqz9" name="PaddingA">
+      <bpmn:incoming>Flow_08yg9t5</bpmn:incoming>
+      <bpmn:outgoing>Flow_11fj5bn</bpmn:outgoing>
+    </bpmn:scriptTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_pvfr8r8">
@@ -65,10 +85,10 @@ d=1</bpmn:script>
         <dc:Bounds x="45" y="15" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0wvflyk_di" bpmnElement="Gateway_0ee2g9g">
-        <dc:Bounds x="325" y="15" width="50" height="50" />
+        <dc:Bounds x="455" y="15" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0g4hezy_di" bpmnElement="Event_0g4hezy">
-        <dc:Bounds x="442" y="22" width="36" height="36" />
+        <dc:Bounds x="572" y="22" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1cr4mii_di" bpmnElement="Activity_1srrljd">
         <dc:Bounds x="160" y="0" width="100" height="80" />
@@ -84,6 +104,22 @@ d=1</bpmn:script>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1y62zlm_di" bpmnElement="Activity_1pndt6s">
         <dc:Bounds x="160" y="330" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0xdpg5u_di" bpmnElement="Activity_0tchoum">
+        <dc:Bounds x="310" y="110" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0xlvrqx_di" bpmnElement="Activity_0femqz9">
+        <dc:Bounds x="310" y="0" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0vfd6nh_di" bpmnElement="Activity_0btwzqo">
+        <dc:Bounds x="310" y="220" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ophz6v_di" bpmnElement="Activity_0ggu1e4">
+        <dc:Bounds x="310" y="330" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_0v5xitk_di" bpmnElement="Flow_0v5xitk">
@@ -111,26 +147,42 @@ d=1</bpmn:script>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_08yg9t5_di" bpmnElement="Flow_08yg9t5">
         <di:waypoint x="260" y="40" />
-        <di:waypoint x="325" y="40" />
+        <di:waypoint x="310" y="40" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_03k3kx2_di" bpmnElement="Flow_03k3kx2">
         <di:waypoint x="260" y="150" />
-        <di:waypoint x="350" y="150" />
-        <di:waypoint x="350" y="65" />
+        <di:waypoint x="310" y="150" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1pm1w0h_di" bpmnElement="Flow_1pm1w0h">
         <di:waypoint x="260" y="260" />
-        <di:waypoint x="350" y="260" />
-        <di:waypoint x="350" y="65" />
+        <di:waypoint x="310" y="260" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0e2holy_di" bpmnElement="Flow_0e2holy">
         <di:waypoint x="260" y="370" />
-        <di:waypoint x="350" y="370" />
-        <di:waypoint x="350" y="65" />
+        <di:waypoint x="310" y="370" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0kguhla_di" bpmnElement="Flow_0kguhla">
-        <di:waypoint x="375" y="40" />
-        <di:waypoint x="442" y="40" />
+        <di:waypoint x="505" y="40" />
+        <di:waypoint x="572" y="40" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_11fj5bn_di" bpmnElement="Flow_11fj5bn">
+        <di:waypoint x="410" y="40" />
+        <di:waypoint x="455" y="40" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_02nckfs_di" bpmnElement="Flow_02nckfs">
+        <di:waypoint x="410" y="150" />
+        <di:waypoint x="480" y="150" />
+        <di:waypoint x="480" y="65" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0s3m7td_di" bpmnElement="Flow_0s3m7td">
+        <di:waypoint x="410" y="260" />
+        <di:waypoint x="480" y="260" />
+        <di:waypoint x="480" y="65" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1nyxldz_di" bpmnElement="Flow_1nyxldz">
+        <di:waypoint x="410" y="370" />
+        <di:waypoint x="480" y="370" />
+        <di:waypoint x="480" y="65" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
Supports #1359 

This PR forces any task that has gateway children to be run sequentially out of Threads.

When a task with a gateway is completed it marks the gateway as either WAITING or READY. The problem is if two of these parent tasks mark their gateways as READY then both are processed and end up being marked completed, when in fact only one gateway attached to the same bpmn bpmn_id is allowed to be READY/COMPLETED. If two are READY and execute, then the tasks after the gateway will be unintentially duplicated.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a configuration option to control thread execution for debugging purposes.
	- Improved task handling logic in workflows involving gateways to prevent duplications and ensure accurate task completion.

- **Refactor**
	- Introduced new functions to manage task executions with or without threads based on the gateway configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->