### PR TITLE
allow guest users to use typeahead

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
@@ -367,6 +367,8 @@ class AuthorizationService:
 
         if cls.request_is_excluded_from_permission_check():
             return None
+        if cls.request_is_excluded_from_public_user_permission_check(decoded_token):
+            return None
 
         cls.check_permission_for_request()
 
@@ -379,6 +381,24 @@ class AuthorizationService:
         api_function_full_path, module = cls.get_fully_qualified_api_function_from_request()
         if api_function_full_path and (api_function_full_path in authorization_exclusion_list):
             return True
+
+        return False
+
+    @classmethod
+    def request_is_excluded_from_public_user_permission_check(cls, decoded_token: dict | None) -> bool:
+        authorization_exclusion_for_public_user_list = [
+            "spiffworkflow_backend.routes.connector_proxy_controller.typeahead",
+        ]
+        api_function_full_path, module = cls.get_fully_qualified_api_function_from_request()
+        if (
+            api_function_full_path
+            and (api_function_full_path in authorization_exclusion_for_public_user_list)
+            and decoded_token
+            and "public" in decoded_token
+            and decoded_token["public"] is True
+        ):
+            return True
+
         return False
 
     @staticmethod


### PR DESCRIPTION
This opens the typeahead endpoint to guest users so they can use typeahead features.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced authorization service to exclude certain requests from public user permission checks based on token properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->