### PR TITLE
make sure ProcessGroup init params are in include list

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/process_group.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/process_group.py
@@ -56,6 +56,11 @@ class ProcessGroup:
     def id_for_file_path(self) -> str:
         return self.id.replace("/", os.sep)
 
+    @classmethod
+    def get_valid_properties(cls) -> list[str]:
+        dict_keys = cls.__dataclass_fields__.keys()
+        return list(dict_keys)
+
 
 class ProcessGroupSchema(Schema):
     class Meta:

--- a/spiffworkflow-backend/tests/data/bpmn_unit_test_process_models/expected-to-fail/process_group.json
+++ b/spiffworkflow-backend/tests/data/bpmn_unit_test_process_models/expected-to-fail/process_group.json
@@ -1,9 +1,10 @@
 {
-    "admin": false,
-    "description": "",
-    "display_name": "Expected To Fail",
-    "display_order": 0,
-    "parent_groups": null,
-    "process_groups": [],
-    "process_models": []
+  "admin": false,
+  "garbage": true,
+  "description": "",
+  "display_name": "Expected To Fail",
+  "display_order": 0,
+  "parent_groups": null,
+  "process_groups": [],
+  "process_models": []
 }


### PR DESCRIPTION
avoids runtime errors when process_group.json files have unexpected keys.

mitigates https://github.com/sartography/gsa-process-models/issues/1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data handling in the backend by introducing methods to filter and validate properties and dictionary keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->