### PR TITLE
create a top level route for the new spiff ui from App.tsx

### DIFF
--- a/spiffworkflow-backend/poetry.lock
+++ b/spiffworkflow-backend/poetry.lock
@@ -1750,24 +1750,6 @@ files = [
 ]
 
 [[package]]
-name = "mysqlclient"
-version = "2.2.4"
-description = "Python interface to MySQL"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "mysqlclient-2.2.4-cp310-cp310-win_amd64.whl", hash = "sha256:ac44777eab0a66c14cb0d38965572f762e193ec2e5c0723bcd11319cc5b693c5"},
-    {file = "mysqlclient-2.2.4-cp311-cp311-win_amd64.whl", hash = "sha256:329e4eec086a2336fe3541f1ce095d87a6f169d1cc8ba7b04ac68bcb234c9711"},
-    {file = "mysqlclient-2.2.4-cp312-cp312-win_amd64.whl", hash = "sha256:e1ebe3f41d152d7cb7c265349fdb7f1eca86ccb0ca24a90036cde48e00ceb2ab"},
-    {file = "mysqlclient-2.2.4-cp38-cp38-win_amd64.whl", hash = "sha256:3c318755e06df599338dad7625f884b8a71fcf322a9939ef78c9b3db93e1de7a"},
-    {file = "mysqlclient-2.2.4-cp39-cp39-win_amd64.whl", hash = "sha256:9d4c015480c4a6b2b1602eccd9846103fc70606244788d04aa14b31c4bd1f0e2"},
-    {file = "mysqlclient-2.2.4-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d43987bb9626096a302ca6ddcdd81feaeca65ced1d5fe892a6a66b808326aa54"},
-    {file = "mysqlclient-2.2.4-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:4e80dcad884dd6e14949ac6daf769123223a52a6805345608bf49cdaf7bc8b3a"},
-    {file = "mysqlclient-2.2.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:9d3310295cb682232cadc28abd172f406c718b9ada41d2371259098ae37779d3"},
-    {file = "mysqlclient-2.2.4.tar.gz", hash = "sha256:33bc9fb3464e7d7c10b1eaf7336c5ff8f2a3d3b88bab432116ad2490beb3bf41"},
-]
-
-[[package]]
 name = "nodeenv"
 version = "1.8.0"
 description = "Node.js virtual environment builder"
@@ -1959,26 +1941,6 @@ files = [
 
 [package.dependencies]
 wcwidth = "*"
-
-[[package]]
-name = "psycopg2"
-version = "2.9.9"
-description = "psycopg2 - Python-PostgreSQL Database Adapter"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "psycopg2-2.9.9-cp310-cp310-win32.whl", hash = "sha256:38a8dcc6856f569068b47de286b472b7c473ac7977243593a288ebce0dc89516"},
-    {file = "psycopg2-2.9.9-cp310-cp310-win_amd64.whl", hash = "sha256:426f9f29bde126913a20a96ff8ce7d73fd8a216cfb323b1f04da402d452853c3"},
-    {file = "psycopg2-2.9.9-cp311-cp311-win32.whl", hash = "sha256:ade01303ccf7ae12c356a5e10911c9e1c51136003a9a1d92f7aa9d010fb98372"},
-    {file = "psycopg2-2.9.9-cp311-cp311-win_amd64.whl", hash = "sha256:121081ea2e76729acfb0673ff33755e8703d45e926e416cb59bae3a86c6a4981"},
-    {file = "psycopg2-2.9.9-cp37-cp37m-win32.whl", hash = "sha256:5e0d98cade4f0e0304d7d6f25bbfbc5bd186e07b38eac65379309c4ca3193efa"},
-    {file = "psycopg2-2.9.9-cp37-cp37m-win_amd64.whl", hash = "sha256:7e2dacf8b009a1c1e843b5213a87f7c544b2b042476ed7755be813eaf4e8347a"},
-    {file = "psycopg2-2.9.9-cp38-cp38-win32.whl", hash = "sha256:ff432630e510709564c01dafdbe996cb552e0b9f3f065eb89bdce5bd31fabf4c"},
-    {file = "psycopg2-2.9.9-cp38-cp38-win_amd64.whl", hash = "sha256:bac58c024c9922c23550af2a581998624d6e02350f4ae9c5f0bc642c633a2d5e"},
-    {file = "psycopg2-2.9.9-cp39-cp39-win32.whl", hash = "sha256:c92811b2d4c9b6ea0285942b2e7cac98a59e166d59c588fe5cfe1eda58e72d59"},
-    {file = "psycopg2-2.9.9-cp39-cp39-win_amd64.whl", hash = "sha256:de80739447af31525feddeb8effd640782cf5998e1a4e9192ebdf829717e3913"},
-    {file = "psycopg2-2.9.9.tar.gz", hash = "sha256:d1454bde93fb1e224166811694d600e746430c006fbb031ea06ecc2ea41bf156"},
-]
 
 [[package]]
 name = "pycparser"
@@ -3532,4 +3494,4 @@ tests-strict = ["pytest (==4.6.0)", "pytest (==4.6.0)", "pytest (==6.2.5)", "pyt
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "e9b302855b0c6a7745e69132c1be886a5d1f76e8bbf4dc32efc4a4b4603e331f"
+content-hash = "f4cb6bbc0186ada27e825a6f7c98e2d5840c60095987bdcee8a2e3deaf3086a2"

--- a/spiffworkflow-frontend/src/App.tsx
+++ b/spiffworkflow-frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { AbilityContext } from './contexts/Can';
 import APIErrorProvider from './contexts/APIErrorContext';
 import ContainerForExtensions from './ContainerForExtensions';
 import PublicRoutes from './routes/PublicRoutes';
+import SpiffUIV2 from './routes/SpiffUIV2';
 
 const queryClient = new QueryClient();
 
@@ -15,6 +16,7 @@ export default function App() {
   const routeComponents = () => {
     return [
       { path: 'public/*', element: <PublicRoutes /> },
+      { path: 'newui/*', element: <SpiffUIV2 /> },
       {
         path: '*',
         element: <ContainerForExtensions />,

--- a/spiffworkflow-frontend/src/ContainerForExtensions.tsx
+++ b/spiffworkflow-frontend/src/ContainerForExtensions.tsx
@@ -43,14 +43,6 @@ export default function ContainerForExtensions() {
 
   const location = useLocation();
 
-  // NEWUI: This a hack to hide the navigation bar in the "old" UI
-  const [showToolbar, setShowToolbar] = useState(true);
-  useEffect(() => {
-    if (location.pathname === '/newui') {
-      setShowToolbar(false);
-    }
-  }, []);
-
   // never carry an error message across to a different path
   useEffect(() => {
     removeError();
@@ -151,9 +143,7 @@ export default function ContainerForExtensions() {
 
   return (
     <>
-      {showToolbar && (
-        <NavigationBar extensionUxElements={extensionUxElements} />
-      )}
+      <NavigationBar extensionUxElements={extensionUxElements} />
       <Content className={contentClassName}>
         <ScrollToTop />
         <ErrorBoundary FallbackComponent={ErrorBoundaryFallback}>

--- a/spiffworkflow-frontend/src/routes/BaseRoutes.tsx
+++ b/spiffworkflow-frontend/src/routes/BaseRoutes.tsx
@@ -17,8 +17,6 @@ import RootRoute from './RootRoute';
 import LoginHandler from '../components/LoginHandler';
 import { ExtensionUxElementMap } from '../components/ExtensionUxElementForDisplay';
 import Extension from './Extension';
-import SpiffUIV2 from './SpiffUIV2';
-import TaskShow from './TaskShow';
 
 type OwnProps = {
   extensionUxElements?: UiSchemaUxElement[] | null;
@@ -71,7 +69,6 @@ export default function BaseRoutes({ extensionUxElements }: OwnProps) {
           <Route path="about" element={<About />} />
           <Route path="admin/*" element={<AdminRedirect />} />
           <Route path="/*" element={<Page404 />} />
-          <Route path="newui/*" element={<SpiffUIV2 />} />
         </Routes>
       </div>
     );


### PR DESCRIPTION
Let the new webui exist outside of ContainerForExtensions so it can pull in components as it needs without be hindered by the old webui when it's not necessary.