### PR TITLE
always load the file up as binary

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/process_instance_file_data.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/process_instance_file_data.py
@@ -46,8 +46,8 @@ class ProcessInstanceFileDataModel(SpiffworkflowBaseDBModel):
 
     def get_contents_on_file_system(self) -> bytes:
         filepath = self.get_full_filepath()
-        with open(filepath) as f:
-            return f.read().encode()
+        with open(filepath, "rb") as f:
+            return f.read()
 
     def get_full_filepath(self) -> str:
         dir_parts = self.__class__.get_hashed_directory_structure(self.digest)

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_file_data_migrator.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_file_data_migrator.py
@@ -62,3 +62,51 @@ class TestProcessInstanceFileDataMigrator(BaseTest):
             assert test_file_one_model is not None
             assert test_file_one_model.contents == PROCESS_INSTANCE_DATA_FILE_ON_FILE_SYSTEM.encode()
             assert test_file_one_model.get_contents() == test_file_one_contents.encode()
+
+    def test_can_migrate_binary_file_from_db_to_fs(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+    ) -> None:
+        process_model = load_test_spec(
+            process_model_id="test_group/random_fact",
+            bpmn_file_name="random_fact_set.bpmn",
+            process_model_source_directory="random_fact",
+        )
+        process_instance = self.create_process_instance_from_process_model(process_model=process_model)
+        processor = ProcessInstanceProcessor(process_instance)
+        processor.do_engine_steps(save=True)
+        assert process_instance.status == ProcessInstanceStatus.complete.value
+
+        # b'\xff\xfe\r\x00\n'
+        test_file_one_contents = b"\xff\xfe\r\x00\n"
+        test_file_one_digest = hashlib.sha256(test_file_one_contents).hexdigest()
+        pi_files = [
+            {
+                "mimetype": "application/json",
+                "filename": "test_file_one.json",
+                "contents": test_file_one_contents,
+                "digest": test_file_one_digest,
+            }
+        ]
+        for pi_file in pi_files:
+            pi_model = ProcessInstanceFileDataModel(
+                process_instance_id=process_instance.id,
+                mimetype=str(pi_file["mimetype"]),
+                filename=str(pi_file["filename"]),
+                contents=pi_file["contents"],  # type: ignore
+                digest=str(pi_file["digest"]),
+            )
+            db.session.add(pi_model)
+        db.session.commit()
+
+        with self.app_config_mock(
+            app, "SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_FILE_DATA_FILESYSTEM_PATH", ProcessModelService.root_path()
+        ):
+            ProcessInstanceFileDataMigrator.migrate_from_database_to_filesystem()
+
+            test_file_one_model = ProcessInstanceFileDataModel.query.filter_by(filename="test_file_one.json").first()
+            assert test_file_one_model is not None
+            assert test_file_one_model.contents == PROCESS_INSTANCE_DATA_FILE_ON_FILE_SYSTEM.encode()
+            assert test_file_one_model.get_contents() == test_file_one_contents


### PR DESCRIPTION
Supports #1402 

Always read the files from the file system as binary to avoid encoding issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Modified file reading functionality to handle binary data correctly, enhancing data integrity during file operations.

- **Tests**
	- Added a new test to ensure reliable migration of binary files from the database to the filesystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->