### PR TITLE
check-ready-for-example-data

### DIFF
--- a/spiffworkflow-frontend/src/components/ReactFormBuilder/ReactFormBuilder.tsx
+++ b/spiffworkflow-frontend/src/components/ReactFormBuilder/ReactFormBuilder.tsx
@@ -189,7 +189,7 @@ export default function ReactFormBuilder({
 
   // Auto save example data changes
   useEffect(() => {
-    if (baseFileName !== '') {
+    if (baseFileName !== '' && ready) {
       saveFile(new File([debouncedFormData], baseFileName + DATA_EXTENSION));
     }
   }, [debouncedFormData, baseFileName, saveFile, ready]);


### PR DESCRIPTION
Do not post example data content in the form build until it has fully loaded like the other files.