### PR TITLE
json-data-update-hash-on-dup

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/json_data.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/json_data.py
@@ -67,7 +67,7 @@ class JsonDataModel(SpiffworkflowBaseDBModel):
             on_duplicate_key_stmt = None
             if current_app.config["SPIFFWORKFLOW_BACKEND_DATABASE_TYPE"] == "mysql":
                 insert_stmt = mysql_insert(JsonDataModel).values(list_of_dicts)
-                on_duplicate_key_stmt = insert_stmt.on_duplicate_key_update(data=insert_stmt.inserted.data)
+                on_duplicate_key_stmt = insert_stmt.on_duplicate_key_update(hash=insert_stmt.inserted.hash)
             else:
                 insert_stmt = postgres_insert(JsonDataModel).values(list_of_dicts)
                 on_duplicate_key_stmt = insert_stmt.on_conflict_do_nothing(index_elements=["hash"])


### PR DESCRIPTION
Supports #1057 

This changes json data to update the hash column on duplicate entry. This hopefully keeps the transaction smaller and is less likely to get the deadlock issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of database operations for JSON data records, preventing issues with duplicate keys by using the `hash` field instead of the `data` field for MySQL databases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->