### PR TITLE
update security lib for release without stdout

### DIFF
--- a/spiffworkflow-backend/poetry.lock
+++ b/spiffworkflow-backend/poetry.lock
@@ -2620,13 +2620,13 @@ typing-extensions = ">=4.7.1"
 
 [[package]]
 name = "security"
-version = "1.2.1"
+version = "1.3.1"
 description = "The security toolkit for the Python community"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "security-1.2.1-py3-none-any.whl", hash = "sha256:4ca5f8cfc6b836e2192a84bb5a28b72c17f3cd1abbfe3281f917394c6e6c9238"},
-    {file = "security-1.2.1.tar.gz", hash = "sha256:0a9dc7b457330e6d0f92bdae3603fecb85394beefad0fd3b5058758a58781ded"},
+    {file = "security-1.3.1-py3-none-any.whl", hash = "sha256:9df6e75393f494ca3fd06dac3ed02f3c4fed60842b13fd00757b026cedff426b"},
+    {file = "security-1.3.1.tar.gz", hash = "sha256:7ec0853c74c7dd22a9967bda087db5d4a7df58253574e60ec475c660f839da6d"},
 ]
 
 [package.dependencies]
@@ -3355,4 +3355,4 @@ tests-strict = ["pytest (==4.6.0)", "pytest (==4.6.0)", "pytest (==6.2.5)", "pyt
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "5ff8d9a24a8ac7534be9c1261396d7023c187ac781655e2505be1e6919443bcf"
+content-hash = "2be3f1f25fe8f0f35582bce19931cf3557f9de2da8bf170d71922ae30b87e9d6"

--- a/spiffworkflow-backend/pyproject.toml
+++ b/spiffworkflow-backend/pyproject.toml
@@ -86,7 +86,7 @@ chardet = "^5.2.0"
 
 # 1.3.0 adds an print statement that keeps printing None
 # https://github.com/pixee/python-security/blob/6256809dac1c45530e5eeef8b48032a2bbd6b7d6/src/security/safe_command/api.py#L640
-security = "1.2.1"
+security = "^1.3.1"
 
 [tool.poetry.scripts]
 spiffworkflow-backend = "spiffworkflow_backend.__main__:main"

--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/human_task.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/human_task.py
@@ -57,6 +57,7 @@ class HumanTaskModel(SpiffworkflowBaseDBModel):
         viewonly=True,
         secondary="human_task_user",
         overlaps="human_task_user,users",
+        order_by="HumanTaskUserModel.id",
     )
 
     @classmethod


### PR DESCRIPTION
1.3.0 is the release that HAD stdout (we had to downgrade).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved task management by adding sorting to human tasks based on user ID.

- **Chores**
  - Updated `security` package to version `^1.3.1` for enhanced security and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->