### PR TITLE
Prevent KeyError for optional data store writes

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/json.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/json.py
@@ -69,6 +69,8 @@ class JSONDataStore(BpmnDataStoreSpecification, DataStoreCRUD):  # type: ignore
 
     def set(self, my_task: SpiffTask) -> None:
         """set."""
+        if self.bpmn_id not in my_task.data:
+            return
         model: JSONDataStoreModel | None = None
         location = self.data_store_location_for_task(JSONDataStoreModel, my_task, self.bpmn_id)
 
@@ -127,6 +129,8 @@ class JSONFileDataStore(BpmnDataStoreSpecification):  # type: ignore
 
     def set(self, my_task: SpiffTask) -> None:
         """set."""
+        if self.bpmn_id not in my_task.data:
+            return
         location = self._data_store_location_for_task(my_task, self.bpmn_id)
         if location is None:
             raise DataStoreWriteError(f"Unable to write to data store '{self.bpmn_id}' using location '{location}'.")

--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/kkv.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/kkv.py
@@ -114,6 +114,8 @@ class KKVDataStore(BpmnDataStoreSpecification, DataStoreCRUD):  # type: ignore
         my_task.data[self.bpmn_id] = getter
 
     def set(self, my_task: SpiffTask) -> None:
+        if self.bpmn_id not in my_task.data:
+            return
         location = self.data_store_location_for_task(KKVDataStoreModel, my_task, self.bpmn_id)
         store_model: KKVDataStoreModel | None = None
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/typeahead.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/typeahead.py
@@ -43,6 +43,8 @@ class TypeaheadDataStore(BpmnDataStoreSpecification, DataStoreCRUD):  # type: ig
 
     def set(self, my_task: SpiffTask) -> None:
         """set."""
+        if self.bpmn_id not in my_task.data:
+            return
         typeahead_data_by_category = my_task.data[self.bpmn_id]
         for category, items in typeahead_data_by_category.items():
             db.session.query(TypeaheadModel).filter_by(category=category).delete()


### PR DESCRIPTION
This has come up a couple times during process model creation - if you have a data store wired up for a write from a script task, but inside that script task only want to write under certain conditions a KeyError would arise. Instead of forcing the bpmn authors to work around the KeyError, we can just skip trying to write if the data store variable has not been set in task data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved data integrity by adding checks to ensure `self.bpmn_id` is present in task data before proceeding with operations, preventing potential issues in various data stores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->