### PR TITLE
Only save all process models when a new bpmn file is added

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
@@ -601,7 +601,7 @@ def _create_or_update_process_model_file(
     file.file_contents_hash = file_contents_hash
     _commit_and_push_to_git(f"{message_for_git_commit} {process_model_identifier}/{file.name}")
 
-    if is_new_file:
+    if is_new_file and file.name.endswith(".bpmn"):
         DataSetupService.save_all_process_models()
 
     return make_response(jsonify(file), http_status_to_return)


### PR DESCRIPTION
Work on #1632 - I don't have a good way to directly test this, on my box `DataSetupService.save_all_process_models()` is quick enough that I can't notice the 10s of seconds delay - but following up on Dan's debugging from the ticket, this only saves all process models if a new bpmn file is being added. Did confirm that deleting/uploading a bpmn file that is used as a call activity still gets its references correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file handling logic to ensure that only new files ending with ".bpmn" trigger the save process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->