### PR TITLE
Clean up process references when deleting models and groups

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_groups_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_groups_controller.py
@@ -12,6 +12,7 @@ from flask.wrappers import Response
 from spiffworkflow_backend.exceptions.api_error import ApiError
 from spiffworkflow_backend.exceptions.error import NotAuthorizedError
 from spiffworkflow_backend.exceptions.process_entity_not_found_error import ProcessEntityNotFoundError
+from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.models.process_group import ProcessGroup
 from spiffworkflow_backend.models.process_group import ProcessGroupSchema
 from spiffworkflow_backend.routes.process_api_blueprint import _commit_and_push_to_git
@@ -19,9 +20,8 @@ from spiffworkflow_backend.routes.process_api_blueprint import _un_modify_modifi
 from spiffworkflow_backend.services.authorization_service import AuthorizationService
 from spiffworkflow_backend.services.process_model_service import ProcessModelService
 from spiffworkflow_backend.services.process_model_service import ProcessModelWithInstancesNotDeletableError
-from spiffworkflow_backend.services.user_service import UserService
 from spiffworkflow_backend.services.spec_file_service import SpecFileService
-from spiffworkflow_backend.models.db import db
+from spiffworkflow_backend.services.user_service import UserService
 
 
 def process_group_create(body: dict) -> flask.wrappers.Response:
@@ -51,7 +51,7 @@ def process_group_delete(modified_process_group_id: str) -> flask.wrappers.Respo
 
     try:
         ProcessModelService.process_group_delete(process_group_id)
-        
+
         # can't do this in the ProcessModelService due to circular imports
         SpecFileService.clear_caches_for_process_group(process_group_id)
         db.session.commit()

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
@@ -115,6 +115,7 @@ def process_model_delete(
         process_model = _get_process_model(process_model_identifier)
         # can't do this in the ProcessModelService due to circular imports
         SpecFileService.clear_caches_for_process_model(process_model)
+        db.session.commit()
 
         ProcessModelService.process_model_delete(process_model_identifier)
     except ProcessModelWithInstancesNotDeletableError as exception:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
@@ -112,6 +112,10 @@ def process_model_delete(
 ) -> flask.wrappers.Response:
     process_model_identifier = modified_process_model_identifier.replace(":", "/")
     try:
+        process_model = _get_process_model(process_model_identifier)
+        # can't do this in the ProcessModelService due to circular imports
+        SpecFileService.clear_caches_for_process_model(process_model)
+        
         ProcessModelService.process_model_delete(process_model_identifier)
     except ProcessModelWithInstancesNotDeletableError as exception:
         raise ApiError(

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
@@ -114,7 +114,7 @@ def process_model_delete(
     try:
         process_model = _get_process_model(process_model_identifier)
         ProcessModelService.process_model_delete(process_model_identifier)
-        
+
         # can't do this in the ProcessModelService due to circular imports
         SpecFileService.clear_caches_for_process_model(process_model)
         db.session.commit()

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
@@ -113,11 +113,11 @@ def process_model_delete(
     process_model_identifier = modified_process_model_identifier.replace(":", "/")
     try:
         process_model = _get_process_model(process_model_identifier)
+        ProcessModelService.process_model_delete(process_model_identifier)
+        
         # can't do this in the ProcessModelService due to circular imports
         SpecFileService.clear_caches_for_process_model(process_model)
         db.session.commit()
-
-        ProcessModelService.process_model_delete(process_model_identifier)
     except ProcessModelWithInstancesNotDeletableError as exception:
         raise ApiError(
             error_code="existing_instances",

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
@@ -115,7 +115,7 @@ def process_model_delete(
         process_model = _get_process_model(process_model_identifier)
         # can't do this in the ProcessModelService due to circular imports
         SpecFileService.clear_caches_for_process_model(process_model)
-        
+
         ProcessModelService.process_model_delete(process_model_identifier)
     except ProcessModelWithInstancesNotDeletableError as exception:
         raise ApiError(

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/spec_file_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/spec_file_service.py
@@ -278,9 +278,7 @@ class SpecFileService(FileSystemService):
     @staticmethod
     def clear_caches_for_process_model(process_model_info: ProcessModelInfo) -> None:
         records = (
-            db.session.query(ReferenceCacheModel)
-            .filter(ReferenceCacheModel.relative_location == process_model_info.id)
-            .all()
+            db.session.query(ReferenceCacheModel).filter(ReferenceCacheModel.relative_location == process_model_info.id).all()
         )
 
         reference_cache_ids = []

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/spec_file_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/spec_file_service.py
@@ -276,6 +276,22 @@ class SpecFileService(FileSystemService):
         ProcessCallerService.clear_cache_for_process_ids(reference_cache_ids)
 
     @staticmethod
+    def clear_caches_for_process_model(process_model_info: ProcessModelInfo) -> None:
+        records = (
+            db.session.query(ReferenceCacheModel)
+            .filter(ReferenceCacheModel.relative_location == process_model_info.id)
+            .all()
+        )
+
+        reference_cache_ids = []
+
+        for record in records:
+            reference_cache_ids.append(record.id)
+            db.session.delete(record)
+
+        ProcessCallerService.clear_cache_for_process_ids(reference_cache_ids)
+
+    @staticmethod
     def update_process_cache(ref: Reference) -> None:
         process_id_lookup = (
             ReferenceCacheModel.basic_query()

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/spec_file_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/spec_file_service.py
@@ -276,6 +276,20 @@ class SpecFileService(FileSystemService):
         ProcessCallerService.clear_cache_for_process_ids(reference_cache_ids)
 
     @staticmethod
+    def clear_caches_for_process_group(process_group_id: str) -> None:
+        records = (
+            db.session.query(ReferenceCacheModel).filter(ReferenceCacheModel.relative_location.like(f"{process_group_id}%")).all()
+        )
+
+        reference_cache_ids = []
+
+        for record in records:
+            reference_cache_ids.append(record.id)
+            db.session.delete(record)
+
+        ProcessCallerService.clear_cache_for_process_ids(reference_cache_ids)
+
+    @staticmethod
     def clear_caches_for_process_model(process_model_info: ProcessModelInfo) -> None:
         records = (
             db.session.query(ReferenceCacheModel).filter(ReferenceCacheModel.relative_location == process_model_info.id).all()

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/spec_file_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/spec_file_service.py
@@ -279,7 +279,7 @@ class SpecFileService(FileSystemService):
     def clear_caches_for_process_group(process_group_id: str) -> None:
         records = (
             db.session.query(ReferenceCacheModel)
-            .filter(ReferenceCacheModel.relative_location.like(f"{process_group_id}%"))  # type: ignore
+            .filter(ReferenceCacheModel.relative_location.like(f"{process_group_id}/%"))  # type: ignore
             .all()
         )
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/spec_file_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/spec_file_service.py
@@ -278,7 +278,9 @@ class SpecFileService(FileSystemService):
     @staticmethod
     def clear_caches_for_process_group(process_group_id: str) -> None:
         records = (
-            db.session.query(ReferenceCacheModel).filter(ReferenceCacheModel.relative_location.like(f"{process_group_id}%")).all()
+            db.session.query(ReferenceCacheModel)
+            .filter(ReferenceCacheModel.relative_location.like(f"{process_group_id}%"))  # type: ignore
+            .all()
         )
 
         reference_cache_ids = []

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_callers.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_callers.py
@@ -83,3 +83,45 @@ class TestProcessCallers(BaseTest):
         assert response.json is not None
         assert isinstance(response.json, list)
         assert len(response.json) == 0
+
+    def test_references_after_process_group_delete(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        self.create_group_and_model_with_bpmn(
+            client=client,
+            user=with_super_admin_user,
+            process_group_id="test_group_two",
+            process_model_id="call_activity_nested",
+            bpmn_file_location="call_activity_nested",
+        )
+
+        response = client.delete(
+            "/v1.0/process-groups/test_group_two",
+            headers=self.logged_in_headers(with_super_admin_user),
+        )
+
+        assert response.status_code == 200
+
+        response = client.get(
+            "/v1.0/processes",
+            headers=self.logged_in_headers(with_super_admin_user),
+        )
+
+        assert response.status_code == 200
+        assert response.json is not None
+        assert isinstance(response.json, list)
+        assert len(response.json) == 0
+
+        response = client.get(
+            "/v1.0/processes/callers/Level2",
+            headers=self.logged_in_headers(with_super_admin_user),
+        )
+
+        assert response.status_code == 200
+        assert response.json is not None
+        assert isinstance(response.json, list)
+        assert len(response.json) == 0

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_callers.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_callers.py
@@ -1,43 +1,9 @@
-import base64
-import io
-import json
-import os
-import time
-from hashlib import sha256
-from typing import Any
-from unittest.mock import patch
-
-import flask
-import pytest
 from flask.app import Flask
 from flask.testing import FlaskClient
-from SpiffWorkflow.util.task import TaskState  # type: ignore
-from spiffworkflow_backend.exceptions.process_entity_not_found_error import ProcessEntityNotFoundError
-from spiffworkflow_backend.models.bpmn_process import BpmnProcessModel
-from spiffworkflow_backend.models.bpmn_process_definition import BpmnProcessDefinitionModel
-from spiffworkflow_backend.models.db import db
-from spiffworkflow_backend.models.process_instance import ProcessInstanceModel
-from spiffworkflow_backend.models.process_instance import ProcessInstanceStatus
-from spiffworkflow_backend.models.process_instance_event import ProcessInstanceEventModel
-from spiffworkflow_backend.models.process_instance_event import ProcessInstanceEventType
-from spiffworkflow_backend.models.process_instance_file_data import ProcessInstanceFileDataModel
-from spiffworkflow_backend.models.process_instance_metadata import ProcessInstanceMetadataModel
-from spiffworkflow_backend.models.process_instance_report import ProcessInstanceReportModel
-from spiffworkflow_backend.models.process_instance_report import ReportMetadata
-from spiffworkflow_backend.models.process_model import NotificationType
-from spiffworkflow_backend.models.process_model import ProcessModelInfoSchema
-from spiffworkflow_backend.models.reference_cache import ReferenceCacheModel
 from spiffworkflow_backend.models.task import TaskModel  # noqa: F401
 from spiffworkflow_backend.models.user import UserModel
-from spiffworkflow_backend.services.file_system_service import FileSystemService
-from spiffworkflow_backend.services.process_caller_service import ProcessCallerService
-from spiffworkflow_backend.services.process_instance_processor import ProcessInstanceProcessor
-from spiffworkflow_backend.services.process_instance_service import ProcessInstanceService
-from spiffworkflow_backend.services.process_model_service import ProcessModelService
-from spiffworkflow_backend.services.user_service import UserService
 
 from tests.spiffworkflow_backend.helpers.base_test import BaseTest
-from tests.spiffworkflow_backend.helpers.test_data import load_test_spec
 
 
 class TestProcessCallers(BaseTest):
@@ -60,12 +26,11 @@ class TestProcessCallers(BaseTest):
             "/v1.0/processes/callers/Level2",
             headers=self.logged_in_headers(with_super_admin_user),
         )
-        
+
         assert response.status_code == 200
         assert response.json is not None
         assert isinstance(response.json, list)
         assert len(response.json) == 1
-        
 
     def test_references_after_process_model_delete(
         self,
@@ -86,16 +51,15 @@ class TestProcessCallers(BaseTest):
             "/v1.0/process-models/test_group_two:call_activity_nested",
             headers=self.logged_in_headers(with_super_admin_user),
         )
-        
+
         assert response.status_code == 200
 
         response = client.get(
             "/v1.0/processes/callers/Level2",
             headers=self.logged_in_headers(with_super_admin_user),
         )
-        
+
         assert response.status_code == 200
         assert response.json is not None
         assert isinstance(response.json, list)
         assert len(response.json) == 0
-        

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_callers.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_callers.py
@@ -1,0 +1,101 @@
+import base64
+import io
+import json
+import os
+import time
+from hashlib import sha256
+from typing import Any
+from unittest.mock import patch
+
+import flask
+import pytest
+from flask.app import Flask
+from flask.testing import FlaskClient
+from SpiffWorkflow.util.task import TaskState  # type: ignore
+from spiffworkflow_backend.exceptions.process_entity_not_found_error import ProcessEntityNotFoundError
+from spiffworkflow_backend.models.bpmn_process import BpmnProcessModel
+from spiffworkflow_backend.models.bpmn_process_definition import BpmnProcessDefinitionModel
+from spiffworkflow_backend.models.db import db
+from spiffworkflow_backend.models.process_instance import ProcessInstanceModel
+from spiffworkflow_backend.models.process_instance import ProcessInstanceStatus
+from spiffworkflow_backend.models.process_instance_event import ProcessInstanceEventModel
+from spiffworkflow_backend.models.process_instance_event import ProcessInstanceEventType
+from spiffworkflow_backend.models.process_instance_file_data import ProcessInstanceFileDataModel
+from spiffworkflow_backend.models.process_instance_metadata import ProcessInstanceMetadataModel
+from spiffworkflow_backend.models.process_instance_report import ProcessInstanceReportModel
+from spiffworkflow_backend.models.process_instance_report import ReportMetadata
+from spiffworkflow_backend.models.process_model import NotificationType
+from spiffworkflow_backend.models.process_model import ProcessModelInfoSchema
+from spiffworkflow_backend.models.reference_cache import ReferenceCacheModel
+from spiffworkflow_backend.models.task import TaskModel  # noqa: F401
+from spiffworkflow_backend.models.user import UserModel
+from spiffworkflow_backend.services.file_system_service import FileSystemService
+from spiffworkflow_backend.services.process_caller_service import ProcessCallerService
+from spiffworkflow_backend.services.process_instance_processor import ProcessInstanceProcessor
+from spiffworkflow_backend.services.process_instance_service import ProcessInstanceService
+from spiffworkflow_backend.services.process_model_service import ProcessModelService
+from spiffworkflow_backend.services.user_service import UserService
+
+from tests.spiffworkflow_backend.helpers.base_test import BaseTest
+from tests.spiffworkflow_backend.helpers.test_data import load_test_spec
+
+
+class TestProcessCallers(BaseTest):
+    def test_references_after_process_model_create(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        self.create_group_and_model_with_bpmn(
+            client=client,
+            user=with_super_admin_user,
+            process_group_id="test_group_two",
+            process_model_id="call_activity_nested",
+            bpmn_file_location="call_activity_nested",
+        )
+
+        response = client.get(
+            "/v1.0/processes/callers/Level2",
+            headers=self.logged_in_headers(with_super_admin_user),
+        )
+        
+        assert response.status_code == 200
+        assert response.json is not None
+        assert isinstance(response.json, list)
+        assert len(response.json) == 1
+        
+
+    def test_references_after_process_model_delete(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        self.create_group_and_model_with_bpmn(
+            client=client,
+            user=with_super_admin_user,
+            process_group_id="test_group_two",
+            process_model_id="call_activity_nested",
+            bpmn_file_location="call_activity_nested",
+        )
+
+        response = client.delete(
+            "/v1.0/process-models/test_group_two:call_activity_nested",
+            headers=self.logged_in_headers(with_super_admin_user),
+        )
+        
+        assert response.status_code == 200
+
+        response = client.get(
+            "/v1.0/processes/callers/Level2",
+            headers=self.logged_in_headers(with_super_admin_user),
+        )
+        
+        assert response.status_code == 200
+        assert response.json is not None
+        assert isinstance(response.json, list)
+        assert len(response.json) == 0
+        

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_callers.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_callers.py
@@ -23,6 +23,16 @@ class TestProcessCallers(BaseTest):
         )
 
         response = client.get(
+            "/v1.0/processes",
+            headers=self.logged_in_headers(with_super_admin_user),
+        )
+
+        assert response.status_code == 200
+        assert response.json is not None
+        assert isinstance(response.json, list)
+        assert len(response.json) == 4
+
+        response = client.get(
             "/v1.0/processes/callers/Level2",
             headers=self.logged_in_headers(with_super_admin_user),
         )
@@ -53,6 +63,16 @@ class TestProcessCallers(BaseTest):
         )
 
         assert response.status_code == 200
+
+        response = client.get(
+            "/v1.0/processes",
+            headers=self.logged_in_headers(with_super_admin_user),
+        )
+
+        assert response.status_code == 200
+        assert response.json is not None
+        assert isinstance(response.json, list)
+        assert len(response.json) == 0
 
         response = client.get(
             "/v1.0/processes/callers/Level2",


### PR DESCRIPTION
Work on #822 - when a process model or process group is deleted, its process references were not being cleaned up until the next time data setup service ran. This could cause these deleted processes to still remain in the called element drop down, which could lead to duplicate entries if the process model files were re-uploaded in another area. Fix is to clear the reference caches when deleting a group or model. Deleting a single file from a model already works this way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added cache clearing functionality for process groups and process models to improve performance and consistency.

- **Bug Fixes**
  - Ensured database session commits after deleting process groups and process models to maintain data integrity.

- **Tests**
  - Added integration tests to verify the correct functionality of creating and deleting process models and groups, ensuring system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->