### PR TITLE
message-model-perm-check

### DIFF
--- a/spiffworkflow-backend/bin/local_development_environment_setup
+++ b/spiffworkflow-backend/bin/local_development_environment_setup
@@ -55,7 +55,6 @@ elif [[ "$use_local_open_id" == "true" ]]; then
   export SPIFFWORKFLOW_BACKEND_AUTH_CONFIGS__0__uri="${backend_base_url}/openid"
   export SPIFFWORKFLOW_BACKEND_AUTH_CONFIGS__0__client_id="spiffworkflow-backend"
   export SPIFFWORKFLOW_BACKEND_AUTH_CONFIGS__0__client_secret="JXeQExm0JhQPLumgHtIIqf52bDalHz0q"
-  export SPIFFWORKFLOW_BACKEND_PERMISSIONS_FILE_NAME="example.yml"
 
 # else  # uncomment to test multiple auths
 #   export SPIFFWORKFLOW_BACKEND_AUTH_CONFIGS__0__identifier="keycloak_internal"

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/local_development.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/local_development.yml
@@ -1,14 +1,19 @@
 users:
   admin:
     service: local_open_id
-    email: admin@spiffworkflow.org
+    email: admin@example.com
     password: admin
     preferred_username: Admin
   nelson:
     service: local_open_id
-    email: nelson@spiffworkflow.org
+    email: nelson@example.com
     password: nelson
     preferred_username: Nelson
+  dan:
+    service: local_open_id
+    email: dan@example.com
+    password: dan
+    preferred_username: dan
 groups:
   admin:
     users: [admin@spiffworkflow.org, nelson@spiffworkflow.org]

--- a/spiffworkflow-frontend/src/hooks/UriListForPermissions.tsx
+++ b/spiffworkflow-frontend/src/hooks/UriListForPermissions.tsx
@@ -8,7 +8,7 @@ export const useUriListForPermissions = () => {
       authenticationListPath: `/v1.0/authentications`,
       statusPath: `/v1.0/status`,
       messageInstanceListPath: '/v1.0/messages',
-      messageModelListpath: `/v1.0/message-models/${params.process_model_id}`,
+      messageModelListPath: `/v1.0/message-models/${params.process_model_id}`,
       dataStoreListPath: '/v1.0/data-stores',
       extensionListPath: '/v1.0/extensions',
       extensionPath: `/v1.0/extensions/${params.page_identifier}`,

--- a/spiffworkflow-frontend/src/hooks/UriListForPermissions.tsx
+++ b/spiffworkflow-frontend/src/hooks/UriListForPermissions.tsx
@@ -8,6 +8,7 @@ export const useUriListForPermissions = () => {
       authenticationListPath: `/v1.0/authentications`,
       statusPath: `/v1.0/status`,
       messageInstanceListPath: '/v1.0/messages',
+      messageModelListpath: `/v1.0/message-models/${params.process_model_id}`,
       dataStoreListPath: '/v1.0/data-stores',
       extensionListPath: '/v1.0/extensions',
       extensionPath: `/v1.0/extensions/${params.page_identifier}`,

--- a/spiffworkflow-frontend/src/routes/ProcessModelEditDiagram.tsx
+++ b/spiffworkflow-frontend/src/routes/ProcessModelEditDiagram.tsx
@@ -120,7 +120,7 @@ export default function ProcessModelEditDiagram() {
 
   const { targetUris } = useUriListForPermissions();
   const permissionRequestData: PermissionsToCheck = {
-    [targetUris.messageModelListpath]: ['GET'],
+    [targetUris.messageModelListPath]: ['GET'],
   };
   const { ability } = usePermissionFetcher(permissionRequestData);
 
@@ -470,9 +470,9 @@ export default function ProcessModelEditDiagram() {
     // access to the read the process model. we also considered automatically giving you access to read message_model_list
     // when you have read access to the process model, but this seemed easier and more in line with the current backend permission system,
     // where we normally only pork barrel permissions on top of "start" and "all."
-    if (ability.can('GET', targetUris.messageModelListpath)) {
+    if (ability.can('GET', targetUris.messageModelListPath)) {
       HttpService.makeCallToBackend({
-        path: targetUris.messageModelListpath,
+        path: targetUris.messageModelListPath,
         successCallback: makeMessagesRequestedHandler(event),
       });
     }


### PR DESCRIPTION
Addresses https://github.com/sartography/spiff-arena/issues/1800#issue-2369710265

This updates the diagram editor to make sure the user has read access to the message model list api before making the call. This is to fix issues when viewing the diagram in readonly mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Integrated permission checks in the process model edit diagram.
  - Enhanced security by dynamically fetching permission-based URIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->