### PR TITLE
Remove add proce info

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/apscheduler.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/apscheduler.py
@@ -84,7 +84,6 @@ def _add_jobs_that_should_run_regardless_of_celery_config(app: flask.app.Flask, 
     ]
 
     # TODO: see if we can queue with celery instead on celery based configuration
-    # NOTE: pass in additional_processing_identifier if we move to celery
     scheduler.add_job(
         BackgroundProcessingService(app).process_message_instances_with_app_context,
         "interval",

--- a/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/celery_tasks/process_instance_task.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/celery_tasks/process_instance_task.py
@@ -41,6 +41,7 @@ def celery_task_process_instance_run(process_instance_id: int, task_guid: str | 
         }
     try:
         task_guid_for_requeueing = task_guid
+        print(f"➡️ ➡️ ➡️  FROM CELERY TASK: additional_processing_identifier: {proc_index}")
         with ProcessInstanceQueueService.dequeued(process_instance, additional_processing_identifier=proc_index):
             ProcessInstanceService.run_process_instance_with_processor(
                 process_instance, execution_strategy_name="run_current_ready_tasks", additional_processing_identifier=proc_index

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/error_handling_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/error_handling_service.py
@@ -12,8 +12,14 @@ class ErrorHandlingService:
     MESSAGE_NAME = "SystemErrorMessage"
 
     @classmethod
-    def handle_error(cls, process_instance: ProcessInstanceModel, error: Exception) -> None:
+    def handle_error(
+        cls,
+        process_instance: ProcessInstanceModel,
+        error: Exception,
+        additional_processing_identifier: str | None = None,
+    ) -> None:
         """On unhandled exceptions, set instance.status based on model.fault_or_suspend_on_exception."""
+        print(f"➡️ ➡️ ➡️  FROM HANDLE_ERROR: additional_processing_identifier: {additional_processing_identifier}")
         process_model = ProcessModelService.get_process_model(process_instance.process_model_identifier)
         cls._update_process_instance_in_database(process_instance, process_model.fault_or_suspend_on_exception)
 
@@ -22,10 +28,13 @@ class ErrorHandlingService:
         # body.
         if len(process_model.exception_notification_addresses) > 0:
             try:
-                cls._handle_system_notification(error, process_model, process_instance)
+                cls._handle_system_notification(
+                    error, process_model, process_instance, additional_processing_identifier=additional_processing_identifier
+                )
             except Exception as e:
                 # hmm... what to do if a notification method fails. Probably log, at least
                 current_app.logger.error(e)
+                raise e
 
     @classmethod
     def _update_process_instance_in_database(
@@ -54,6 +63,7 @@ class ErrorHandlingService:
         error: Exception,
         process_model: ProcessModelInfo,
         process_instance: ProcessInstanceModel,
+        additional_processing_identifier: str | None = None,
     ) -> None:
         """Send a BPMN Message - which may kick off a waiting process."""
 
@@ -76,6 +86,7 @@ class ErrorHandlingService:
         else:
             user_id = process_instance.process_initiator_id
 
+        print(f"➡️ ➡️ ➡️  FROM HANDLE_ERROR: additional_processing_identifier: {additional_processing_identifier}")
         message_instance = MessageInstanceModel(
             message_type="send",
             name=ErrorHandlingService.MESSAGE_NAME,
@@ -84,7 +95,7 @@ class ErrorHandlingService:
         )
         db.session.add(message_instance)
         db.session.commit()
-        MessageService.correlate_send_message(message_instance)
+        MessageService.correlate_send_message(message_instance, additional_processing_identifier=additional_processing_identifier)
 
     @staticmethod
     def _set_instance_status(process_instance: ProcessInstanceModel, status: str) -> None:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/message_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/message_service.py
@@ -1,4 +1,3 @@
-import os
 from typing import Any
 
 from flask import g
@@ -39,7 +38,6 @@ class MessageService:
         cls,
         message_instance_send: MessageInstanceModel,
         execution_mode: str | None = None,
-        additional_processing_identifier: str | None = None,
     ) -> MessageInstanceModel | None:
         """Connects the given send message to a 'receive' message if possible.
 
@@ -47,7 +45,6 @@ class MessageService:
         :return: the message instance that received this message.
         """
         # Thread safe via db locking - don't try to progress the same send message over multiple instances
-        print(f"➡️ ➡️ ➡️  FROM CORRELATE: additional_processing_identifier: {additional_processing_identifier}")
         if message_instance_send.status != MessageStatuses.ready.value:
             return None
         message_instance_send.status = MessageStatuses.running.value
@@ -75,7 +72,7 @@ class MessageService:
                     if user is None:
                         user = UserService.find_or_create_system_user()
                     receiving_process_instance = MessageService.start_process_with_message(
-                        message_triggerable_process_model, user, additional_processing_identifier=additional_processing_identifier
+                        message_triggerable_process_model, user
                     )
                     message_instance_receive = MessageInstanceModel.query.filter_by(
                         process_instance_id=receiving_process_instance.id,
@@ -93,22 +90,12 @@ class MessageService:
                 return None
 
             try:
-                # currently only controllers and apscheduler call this
-                cls.raise_if_running_in_celery(
-                    "correlate_send_message", additional_processing_identifier=additional_processing_identifier
-                )
-                with ProcessInstanceQueueService.dequeued(
-                    receiving_process_instance, additional_processing_identifier=additional_processing_identifier
-                ):
+                with ProcessInstanceQueueService.dequeued(receiving_process_instance):
                     # Set the receiving message to running, so it is not altered elswhere ...
                     message_instance_receive.status = "running"
 
                     cls.process_message_receive(
-                        receiving_process_instance,
-                        message_instance_receive,
-                        message_instance_send,
-                        execution_mode=execution_mode,
-                        additional_processing_identifier=additional_processing_identifier,
+                        receiving_process_instance, message_instance_receive, message_instance_send, execution_mode=execution_mode
                     )
                     message_instance_receive.status = "completed"
                     message_instance_receive.counterpart_id = message_instance_send.id
@@ -152,23 +139,14 @@ class MessageService:
         cls,
         message_triggerable_process_model: MessageTriggerableProcessModel,
         user: UserModel,
-        additional_processing_identifier: str | None = None,
     ) -> ProcessInstanceModel:
         """Start up a process instance, so it is ready to catch the event."""
-        print(f"➡️ ➡️ ➡️  FROM START: additional_processing_identifier: {additional_processing_identifier}")
-        cls.raise_if_running_in_celery(
-            "start_process_with_message", additional_processing_identifier=additional_processing_identifier
-        )
         receiving_process_instance = ProcessInstanceService.create_process_instance_from_process_model_identifier(
             message_triggerable_process_model.process_model_identifier,
             user,
         )
-        with ProcessInstanceQueueService.dequeued(
-            receiving_process_instance, additional_processing_identifier=additional_processing_identifier
-        ):
-            processor_receive = ProcessInstanceProcessor(
-                receiving_process_instance, additional_processing_identifier=additional_processing_identifier
-            )
+        with ProcessInstanceQueueService.dequeued(receiving_process_instance):
+            processor_receive = ProcessInstanceProcessor(receiving_process_instance)
             cls._cancel_non_matching_start_events(processor_receive, message_triggerable_process_model)
             processor_receive.save()
 
@@ -182,7 +160,6 @@ class MessageService:
         message_instance_receive: MessageInstanceModel,
         message_instance_send: MessageInstanceModel,
         execution_mode: str | None = None,
-        additional_processing_identifier: str | None = None,
     ) -> None:
         correlation_properties = []
         for cr in message_instance_receive.correlation_rules:
@@ -202,9 +179,7 @@ class MessageService:
             payload=message_instance_send.payload,
             correlations=message_instance_send.correlation_keys,
         )
-        processor_receive = ProcessInstanceProcessor(
-            receiving_process_instance, additional_processing_identifier=additional_processing_identifier
-        )
+        processor_receive = ProcessInstanceProcessor(receiving_process_instance)
         processor_receive.bpmn_process_instance.send_event(bpmn_event)
         execution_strategy_name = None
 
@@ -330,14 +305,3 @@ class MessageService:
                 )
             )
         return receiving_process_instance
-
-    @classmethod
-    def raise_if_running_in_celery(cls, method_name: str, additional_processing_identifier: str | None = None) -> None:
-        if (
-            os.environ.get("SPIFFWORKFLOW_BACKEND_RUNNING_IN_CELERY_WORKER") == "true"
-            and additional_processing_identifier is None
-        ):
-            raise MessageServiceError(
-                f"Calling {method_name} in a celery worker. This is not supported! We may need to add"
-                " additional_processing_identifier to this code path."
-            )

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_queue_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_queue_service.py
@@ -119,6 +119,7 @@ class ProcessInstanceQueueService:
         additional_processing_identifier: str | None = None,
         max_attempts: int = 1,
     ) -> Generator[None, None, None]:
+        print(f"➡️ ➡️ ➡️  FROM DEQUEUE: additional_processing_identifier: {additional_processing_identifier}")
         reentering_lock = ProcessInstanceLockService.has_lock(
             process_instance.id, additional_processing_identifier=additional_processing_identifier
         )
@@ -138,7 +139,9 @@ class ProcessInstanceQueueService:
                 ProcessInstanceTmpService.add_event_to_process_instance(
                     process_instance, ProcessInstanceEventType.process_instance_error.value, exception=ex
                 )
-            ErrorHandlingService.handle_error(process_instance, ex)
+            ErrorHandlingService.handle_error(
+                process_instance, ex, additional_processing_identifier=additional_processing_identifier
+            )
             raise ex
         finally:
             if not reentering_lock:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
@@ -278,18 +278,14 @@ class ProcessInstanceService:
         process_instance: ProcessInstanceModel,
         status_value: str | None = None,
         execution_strategy_name: str | None = None,
-        additional_processing_identifier: str | None = None,
     ) -> tuple[ProcessInstanceProcessor | None, TaskRunnability]:
         processor = None
         task_runnability = TaskRunnability.unknown_if_ready_tasks
-        with ProcessInstanceQueueService.dequeued(
-            process_instance, additional_processing_identifier=additional_processing_identifier
-        ):
+        with ProcessInstanceQueueService.dequeued(process_instance):
             ProcessInstanceMigrator.run(process_instance)
             processor = ProcessInstanceProcessor(
                 process_instance,
                 workflow_completed_handler=cls.schedule_next_process_model_cycle,
-                additional_processing_identifier=additional_processing_identifier,
             )
 
         # if status_value is user_input_required (we are processing instances with that status from background processor),

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
@@ -442,14 +442,12 @@ class WorkflowExecutionService:
         execution_strategy: ExecutionStrategy,
         process_instance_completer: ProcessInstanceCompleter,
         process_instance_saver: ProcessInstanceSaver,
-        additional_processing_identifier: str | None = None,
     ):
         self.bpmn_process_instance = bpmn_process_instance
         self.process_instance_model = process_instance_model
         self.execution_strategy = execution_strategy
         self.process_instance_completer = process_instance_completer
         self.process_instance_saver = process_instance_saver
-        self.additional_processing_identifier = additional_processing_identifier
 
     # names of methods that do spiff stuff:
     # processor.do_engine_steps calls:
@@ -458,11 +456,7 @@ class WorkflowExecutionService:
     #       spiff.[some_run_task_method]
     def run_and_save(self, exit_at: None = None, save: bool = False) -> TaskRunnability:
         if self.process_instance_model.persistence_level != "none":
-            with safe_assertion(
-                ProcessInstanceLockService.has_lock(
-                    self.process_instance_model.id, additional_processing_identifier=self.additional_processing_identifier
-                )
-            ) as tripped:
+            with safe_assertion(ProcessInstanceLockService.has_lock(self.process_instance_model.id)) as tripped:
                 if tripped:
                     raise AssertionError(
                         "The current thread has not obtained a lock for this process"


### PR DESCRIPTION
Fixes #1501 

This removes the additional_processing_identifier property and instead calls out to the current process to get the index whenever it is needed. This is to avoid passing it through in all cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Simplified process instance management by removing an obsolete parameter across various services, enhancing system efficiency and reducing complexity.
- **Bug Fixes**
	- Corrected control flow and logic in handling messages and process instances, ensuring smoother operations.
- **New Features**
	- Introduced a method to retrieve the current process index, improving process tracking and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->