### PR TITLE
config scope

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
@@ -242,3 +242,5 @@ config_from_env("SPIFFWORKFLOW_BACKEND_USE_WERKZEUG_MIDDLEWARE_PROXY_FIX", defau
 
 # only for DEBUGGING - turn off threaded task execution.
 config_from_env("SPIFFWORKFLOW_BACKEND_USE_THREADS_FOR_TASK_EXECUTION", default=True)
+
+config_from_env("SPIFFWORKFLOW_BACKEND_OPENID_SCOPE", default="openid profile email")

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authentication_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authentication_service.py
@@ -259,7 +259,7 @@ class AuthenticationService:
             + f"?state={state}&"
             + "response_type=code&"
             + f"client_id={self.client_id(authentication_identifier)}&"
-            + "scope=openid profile email&"
+            + f"scope={current_app.config['SPIFFWORKFLOW_BACKEND_OPENID_SCOPE']}&"
             + f"redirect_uri={redirect_url_to_use}"
         )
         return login_redirect_url


### PR DESCRIPTION
we default to request openid, profile, and email, but other configurations may be appropriate, and it may depend on your openid provider.