### PR TITLE
Feature - use docker secrets files content as env values

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
@@ -1,5 +1,5 @@
 import re
-from os import environ
+from os import environ, path
 from typing import Any
 
 from spiffworkflow_backend.config.normalized_environment import normalized_environment
@@ -21,9 +21,12 @@ def config_from_env(variable_name: str, *, default: str | bool | int | None = No
         if value_from_file.startswith("/run/secrets"):
             # rewrite variable name: remove _FILE
             variable_name = variable_name.removesuffix("_FILE")
-            print(variable_name)
-            with open(value_from_file) as f:
-                value_to_return = f.readline()
+
+            if path.exists(value_from_file):
+                with open(value_from_file) as f:
+                    value_to_return = f.readline()
+            else:
+                value_to_return = None
 
     if value_from_env is not None:
         if isinstance(default, bool):

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
@@ -18,7 +18,7 @@ def config_from_env(variable_name: str, *, default: str | bool | int | None = No
     # using docker secrets - put file contents to env value
     if variable_name.endswith("_FILE"):
         value_from_file = default if value_from_env is None else value_from_env
-        if value_from_file.startswith("/run/secrets"):
+        if value_from_file and value_from_file.startswith("/run/secrets"):
             # rewrite variable name: remove _FILE
             variable_name = variable_name.removesuffix("_FILE")
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
@@ -1,5 +1,6 @@
 import re
-from os import environ, path
+from os import environ
+from os import path
 from typing import Any
 
 from spiffworkflow_backend.config.normalized_environment import normalized_environment

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
@@ -1,6 +1,5 @@
 import re
 from os import environ
-from os import path
 from typing import Any
 
 from flask import current_app

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
@@ -15,6 +15,16 @@ def config_from_env(variable_name: str, *, default: str | bool | int | None = No
         value_from_env = None
 
     value_to_return: str | bool | int | None = value_from_env
+    # using docker secrets - put file contents to env value
+    if variable_name.endswith("_FILE"):
+        value_from_file = default if value_from_env is None else value_from_env
+        if value_from_file.startswith("/run/secrets"):
+            # rewrite variable name: remove _FILE
+            variable_name = variable_name.removesuffix("_FILE")
+            print(variable_name)
+            with open(value_from_file) as f:
+                value_to_return = f.readline()
+
     if value_from_env is not None:
         if isinstance(default, bool):
             if value_from_env.lower() == "true":


### PR DESCRIPTION
This PR enables the docker secrets feature. Instead of an env value a file content of an mounted secrets file is used: 

- the env **key** should have the prefix _FILE, e.g. FLASK_SESSION_SECRET_KEY_FILE
- the env **value** should point to a file in /run/secrets, e.g. /run/secrets/flask_session_secret_key. If so, the file content is written to FLASK_SESSION_SECRET_KEY (without _FILE)

Docker compose snippet:

```yml
services:
  spiffworkflow-backend:
    container_name: spiffworkflow-backend
    image: ghcr.io/sartography/spiffworkflow-backend:latest
    depends_on:
      spiffworkflow-db:
        condition: service_healthy
    restart: unless-stopped
    environment:
      FLASK_SESSION_SECRET_KEY_FILE: /run/secrets/flask_session_secret_key
      ...
    secrets:
      - flask_session_secret_key
    ...
      
secrets:
  flask_session_secret_key:
    file: /opt/containers/spiff-arena/secrets/flask_session_secret_key.txt
...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced configuration handling to support Docker secrets, ensuring environment values can be read from file contents.
  
- **Improvements**
  - Improved system reliability by importing necessary modules for better environment management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->