### PR TITLE
Reference cache integrity fix

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_groups_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_groups_controller.py
@@ -53,7 +53,7 @@ def process_group_delete(modified_process_group_id: str) -> flask.wrappers.Respo
         ProcessModelService.process_group_delete(process_group_id)
 
         # can't do this in the ProcessModelService due to circular imports
-        SpecFileService.clear_caches_for_process_group(process_group_id)
+        SpecFileService.clear_caches_for_item(process_group_id=process_group_id)
         db.session.commit()
 
     except ProcessModelWithInstancesNotDeletableError as exception:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
@@ -117,7 +117,7 @@ def process_model_delete(
         ProcessModelService.process_model_delete(process_model_identifier)
 
         # can't do this in the ProcessModelService due to circular imports
-        SpecFileService.clear_caches_for_process_model(process_model)
+        SpecFileService.clear_caches_for_item(process_model_info=process_model)
         db.session.commit()
     except ProcessModelWithInstancesNotDeletableError as exception:
         raise ApiError(

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_caller_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_caller_service.py
@@ -20,6 +20,7 @@ class ProcessCallerService:
 
     @staticmethod
     def clear_cache_for_process_ids(reference_cache_ids: list[int]) -> None:
+        # query-invoked autoflush happens here
         ProcessCallerRelationshipModel.query.filter(
             or_(
                 ProcessCallerRelationshipModel.called_reference_cache_process_id.in_(reference_cache_ids),

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_spec_file_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_spec_file_service.py
@@ -4,10 +4,10 @@ import sys
 import pytest
 from flask import Flask
 from flask.testing import FlaskClient
-from lxml import etree
-from spiffworkflow_backend.models import process_caller_relationship  # type: ignore
+from lxml import etree  # type: ignore
 from spiffworkflow_backend.models.cache_generation import CacheGenerationModel
 from spiffworkflow_backend.models.db import db
+from spiffworkflow_backend.models.process_caller_relationship import ProcessCallerRelationshipModel
 from spiffworkflow_backend.models.reference_cache import ReferenceCacheModel
 from spiffworkflow_backend.services.process_model_service import ProcessModelService
 from spiffworkflow_backend.services.reference_cache_service import ReferenceCacheService
@@ -290,7 +290,7 @@ class TestSpecFileService(BaseTest):
         assert reference.relative_path() == self.call_activity_nested_relative_file_path
 
         # ensure we add and remove from this table
-        process_caller_relationships = process_caller_relationship.ProcessCallerRelationshipModel.query.all()
+        process_caller_relationships = ProcessCallerRelationshipModel.query.all()
         assert len(process_caller_relationships) == 4
 
         process_model = ProcessModelService.get_process_model(reference.relative_location)
@@ -301,7 +301,7 @@ class TestSpecFileService(BaseTest):
         bpmn_process_id_lookups = ReferenceCacheService.get_reference_cache_entries_calling_process(["Level2"])
         assert len(bpmn_process_id_lookups) == 0
 
-        process_caller_relationships = process_caller_relationship.ProcessCallerRelationshipModel.query.all()
+        process_caller_relationships = ProcessCallerRelationshipModel.query.all()
         assert len(process_caller_relationships) == 2
 
     @pytest.mark.skipif(


### PR DESCRIPTION
Supports #1608 

Some code refactors to hopefully help with integrity issues found in #1608. This also adds a test to help ensure the process caller relationship table is properly cleared although we were unable to fully replicate the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Unified cache clearing methods for better maintainability and flexibility.
  - Converted several static methods to class methods for improved encapsulation and inheritance support.

- **Tests**
  - Added a new test to verify cache clearing functionality for specific files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->