### PR TITLE
Feature: Add bpmn-js-cli to model diagram with cli commands

### DIFF
--- a/spiffworkflow-frontend/package-lock.json
+++ b/spiffworkflow-frontend/package-lock.json
@@ -39,6 +39,7 @@
         "autoprefixer": "^10.4.13",
         "axios": "^1.7.2",
         "bpmn-js": "^13.2.2",
+        "bpmn-js-cli": "^2.4.0",
         "bpmn-js-properties-panel": "^1.22.0",
         "bpmn-js-spiffworkflow": "github:sartography/bpmn-js-spiffworkflow#main",
         "cookie": "^0.6.0",
@@ -7621,6 +7622,17 @@
         "min-dom": "^4.0.3",
         "object-refs": "^0.3.0",
         "tiny-svg": "^3.0.0"
+      }
+    },
+    "node_modules/bpmn-js-cli": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-cli/-/bpmn-js-cli-2.4.0.tgz",
+      "integrity": "sha512-/dVf6V1EwyJjN090/NbdY7bQdeA+I7/0Mi2JD/kFNhUVx4TN5ZrmNd/9l/EwjraYTk6o4Xvxd8nH7GdPXIu76g==",
+      "dependencies": {
+        "min-dash": "^4.1.1"
+      },
+      "peerDependencies": {
+        "bpmn-js": "*"
       }
     },
     "node_modules/bpmn-js-properties-panel": {
@@ -30936,6 +30948,14 @@
           "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.0.1.tgz",
           "integrity": "sha512-P8T4iwiW1t95vpHVHqrD36Brn7TqFYCPSHIWk9WLJtYK1X4aDd+5cgqcAADIWSjf1/i5idKnpCh9mim8hEdRBg=="
         }
+      }
+    },
+    "bpmn-js-cli": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-cli/-/bpmn-js-cli-2.4.0.tgz",
+      "integrity": "sha512-/dVf6V1EwyJjN090/NbdY7bQdeA+I7/0Mi2JD/kFNhUVx4TN5ZrmNd/9l/EwjraYTk6o4Xvxd8nH7GdPXIu76g==",
+      "requires": {
+        "min-dash": "^4.1.1"
       }
     },
     "bpmn-js-properties-panel": {

--- a/spiffworkflow-frontend/package.json
+++ b/spiffworkflow-frontend/package.json
@@ -35,6 +35,7 @@
     "autoprefixer": "^10.4.13",
     "axios": "^1.7.2",
     "bpmn-js": "^13.2.2",
+    "bpmn-js-cli": "^2.4.0",
     "bpmn-js-properties-panel": "^1.22.0",
     "bpmn-js-spiffworkflow": "github:sartography/bpmn-js-spiffworkflow#main",
     "cookie": "^0.6.0",

--- a/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
+++ b/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
@@ -6,6 +6,7 @@ import {
   BpmnPropertiesProviderModule,
   // @ts-expect-error TS(7016) FIXME: Could not find a declaration file for module 'bpmn... RemoFve this comment to see the full error message
 } from 'bpmn-js-properties-panel';
+import CliModule  from 'bpmn-js-cli';
 
 // @ts-expect-error TS(7016) FIXME: Could not find a declaration file for module 'dmn-... Remove this comment to see the full error message
 import DmnModeler from 'dmn-js/lib/Modeler';
@@ -243,7 +244,11 @@ export default function ReactDiagramEditor({
           BpmnPropertiesPanelModule,
           BpmnPropertiesProviderModule,
           ZoomScrollModule,
+          CliModule,
         ],
+        cli: {
+          bindTo: 'cli'
+        },
         moddleExtensions: {
           spiffworkflow: spiffModdleExtension,
         },


### PR DESCRIPTION
Access the cli in your developer console (open via F12 in most browsers).
Use the cli to model BPMN 2.0 diagrams in a programmatically way.

See https://github.com/bpmn-io/bpmn-js-cli

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Integrated `bpmn-js-cli` into the diagram editor for enhanced command-line interface capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->