### PR TITLE
Fix dictionary changed size during iteration error

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
@@ -43,8 +43,6 @@ from spiffworkflow_backend.services.process_instance_tmp_service import ProcessI
 from spiffworkflow_backend.services.task_service import StartAndEndTimes
 from spiffworkflow_backend.services.task_service import TaskService
 
-mutex = Lock()
-
 
 class WorkflowExecutionServiceError(WorkflowTaskException):  # type: ignore
     @classmethod
@@ -99,6 +97,8 @@ class EngineStepDelegate:
 class ExecutionStrategy:
     """Interface of sorts for a concrete execution strategy."""
 
+    _mutex = Lock()
+
     def __init__(self, delegate: EngineStepDelegate, options: dict | None = None):
         self.delegate = delegate
         self.options = options
@@ -129,7 +129,7 @@ class ExecutionStrategy:
             should_lock = any(isinstance(child.task_spec, SubWorkflowTaskMixin) for child in spiff_task.children)
 
             if should_lock:
-                with mutex:
+                with self._mutex:
                     spiff_task.run()
             else:
                 spiff_task.run()


### PR DESCRIPTION
Work on #1190 

Worked with @essweine - now that the core library performance changes are in we were able to reproduce the issue 100% of the time with ~200 iterations. With this fix we have been able to run without the error 100% of the time, testing up to 600 iterations. To limit the amount of locking required we are only locking when the spiff task about to be run has a child that is a sub workflow task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved task execution reliability by introducing conditional locking in the workflow execution process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->