### PR TITLE
default to local openid

### DIFF
--- a/spiffworkflow-backend/bin/local_development_environment_setup
+++ b/spiffworkflow-backend/bin/local_development_environment_setup
@@ -18,8 +18,9 @@ acceptance_test_mode="false"
 
 arg_1="${1:-}"
 
-if [[ "$arg_1" == "localopenid" ]]; then
-  use_local_open_id="true"
+use_local_open_id="true"
+if [[ "$arg_1" == "keycloak" ]]; then
+  use_local_open_id="false"
   shift
 fi
 if [[ "$arg_1" == "acceptance" ]]; then


### PR DESCRIPTION
this eliminates a keycloak container dependency by default.
you can still use keycloak if you want it, but it isn't necessary in many local dev use cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated local development environment setup to streamline OAuth configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->