### PR TITLE
Fix gunicorn and wait for schema issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,9 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 1
+    ignore:
+      - dependency-name: "gunicorn"
+        versions: ["22.0.0"]
 
   # NPM
   - package-ecosystem: npm

--- a/spiffworkflow-backend/bin/wait_for_backend_to_be_up
+++ b/spiffworkflow-backend/bin/wait_for_backend_to_be_up
@@ -23,6 +23,10 @@ while [[ "$(curl -s -o /dev/null -w '%{http_code}' "${backend_base_url}/v1.0/sta
 done
 
 echo "attempting to hit backend with SCRIPT_NAME as well, just to make sure that works, since gunicorn broke this in 22.0.0"
-curl -H "SCRIPT_NAME: /api" "${backend_base_url}/api/v1.0/status"
+status_code_for_script_name_check="$(curl -s -o /dev/null -w '%{http_code}' -H "SCRIPT_NAME: /api" "${backend_base_url}/api/v1.0/status")"
+if [[ "$status_code_for_script_name_check" != "200" ]]; then
+  >&2 echo "ERROR: Server came up, but the additional check for hitting it at /api with a SCRIPT_NAME header failed. This probably means that celery was upgraded past 22.0.0 and they still haven't fixed the bug linked in pyproject.toml. status code was: ${status_code_for_script_name_check}"
+  exit 1
+fi
 
 echo "backend up"

--- a/spiffworkflow-backend/bin/wait_for_backend_to_be_up
+++ b/spiffworkflow-backend/bin/wait_for_backend_to_be_up
@@ -10,14 +10,19 @@ set -o errtrace -o errexit -o nounset -o pipefail
 max_attempts="${1:-100}"
 port="${2:-7000}"
 
-echo "waiting for backend to come up..."
 attempts=0
-while [[ "$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:${port}/v1.0/status")" != "200" ]]; do
+backend_base_url="http://localhost:${port}"
+echo "waiting for backend to come up at ${backend_base_url} ..."
+while [[ "$(curl -s -o /dev/null -w '%{http_code}' "${backend_base_url}/v1.0/status")" != "200" ]]; do
   if [[ "$attempts" -gt "$max_attempts" ]]; then
     >&2 echo "ERROR: Server not up after $max_attempts attempts. There is probably a problem"
     exit 1
   fi
-  attempts=$(( attempts + 1 ))
+  attempts=$((attempts + 1))
   sleep 1
 done
+
+echo "attempting to hit backend with SCRIPT_NAME as well, just to make sure that works, since gunicorn broke this in 22.0.0"
+curl -H "SCRIPT_NAME: /api" "${backend_base_url}/api/v1.0/status"
+
 echo "backend up"

--- a/spiffworkflow-backend/bin/wait_for_db_schema_migrations
+++ b/spiffworkflow-backend/bin/wait_for_db_schema_migrations
@@ -7,12 +7,17 @@ function error_handler() {
 trap 'error_handler ${LINENO} $?' ERR
 set -o errtrace -o errexit -o nounset -o pipefail
 
-current_db_migration_revision=$(poetry run flask db current | awk '{print $1}')
-current_db_migration_head=$(poetry run flask db heads | awk '{print $1}')
-if [[ "$current_db_migration_revision" != "$current_db_migration_head" ]]; then
-  echo "Waiting for db migrations to finish"
-  echo "current revision: ${current_db_migration_head}"
-  echo "head revision: ${current_db_migration_revision}"
-  sleep 2
-  wait_for_db_migrations
-fi
+while true; do
+  current_db_migration_revision=$(poetry run flask db current | awk '{print $1}')
+  current_db_migration_head=$(poetry run flask db heads | awk '{print $1}')
+
+  if [[ "$current_db_migration_revision" == "$current_db_migration_head" ]]; then
+    echo "DB migrations are complete."
+    break
+  else
+    echo "Waiting for db migrations to finish"
+    echo "current revision: ${current_db_migration_head}"
+    echo "head revision: ${current_db_migration_revision}"
+    sleep 2
+  fi
+done

--- a/spiffworkflow-backend/poetry.lock
+++ b/spiffworkflow-backend/poetry.lock
@@ -1130,23 +1130,22 @@ test = ["objgraph", "psutil"]
 
 [[package]]
 name = "gunicorn"
-version = "22.0.0"
+version = "21.2.0"
 description = "WSGI HTTP Server for UNIX"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.5"
 files = [
-    {file = "gunicorn-22.0.0-py3-none-any.whl", hash = "sha256:350679f91b24062c86e386e198a15438d53a7a8207235a78ba1b53df4c4378d9"},
-    {file = "gunicorn-22.0.0.tar.gz", hash = "sha256:4a0b436239ff76fb33f11c07a16482c521a7e09c1ce3cc293c2330afe01bec63"},
+    {file = "gunicorn-21.2.0-py3-none-any.whl", hash = "sha256:3213aa5e8c24949e792bcacfc176fef362e7aac80b76c56f6b5122bf350722f0"},
+    {file = "gunicorn-21.2.0.tar.gz", hash = "sha256:88ec8bff1d634f98e61b9f65bc4bf3cd918a90806c6f5c48bc5603849ec81033"},
 ]
 
 [package.dependencies]
 packaging = "*"
 
 [package.extras]
-eventlet = ["eventlet (>=0.24.1,!=0.36.0)"]
+eventlet = ["eventlet (>=0.24.1)"]
 gevent = ["gevent (>=1.4.0)"]
 setproctitle = ["setproctitle"]
-testing = ["coverage", "eventlet", "gevent", "pytest", "pytest-cov"]
 tornado = ["tornado (>=0.2)"]
 
 [[package]]
@@ -3500,4 +3499,4 @@ tests-strict = ["pytest (==4.6.0)", "pytest (==4.6.0)", "pytest (==6.2.5)", "pyt
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "ea793944937ef97a8342a9bb06a94d3f7c0572c68fd1e982dee2e7a20d418253"
+content-hash = "6ed7e7d2fb0b1775baf99cd6599c4f516b6cf9005c0e014a7c4afe8936e4697e"

--- a/spiffworkflow-backend/pyproject.toml
+++ b/spiffworkflow-backend/pyproject.toml
@@ -57,7 +57,7 @@ Flask-SQLAlchemy = "^3"
 # 22.0.0 breaks passing in SCRIPT_NAME as a header which breaks status environments
 # https://github.com/benoitc/gunicorn/issues/3200
 # https://github.com/benoitc/gunicorn/issues/2650
-gunicorn = "22.0.0"
+gunicorn = "21.2.0"
 
 # https://github.com/dropbox/sqlalchemy-stubs/pull/251
 # someday get off github


### PR DESCRIPTION
downgrade gunicorn again (and add to catch it this time)
wait for schema script had a rename bug that made it not work at all

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved backend availability checks in the `wait_for_backend_to_be_up` script for better reliability.
  - Enhanced logic in the `wait_for_db_schema_migrations` script to ensure database schema migrations are completed correctly.

- **Bug Fixes**
  - Downgraded `gunicorn` package to version `21.2.0` to resolve issues with passing `SCRIPT_NAME` as a header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->