### PR TITLE
task-info-limit-tasks

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_instances_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_instances_controller.py
@@ -377,19 +377,21 @@ def _process_instance_task_list(
     This is how we know what the state of each task is and how to color things.
     """
     bpmn_process_ids = []
+    bpmn_process = None
     if bpmn_process_guid:
         bpmn_process = BpmnProcessModel.query.filter_by(guid=bpmn_process_guid).first()
-        if bpmn_process is None:
-            raise ApiError(
-                error_code="bpmn_process_not_found",
-                message=(
-                    f"Cannot find a bpmn process with guid '{bpmn_process_guid}' for process instance '{process_instance.id}'"
-                ),
-                status_code=400,
-            )
+    else:
+        bpmn_process = process_instance.bpmn_process
 
-        bpmn_processes = TaskService.bpmn_process_and_descendants([bpmn_process])
-        bpmn_process_ids = [p.id for p in bpmn_processes]
+    if bpmn_process is None:
+        raise ApiError(
+            error_code="bpmn_process_not_found",
+            message=(f"Cannot find a bpmn process with guid '{bpmn_process_guid}' for process instance '{process_instance.id}'"),
+            status_code=400,
+        )
+
+    bpmn_processes = TaskService.bpmn_process_and_descendants([bpmn_process])
+    bpmn_process_ids = [p.id for p in bpmn_processes]
 
     task_model_query = db.session.query(TaskModel).filter(
         TaskModel.process_instance_id == process_instance.id,


### PR DESCRIPTION
This will hopefully make the process instance show page load a little faster since it will only load tasks for the current bpmn process and will omit tasks for call activities. Tasks for subprocesses should still be returned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability by adding a check for `bpmn_process` being None before querying tasks.

- **Improvements**
  - Enhanced process handling logic for better assignment of `bpmn_process`.
  - Optimized task queries for more efficient data retrieval and processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->