### PR TITLE
fix-force-lock-pi-event

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_instances_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_instances_controller.py
@@ -670,7 +670,8 @@ def _process_instance_run(
 
     processor = None
     try:
-        ProcessInstanceTmpService.add_event_to_process_instance(process_instance, "process_instance_force_run")
+        if force_run is True:
+            ProcessInstanceTmpService.add_event_to_process_instance(process_instance, "process_instance_force_run")
         if not queue_process_instance_if_appropriate(
             process_instance, execution_mode=execution_mode
         ) and not ProcessInstanceTmpService.is_enqueued_to_run_in_the_future(process_instance):

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_api.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_api.py
@@ -1150,6 +1150,49 @@ class TestProcessApi(BaseTest):
         assert response.json["status"] == "complete"
         assert response.json["process_model_identifier"] == process_model.id
 
+        event_count = ProcessInstanceEventModel.query.filter_by(
+            process_instance_id=process_instance_id, event_type=ProcessInstanceEventType.process_instance_force_run.value
+        ).count()
+        assert event_count == 0
+
+    def test_process_instance_run_with_force(
+        self,
+        app: Flask,
+        client: FlaskClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+    ) -> None:
+        # process_model_id = "runs_without_input/sample"
+        process_model = self.create_group_and_model_with_bpmn(
+            client=client,
+            user=with_super_admin_user,
+            process_group_id="runs_without_input",
+            process_model_id="sample",
+            bpmn_file_name=None,
+            bpmn_file_location="sample",
+        )
+
+        headers = self.logged_in_headers(with_super_admin_user)
+        response = self.create_process_instance_from_process_model_id_with_api(client, process_model.id, headers)
+        assert response.json is not None
+        process_instance_id = response.json["id"]
+        response = client.post(
+            f"/v1.0/process-instances/{self.modify_process_identifier_for_path_param(process_model.id)}/{process_instance_id}/run?force_run=true",
+            headers=self.logged_in_headers(with_super_admin_user),
+        )
+
+        assert response.status_code == 200
+        assert response.json is not None
+        assert isinstance(response.json["updated_at_in_seconds"], int)
+        assert response.json["updated_at_in_seconds"] > 0
+        assert response.json["status"] == "complete"
+        assert response.json["process_model_identifier"] == process_model.id
+
+        event_count = ProcessInstanceEventModel.query.filter_by(
+            process_instance_id=process_instance_id, event_type=ProcessInstanceEventType.process_instance_force_run.value
+        ).count()
+        assert event_count == 1
+
     def test_process_instance_run_with_instructions(
         self,
         app: Flask,


### PR DESCRIPTION
Only create the force run pi event when appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a conditional check for `force_run` when running process instances, allowing more control over process execution.

- **Tests**
  - Added a new test to verify the behavior of running process instances with the `force_run` option, ensuring robustness and correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->