### PR TITLE
rjsf-errors-on-array-template

### DIFF
--- a/spiffworkflow-frontend/src/rjsf/carbon_theme/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/spiffworkflow-frontend/src/rjsf/carbon_theme/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -8,6 +8,7 @@ import {
   RJSFSchema,
   StrictRJSFSchema,
 } from '@rjsf/utils';
+import { getCommonAttributes } from '../../helpers';
 
 /** The `ArrayFieldTemplate` component is the template used to render all items in an array.
  *
@@ -31,6 +32,7 @@ export default function ArrayFieldTemplate<
     required,
     schema,
     title,
+    rawErrors,
   } = props;
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
   const ArrayFieldDescriptionTemplate = getTemplate<
@@ -50,15 +52,19 @@ export default function ArrayFieldTemplate<
     S,
     F
   >('ArrayFieldTitleTemplate', registry, uiOptions);
+
+  const commonAttributes = getCommonAttributes('', schema, uiSchema, rawErrors);
+
   // Button templates are not overridden in the uiSchema
   const {
     ButtonTemplates: { AddButton },
   } = registry.templates;
+
   return (
     <fieldset className={className} id={idSchema.$id}>
       <ArrayFieldTitleTemplate
         idSchema={idSchema}
-        title={uiOptions.title || title}
+        title={commonAttributes.label || title}
         required={required}
         schema={schema}
         uiSchema={uiSchema}
@@ -71,6 +77,14 @@ export default function ArrayFieldTemplate<
         uiSchema={uiSchema}
         registry={registry}
       />
+      {commonAttributes.errorMessageForField && (
+        <>
+          <div className="error-message">
+            {commonAttributes.errorMessageForField}
+          </div>
+          <br />
+        </>
+      )}
       <div className="row array-item-list">
         {items &&
           items.map(

--- a/spiffworkflow-frontend/src/rjsf/carbon_theme/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/spiffworkflow-frontend/src/rjsf/carbon_theme/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -64,7 +64,7 @@ export default function ArrayFieldTemplate<
     <fieldset className={className} id={idSchema.$id}>
       <ArrayFieldTitleTemplate
         idSchema={idSchema}
-        title={commonAttributes.label || title}
+        title={uiOptions.title || title}
         required={required}
         schema={schema}
         uiSchema={uiSchema}

--- a/spiffworkflow-frontend/src/rjsf/helpers.tsx
+++ b/spiffworkflow-frontend/src/rjsf/helpers.tsx
@@ -37,7 +37,7 @@ export const getCommonAttributes = (
       errorMessageForField = (schema as any).validationErrorMessage;
       errorMessageForFieldWithoutLabel = errorMessageForField;
     } else {
-      errorMessageForField = `${labelToUse.replace(/\*$/, '')} ${rawErrors[0]}`;
+      errorMessageForField = `"${labelToUse.replace(/\*$/, '')}" ${rawErrors[0]}`;
     }
   }
 


### PR DESCRIPTION
Fixes #1225 

This adds error message display to the ArrayFieldTemplate. I'm not sure how mui or other frameworks handle this but it works for now and we may have to change the behavior when we switch to mui.