### PR TITLE
blank-task-list-on-new-pi-2

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_instances_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_instances_controller.py
@@ -27,7 +27,7 @@ from spiffworkflow_backend.models.bpmn_process import BpmnProcessModel
 from spiffworkflow_backend.models.bpmn_process_definition import BpmnProcessDefinitionModel
 from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.models.json_data import JsonDataModel  # noqa: F401
-from spiffworkflow_backend.models.process_instance import ProcessInstanceApiSchema, ProcessInstanceStatus
+from spiffworkflow_backend.models.process_instance import ProcessInstanceApiSchema
 from spiffworkflow_backend.models.process_instance import ProcessInstanceCannotBeDeletedError
 from spiffworkflow_backend.models.process_instance import ProcessInstanceModel
 from spiffworkflow_backend.models.process_instance import ProcessInstanceModelSchema
@@ -380,8 +380,8 @@ def _process_instance_task_list(
     bpmn_process = None
     if bpmn_process_guid:
         bpmn_process = BpmnProcessModel.query.filter_by(guid=bpmn_process_guid).first()
-    elif process_instance.bpmn_process_id is None and process_instance.status == ProcessInstanceStatus.not_started.value:
-        # if the process instance hasn't started yet then return a blank array only.
+    elif process_instance.bpmn_process_id is None:
+        # if the process instance does not have a bpmn process then return a blank array.
         # this should help for issues like timer start events when viewing the corresponding instance.
         return make_response(jsonify([]), 200)
     else:


### PR DESCRIPTION
Supports #1629 

This removes the restriction to return a blank list of tasks if the instance is not started only. Anytime the process instance does not have a bpmn process then return a blank task list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved process instance task list handling by refining conditional checks related to `bpmn_process_id` and `status`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->