### PR TITLE
Fix add message fire event

### DIFF
--- a/spiffworkflow-frontend/src/components/messages/MessageEditor.tsx
+++ b/spiffworkflow-frontend/src/components/messages/MessageEditor.tsx
@@ -49,12 +49,6 @@ export function MessageEditor({
         newCorrelationProperties[formProp.id] = {
           retrieval_expression: formProp.retrievalExpression,
         };
-        // ❔❔❔ Should we keep this condition
-        // if (!(formProp.id in newCorrelationProperties)) {
-        //   newCorrelationProperties[formProp.id] = {
-        //     retrieval_expression: formProp.retrievalExpression,
-        //   };
-        // }
       });
       Object.keys(currentMessagesForId.correlation_properties || []).forEach(
         (propId: string) => {
@@ -81,12 +75,6 @@ export function MessageEditor({
     ) => {
       setProcessGroup(response);
       setDisplaySaveMessageMessage(true);
-      // console.log('Firing here', {
-      //   name: messageIdentifier,
-      //   correlation_properties: updatedMessagesForId.correlation_properties,
-      //   elementId,
-      //   updatedMessagesForId
-      // });
       messageEvent.eventBus.fire('spiff.add_message.returned', {
         name: messageIdentifier,
         correlation_properties: updatedMessagesForId.correlation_properties,
@@ -99,9 +87,8 @@ export function MessageEditor({
 
   const updateProcessGroupWithMessages = useCallback(
     (formObject: RJSFFormObject) => {
-
       const { formData } = formObject;
-      
+
       if (!processGroup) {
         return;
       }

--- a/spiffworkflow-frontend/src/components/messages/MessageEditor.tsx
+++ b/spiffworkflow-frontend/src/components/messages/MessageEditor.tsx
@@ -46,13 +46,16 @@ export function MessageEditor({
         ...currentMessagesForId.correlation_properties,
       };
       (formData.correlation_properties || []).forEach((formProp: any) => {
-        if (!(formProp.id in newCorrelationProperties)) {
-          newCorrelationProperties[formProp.id] = {
-            retrieval_expression: formProp.retrievalExpression,
-          };
-        }
+        newCorrelationProperties[formProp.id] = {
+          retrieval_expression: formProp.retrievalExpression,
+        };
+        // ❔❔❔ Should we keep this condition
+        // if (!(formProp.id in newCorrelationProperties)) {
+        //   newCorrelationProperties[formProp.id] = {
+        //     retrieval_expression: formProp.retrievalExpression,
+        //   };
+        // }
       });
-
       Object.keys(currentMessagesForId.correlation_properties || []).forEach(
         (propId: string) => {
           const foundProp = (formData.correlation_properties || []).find(
@@ -78,6 +81,12 @@ export function MessageEditor({
     ) => {
       setProcessGroup(response);
       setDisplaySaveMessageMessage(true);
+      // console.log('Firing here', {
+      //   name: messageIdentifier,
+      //   correlation_properties: updatedMessagesForId.correlation_properties,
+      //   elementId,
+      //   updatedMessagesForId
+      // });
       messageEvent.eventBus.fire('spiff.add_message.returned', {
         name: messageIdentifier,
         correlation_properties: updatedMessagesForId.correlation_properties,
@@ -90,8 +99,9 @@ export function MessageEditor({
 
   const updateProcessGroupWithMessages = useCallback(
     (formObject: RJSFFormObject) => {
-      const { formData } = formObject;
 
+      const { formData } = formObject;
+      
       if (!processGroup) {
         return;
       }


### PR DESCRIPTION
the condition of [ !(formProp.id in newCorrelationProperties) ] prevents the user from updating correlation properties.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Simplified the message editor logic for improved reliability.
  - Added logging statements to assist in debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->