### PR TITLE
debounce date after 100 ms instead of 1s

### DIFF
--- a/spiffworkflow-frontend/src/rjsf/carbon_theme/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/spiffworkflow-frontend/src/rjsf/carbon_theme/BaseInputTemplate/BaseInputTemplate.tsx
@@ -86,7 +86,7 @@ export default function BaseInputTemplate<
       _onChange(fullObject);
     },
     // delay in ms
-    1000
+    100
   );
 
   let enableCounter = false;

--- a/spiffworkflow-frontend/src/services/DateAndTimeService.tsx
+++ b/spiffworkflow-frontend/src/services/DateAndTimeService.tsx
@@ -176,7 +176,7 @@ const attemptToConvertUnknownDateStringFormatToKnownFormat = (
       if (normalizedDateString.match(dateFormatRegex)) {
         const newDate = parse(
           normalizedDateString,
-          dateFormat.replaceAll(/MMM*/g, 'MM'),
+          numericalDateFormat,
           new Date()
         );
         newDateString = convertDateObjectToFormattedString(newDate) || '';


### PR DESCRIPTION
Supports #1521 and #1555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Reduced input delay in the form fields from 1000ms to 100ms for faster user interaction.

- **Bug Fixes**
  - Improved date parsing by using a more accurate date format conversion method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->