### PR TITLE
remove-greater-than-from-md-escape

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/jinja_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/jinja_service.py
@@ -34,7 +34,10 @@ class JinjaHelpers:
     def sanitize_for_md(cls, value: str) -> str:
         """Sanitizes given value for markdown."""
         # modified from https://github.com/python-telegram-bot/python-telegram-bot/blob/1fdaaac8094c9d76c34c8c8e8c9add16080e75e7/telegram/utils/helpers.py#L149
-        escape_chars = r"_*[]()~`>#+-=|{}!"
+        #
+        # > was in this list but was removed because it doesn't seem to cause any
+        # issues and if it is in the list it prints like "&gt;" instead
+        escape_chars = r"_*[]()~`#+-=|{}!"
         escaped_value = re.sub(f"([{re.escape(escape_chars)}])", r"\\\1", value)
         escaped_value = escaped_value.replace("\n", "").replace("\r", "")
         return escaped_value


### PR DESCRIPTION
Fixes https://github.com/sartography/spiff-arena/issues/1474#issuecomment-2151540916

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved markdown sanitization by updating the character list to exclude `>`, ensuring better formatting and display of markdown content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->