### PR TITLE
Update process callers when a file is uploaded

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
@@ -566,7 +566,9 @@ def _create_or_update_process_model_file(
             status_code=400,
         )
 
-    if file_contents_hash is not None:
+    is_new_file = file_contents_hash is None
+
+    if not is_new_file:
         current_file_contents_bytes = SpecFileService.get_data(process_model, request_file.filename)
         if current_file_contents_bytes and file_contents_hash:
             current_file_contents_hash = sha256(current_file_contents_bytes).hexdigest()
@@ -599,6 +601,7 @@ def _create_or_update_process_model_file(
     file.file_contents_hash = file_contents_hash
     _commit_and_push_to_git(f"{message_for_git_commit} {process_model_identifier}/{file.name}")
 
-    DataSetupService.save_all_process_models()
+    if is_new_file:
+        DataSetupService.save_all_process_models()
     
     return make_response(jsonify(file), http_status_to_return)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
@@ -41,6 +41,7 @@ from spiffworkflow_backend.services.process_model_test_generator_service import 
 from spiffworkflow_backend.services.process_model_test_runner_service import ProcessModelTestRunner
 from spiffworkflow_backend.services.spec_file_service import ProcessModelFileInvalidError
 from spiffworkflow_backend.services.spec_file_service import SpecFileService
+from spiffworkflow_backend.services.data_setup_service import DataSetupService
 
 
 def process_model_create(
@@ -598,4 +599,6 @@ def _create_or_update_process_model_file(
     file.file_contents_hash = file_contents_hash
     _commit_and_push_to_git(f"{message_for_git_commit} {process_model_identifier}/{file.name}")
 
+    DataSetupService.save_all_process_models()
+    
     return make_response(jsonify(file), http_status_to_return)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
@@ -28,6 +28,7 @@ from spiffworkflow_backend.routes.process_api_blueprint import _commit_and_push_
 from spiffworkflow_backend.routes.process_api_blueprint import _find_process_instance_by_id_or_raise
 from spiffworkflow_backend.routes.process_api_blueprint import _get_process_model
 from spiffworkflow_backend.routes.process_api_blueprint import _un_modify_modified_process_model_id
+from spiffworkflow_backend.services.data_setup_service import DataSetupService
 from spiffworkflow_backend.services.file_system_service import FileSystemService
 from spiffworkflow_backend.services.git_service import GitCommandError
 from spiffworkflow_backend.services.git_service import GitService
@@ -41,7 +42,6 @@ from spiffworkflow_backend.services.process_model_test_generator_service import 
 from spiffworkflow_backend.services.process_model_test_runner_service import ProcessModelTestRunner
 from spiffworkflow_backend.services.spec_file_service import ProcessModelFileInvalidError
 from spiffworkflow_backend.services.spec_file_service import SpecFileService
-from spiffworkflow_backend.services.data_setup_service import DataSetupService
 
 
 def process_model_create(
@@ -603,5 +603,5 @@ def _create_or_update_process_model_file(
 
     if is_new_file:
         DataSetupService.save_all_process_models()
-    
+
     return make_response(jsonify(file), http_status_to_return)

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_callers.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_callers.py
@@ -1,10 +1,12 @@
+import os
+
 from flask.app import Flask
 from flask.testing import FlaskClient
 from spiffworkflow_backend.models.task import TaskModel  # noqa: F401
 from spiffworkflow_backend.models.user import UserModel
 
 from tests.spiffworkflow_backend.helpers.base_test import BaseTest
-import os
+
 
 class TestProcessCallers(BaseTest):
     def test_references_after_process_model_create(
@@ -195,7 +197,7 @@ class TestProcessCallers(BaseTest):
 
         bpmn_file_name = "call_activity_level_2.bpmn"
         bpmn_file_location = "call_activity_level_2"
-        
+
         response = self.create_spec_file(
             client,
             process_model_id=process_model.id,
@@ -205,7 +207,7 @@ class TestProcessCallers(BaseTest):
             file_data=file_data,
             user=with_super_admin_user,
         )
-        
+
         assert response["process_model_id"] == process_model.id
         assert response["name"] == bpmn_file_name
         assert bytes(str(response["file_contents"]), "utf-8") == file_data

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_callers.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_callers.py
@@ -4,7 +4,7 @@ from spiffworkflow_backend.models.task import TaskModel  # noqa: F401
 from spiffworkflow_backend.models.user import UserModel
 
 from tests.spiffworkflow_backend.helpers.base_test import BaseTest
-
+import os
 
 class TestProcessCallers(BaseTest):
     def test_references_after_process_model_create(
@@ -175,7 +175,7 @@ class TestProcessCallers(BaseTest):
         with_db_and_bpmn_file_cleanup: None,
         with_super_admin_user: UserModel,
     ) -> None:
-        self.create_group_and_model_with_bpmn(
+        process_model = self.create_group_and_model_with_bpmn(
             client=client,
             user=with_super_admin_user,
             process_group_id="test_group_two",
@@ -190,15 +190,25 @@ class TestProcessCallers(BaseTest):
 
         assert response.status_code == 200
 
-        # response = client.get(
-        #     "/v1.0/processes",
-        #     headers=self.logged_in_headers(with_super_admin_user),
-        # )
+        with open(f"{os.getcwd()}/tests/data/call_activity_nested/call_activity_level_2.bpmn", "rb") as f:
+            file_data = f.read()
 
-        # assert response.status_code == 200
-        # assert response.json is not None
-        # assert isinstance(response.json, list)
-        # assert len(response.json) == 0
+        bpmn_file_name = "call_activity_level_2.bpmn"
+        bpmn_file_location = "call_activity_level_2"
+        
+        response = self.create_spec_file(
+            client,
+            process_model_id=process_model.id,
+            process_model=process_model,
+            process_model_location=bpmn_file_location,
+            file_name=bpmn_file_name,
+            file_data=file_data,
+            user=with_super_admin_user,
+        )
+        
+        assert response["process_model_id"] == process_model.id
+        assert response["name"] == bpmn_file_name
+        assert bytes(str(response["file_contents"]), "utf-8") == file_data
 
         response = client.get(
             "/v1.0/processes/callers/Level2",
@@ -208,4 +218,4 @@ class TestProcessCallers(BaseTest):
         assert response.status_code == 200
         assert response.json is not None
         assert isinstance(response.json, list)
-        assert len(response.json) == 0
+        assert len(response.json) == 1

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_callers.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_callers.py
@@ -125,3 +125,87 @@ class TestProcessCallers(BaseTest):
         assert response.json is not None
         assert isinstance(response.json, list)
         assert len(response.json) == 0
+
+    def test_references_after_process_file_delete(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        self.create_group_and_model_with_bpmn(
+            client=client,
+            user=with_super_admin_user,
+            process_group_id="test_group_two",
+            process_model_id="call_activity_nested",
+            bpmn_file_location="call_activity_nested",
+        )
+
+        response = client.delete(
+            "/v1.0/process-models/test_group_two:call_activity_nested/files/call_activity_level_2.bpmn",
+            headers=self.logged_in_headers(with_super_admin_user),
+        )
+
+        assert response.status_code == 200
+
+        response = client.get(
+            "/v1.0/processes",
+            headers=self.logged_in_headers(with_super_admin_user),
+        )
+
+        assert response.status_code == 200
+        assert response.json is not None
+        assert isinstance(response.json, list)
+        assert len(response.json) == 3
+
+        response = client.get(
+            "/v1.0/processes/callers/Level2",
+            headers=self.logged_in_headers(with_super_admin_user),
+        )
+
+        assert response.status_code == 200
+        assert response.json is not None
+        assert isinstance(response.json, list)
+        assert len(response.json) == 0
+
+    def test_references_after_process_file_delete_and_upload(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        self.create_group_and_model_with_bpmn(
+            client=client,
+            user=with_super_admin_user,
+            process_group_id="test_group_two",
+            process_model_id="call_activity_nested",
+            bpmn_file_location="call_activity_nested",
+        )
+
+        response = client.delete(
+            "/v1.0/process-models/test_group_two:call_activity_nested/files/call_activity_level_2.bpmn",
+            headers=self.logged_in_headers(with_super_admin_user),
+        )
+
+        assert response.status_code == 200
+
+        # response = client.get(
+        #     "/v1.0/processes",
+        #     headers=self.logged_in_headers(with_super_admin_user),
+        # )
+
+        # assert response.status_code == 200
+        # assert response.json is not None
+        # assert isinstance(response.json, list)
+        # assert len(response.json) == 0
+
+        response = client.get(
+            "/v1.0/processes/callers/Level2",
+            headers=self.logged_in_headers(with_super_admin_user),
+        )
+
+        assert response.status_code == 200
+        assert response.json is not None
+        assert isinstance(response.json, list)
+        assert len(response.json) == 0


### PR DESCRIPTION
Work on #822 - when a process model is deleted and one of the files is re-uploaded (how things are moved currently), if the file was already set up as a call activity its references tab would not immediately show up. This treats uploading/creating a new file the same as getting a github webhook request and runs data setup service, which ends up showing the references once the file saves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced process model management to save all process models when a new file is created.

- **Tests**
  - Added tests for verifying process references after file deletion and upload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->