### PR TITLE
Celery instructions fix

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/jinja_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/jinja_service.py
@@ -108,6 +108,8 @@ class JinjaService:
         cls, spiff_tasks: list[SpiffTask], process_instance_id: int, tasks_that_have_been_seen: set[str]
     ) -> None:
         for spiff_task in spiff_tasks:
+            if spiff_task.task_spec.manual:
+                continue
             if hasattr(spiff_task.task_spec, "extensions") and spiff_task.task_spec.extensions.get(
                 "instructionsForEndUser", None
             ):


### PR DESCRIPTION
Fixes #1532 

This queues instructions when submitting a task in a celery environment. Otherwise instructions following a human task would not get added to the database. This also avoids adding instructions for human tasks to the database to avoid issues where this instruction could be shown to the user and there's no reason to show it to the user outside of the task show page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the process for updating task instructions for end users, ensuring clearer and condition-specific guidance is provided throughout the workflow.

- **Refactor**
	- Centralized the logic for adding user instructions into the `JinjaService`, improving maintainability and consistency across different services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->