### PR TITLE
bump lib to omit default on inclusive gateway with matched conditions

### DIFF
--- a/spiffworkflow-backend/poetry.lock
+++ b/spiffworkflow-backend/poetry.lock
@@ -2973,7 +2973,7 @@ doc = ["sphinx", "sphinx_rtd_theme"]
 type = "git"
 url = "https://github.com/sartography/SpiffWorkflow"
 reference = "main"
-resolved_reference = "6cf13eb18cd77f17b6c06e99c6756c0dce26675b"
+resolved_reference = "c1b367d95b1a1b4abb2c46795a3e975b65324b87"
 
 [[package]]
 name = "spiffworkflow-connector-command"


### PR DESCRIPTION
this brings exclusive gateway behavior in line with the bpmn spec.