### PR TITLE
Support non task data environment, step 1

### DIFF
--- a/spiffworkflow-backend/dev.docker-compose.yml
+++ b/spiffworkflow-backend/dev.docker-compose.yml
@@ -13,5 +13,8 @@ services:
       SPIFFWORKFLOW_BACKEND_ENV: "${SPIFFWORKFLOW_BACKEND_ENV:-local_development}"
       SPIFFWORKFLOW_BACKEND_LOAD_FIXTURE_DATA: ""
       XDG_CACHE_HOME: "/app/.cache"
+    env_file:
+      - path: .env
+        required: false
     volumes:
       - ./spiffworkflow-backend:/app

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
@@ -234,7 +234,7 @@ config_from_env("SPIFFWORKFLOW_BACKEND_DEBUG_TASK_CONSISTENCY", default=False)
 # we load the CustomBpmnScriptEngine at import time, where we do not have access to current_app,
 # so instead of using config, we use os.environ directly over there.
 # config_from_env("SPIFFWORKFLOW_BACKEND_USE_RESTRICTED_SCRIPT_ENGINE", default=True)
-
+# config_from_env("SPIFFWORKFLOW_BACKEND_USE_NON_TASK_DATA_BASED_SCRIPT_ENGINE_ENVIRONMENT", default=False)
 
 # adds the ProxyFix to Flask on http by processing the 'X-Forwarded-Proto' header
 # to make SpiffWorkflow aware that it should return https for the server urls etc rather than http.

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -186,7 +186,7 @@ class BaseCustomScriptEngineEnvironment(BasePythonScriptEngineEnvironment):  # t
 
     def revise_state_with_task_data(self, task: SpiffTask) -> None:
         pass
-    
+
 
 class TaskDataBasedScriptEngineEnvironment(BaseCustomScriptEngineEnvironment, TaskDataEnvironment):  # type: ignore
     def __init__(self, environment_globals: dict[str, Any]):
@@ -304,8 +304,9 @@ class CustomScriptEngineEnvironment:
     def create(environment_globals: dict[str, Any]) -> BaseCustomScriptEngineEnvironment:
         if os.environ.get("SPIFFWORKFLOW_BACKEND_USE_NON_TASK_DATA_BASED_SCRIPT_ENGINE_ENVIRONMENT") == "true":
             return NonTaskDataBasedScriptEngineEnvironment(environment_globals)
-        
+
         return TaskDataBasedScriptEngineEnvironment(environment_globals)
+
 
 class CustomBpmnScriptEngine(PythonScriptEngine):  # type: ignore
     """This is a custom script processor that can be easily injected into Spiff Workflow.

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_model_test_runner_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_model_test_runner_service.py
@@ -149,7 +149,7 @@ class ProcessModelTestRunnerScriptEngine(PythonScriptEngine):  # type: ignore
         default_globals.update(safe_globals)
         default_globals["__builtins__"]["__import__"] = _import
 
-        environment = CustomScriptEngineEnvironment(default_globals)
+        environment = CustomScriptEngineEnvironment.create(default_globals)
         self.method_overrides = method_overrides
         super().__init__(environment=environment)
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/task_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/task_service.py
@@ -104,8 +104,6 @@ class TaskModelError(Exception):
 
 
 class TaskService:
-    PYTHON_ENVIRONMENT_STATE_KEY = "spiff__python_env_state"
-
     def __init__(
         self,
         process_instance: ProcessInstanceModel,

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_migrator.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_migrator.py
@@ -111,7 +111,7 @@ class TestProcessInstanceMigrator(BaseTest):
         processor = ProcessInstanceProcessor(
             process_instance, include_task_data_for_completed_tasks=True, include_completed_subprocesses=True
         )
-        bpmn_process_dict_version_4 = processor.serialize()
+        bpmn_process_dict_version_4 = processor.serialize(serialize_script_engine_state=False)
         self.round_last_state_change(bpmn_process_dict_version_4)
         self.round_last_state_change(bpmn_process_dict_version_4_from_spiff)
         assert bpmn_process_dict_version_4 == bpmn_process_dict_version_4_from_spiff
@@ -208,7 +208,7 @@ class TestProcessInstanceMigrator(BaseTest):
         processor = ProcessInstanceProcessor(
             process_instance, include_task_data_for_completed_tasks=True, include_completed_subprocesses=True
         )
-        bpmn_process_dict_version_3_after_import = processor.serialize()
+        bpmn_process_dict_version_3_after_import = processor.serialize(serialize_script_engine_state=False)
         self.round_last_state_change(bpmn_process_dict_before_import)
         self.round_last_state_change(bpmn_process_dict_version_3_after_import)
         assert bpmn_process_dict_version_3_after_import == bpmn_process_dict_before_import


### PR DESCRIPTION
Work on #1567 

Starting to bring in some changes from the `non_task_data_based_env` branch that has been in progress for a while. Main changes are moving `CustomScriptEngineEnvironment` from a hardcoded choice to a factory method so the script engine environment can be selected at runtime. This allows running tests or deploying with the non task data based environment without code changes. Also added the ability to omit the non task data state when serializing, which is required to get the migrator tests to pass _edit: when using the non task data based environment_.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for environment variables in the development setup with a new `env_file` configuration.

- **Enhancements**
	- Introduced a new configuration option for script engine environments.
	- Improved script engine environment management with new class structures and dynamic creation methods.

- **Bug Fixes**
	- Updated test cases to include a new argument for script engine state serialization.

- **Refactor**
	- Refactored script engine environment classes for better modularity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->