### PR TITLE
Duplicate help text removed from typeahead field

### DIFF
--- a/spiffworkflow-frontend/src/components/CustomForm.tsx
+++ b/spiffworkflow-frontend/src/components/CustomForm.tsx
@@ -1,5 +1,5 @@
 import validator from '@rjsf/validator-ajv8';
-import { ReactNode, useEffect, useRef } from 'react';
+import { ComponentType, ReactNode, useEffect, useRef } from 'react';
 import { RegistryFieldsType } from '@rjsf/utils';
 import { Button } from '@carbon/react';
 import { Form as MuiForm } from '@rjsf/mui';
@@ -36,6 +36,15 @@ type OwnProps = {
   bpmnEvent?: any;
 };
 
+const withProps = <P extends object>(
+  Component: ComponentType<P>,
+  customProps: Partial<P>,
+) =>
+  function CustomComponent(props: P) {
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    return <Component {...props} {...customProps} />;
+  };
+
 export default function CustomForm({
   id,
   key,
@@ -54,18 +63,6 @@ export default function CustomForm({
   hideSubmitButton = false,
   bpmnEvent,
 }: OwnProps) {
-  // set in uiSchema using the "ui:widget" key for a property
-  const rjsfWidgets = {
-    'date-range': DateRangePickerWidget,
-    markdown: MarkDownFieldWidget,
-    typeahead: TypeaheadWidget,
-  };
-
-  // set in uiSchema using the "ui:field" key for a property
-  const rjsfFields: RegistryFieldsType = {
-    'numeric-range': NumericRangeField,
-  };
-
   let reactJsonSchemaFormTheme = reactJsonSchemaForm;
   if ('ui:theme' in uiSchema) {
     if (uiSchema['ui:theme'] === 'carbon') {
@@ -79,6 +76,22 @@ export default function CustomForm({
       reactJsonSchemaFormTheme = 'mui';
     }
   }
+
+  const customTypeaheadWidget = withProps(TypeaheadWidget, {
+    reactJsonSchemaFormTheme,
+  });
+
+  // set in uiSchema using the "ui:widget" key for a property
+  const rjsfWidgets = {
+    'date-range': DateRangePickerWidget,
+    markdown: MarkDownFieldWidget,
+    typeahead: customTypeaheadWidget,
+  };
+
+  // set in uiSchema using the "ui:field" key for a property
+  const rjsfFields: RegistryFieldsType = {
+    'numeric-range': NumericRangeField,
+  };
 
   const rjsfTemplates: any = {};
   if (restrictedWidth && reactJsonSchemaFormTheme === 'carbon') {

--- a/spiffworkflow-frontend/src/rjsf/custom_widgets/TypeaheadWidget/TypeaheadWidget.tsx
+++ b/spiffworkflow-frontend/src/rjsf/custom_widgets/TypeaheadWidget/TypeaheadWidget.tsx
@@ -15,6 +15,7 @@ interface typeaheadArgs {
   readonly?: boolean;
   rawErrors?: any;
   placeholder?: string;
+  reactJsonSchemaFormTheme?: string;
 }
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
@@ -30,6 +31,7 @@ export default function TypeaheadWidget({
   placeholder,
   label,
   rawErrors = [],
+  reactJsonSchemaFormTheme,
 }: typeaheadArgs) {
   const lastSearchTerm = useRef('');
   const [items, setItems] = useState<any[]>([]);
@@ -128,7 +130,9 @@ export default function TypeaheadWidget({
       itemToString={itemToString}
       placeholder={placeholderText}
       selectedItem={selectedItem}
-      helperText={commonAttributes.helperText}
+      helperText={
+        reactJsonSchemaFormTheme === 'mui' ? '' : commonAttributes.helperText
+      }
       disabled={disabled}
       readOnly={readonly}
       invalid={commonAttributes.invalid}


### PR DESCRIPTION
related to #1726 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a custom `typeahead` widget in forms for enhanced user input options.

- **Enhancements**
  - Updated behavior of helper text in the `TypeaheadWidget` based on theme settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->