### PR TITLE
do not invalidate a numeric range field if it is unset and not required

### DIFF
--- a/spiffworkflow-frontend/src/components/CustomForm.tsx
+++ b/spiffworkflow-frontend/src/components/CustomForm.tsx
@@ -256,6 +256,7 @@ export default function CustomForm({
     errors: any,
     jsonSchema: any,
     _uiSchemaPassedIn?: any
+    // eslint-disable-next-line sonarjs/cognitive-complexity
   ) => {
     if (
       jsonSchema.required &&
@@ -265,43 +266,51 @@ export default function CustomForm({
     ) {
       errors[propertyKey].addError('must have valid Minimum and Maximum');
     }
-    if (
-      !formDataToCheck[propertyKey].min?.toString().match(matchNumberRegex) ||
-      !formDataToCheck[propertyKey].max?.toString().match(matchNumberRegex)
-    ) {
-      errors[propertyKey].addError('must have valid numbers');
+    if (formDataToCheck[propertyKey].min) {
+      if (
+        !formDataToCheck[propertyKey].min.toString().match(matchNumberRegex)
+      ) {
+        errors[propertyKey].addError('must have valid numbers');
+      }
+      if (
+        formDataToCheck[propertyKey].min <
+        jsonSchema.properties[propertyKey].minimum
+      ) {
+        errors[propertyKey].addError(
+          `must have min greater than or equal to ${jsonSchema.properties[propertyKey].minimum}`
+        );
+      }
+      if (
+        formDataToCheck[propertyKey].min >
+        jsonSchema.properties[propertyKey].maximum
+      ) {
+        errors[propertyKey].addError(
+          `must have min less than or equal to ${jsonSchema.properties[propertyKey].maximum}`
+        );
+      }
     }
-    if (
-      formDataToCheck[propertyKey].min <
-      jsonSchema.properties[propertyKey].minimum
-    ) {
-      errors[propertyKey].addError(
-        `must have min greater than or equal to ${jsonSchema.properties[propertyKey].minimum}`
-      );
-    }
-    if (
-      formDataToCheck[propertyKey].min >
-      jsonSchema.properties[propertyKey].maximum
-    ) {
-      errors[propertyKey].addError(
-        `must have min less than or equal to ${jsonSchema.properties[propertyKey].maximum}`
-      );
-    }
-    if (
-      formDataToCheck[propertyKey].max <
-      jsonSchema.properties[propertyKey].minimum
-    ) {
-      errors[propertyKey].addError(
-        `must have max greater than or equal to ${jsonSchema.properties[propertyKey].minimum}`
-      );
-    }
-    if (
-      formDataToCheck[propertyKey].max >
-      jsonSchema.properties[propertyKey].maximum
-    ) {
-      errors[propertyKey].addError(
-        `must have max less than or equal to ${jsonSchema.properties[propertyKey].maximum}`
-      );
+    if (formDataToCheck[propertyKey].max) {
+      if (
+        !formDataToCheck[propertyKey].max.toString().match(matchNumberRegex)
+      ) {
+        errors[propertyKey].addError('must have valid numbers');
+      }
+      if (
+        formDataToCheck[propertyKey].max <
+        jsonSchema.properties[propertyKey].minimum
+      ) {
+        errors[propertyKey].addError(
+          `must have max greater than or equal to ${jsonSchema.properties[propertyKey].minimum}`
+        );
+      }
+      if (
+        formDataToCheck[propertyKey].max >
+        jsonSchema.properties[propertyKey].maximum
+      ) {
+        errors[propertyKey].addError(
+          `must have max less than or equal to ${jsonSchema.properties[propertyKey].maximum}`
+        );
+      }
     }
     if (formDataToCheck[propertyKey].min > formDataToCheck[propertyKey].max) {
       errors[propertyKey].addError(`must have min less than or equal to max`);

--- a/spiffworkflow-frontend/src/rjsf/custom_widgets/NumericRangeField/NumericRangeField.tsx
+++ b/spiffworkflow-frontend/src/rjsf/custom_widgets/NumericRangeField/NumericRangeField.tsx
@@ -83,6 +83,9 @@ export default function NumericRangeField({
   };
 
   const parseNumberString = (numberString: string) => {
+    if (!numberString.match(matchNumberRegex)) {
+      return numberString;
+    }
     if (
       (numberString === '-' && numberString.length === 1) ||
       numberString.endsWith('.')


### PR DESCRIPTION
Addresses https://github.com/sartography/spiff-arena/issues/647#issuecomment-2089568978

This adds in some conditionals so the numeric range field is not invalidated when it is unset and not required. It also cleans up the conditionals a bit and allows for text to be set in the state. Before the text would go away on reload which seemed confusing to me so set the state and let it run through validations on submit seems more intuitive to me.