### PR TITLE
avoid sending MethodNotAllowed to sentry

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/exceptions/api_error.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/exceptions/api_error.py
@@ -258,6 +258,8 @@ def should_notify_sentry(exception: Exception) -> bool:
         return False
 
     # like a 404, 405 Method Not Allowed: The method is not allowed for the requested URL
+    # it doesn't seem to work to exclude this here. i guess it happens before it gets to our app?
+    # excluded via before_send in configure_sentry
     if isinstance(exception, MethodNotAllowed):
         return False
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/monitoring_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/monitoring_service.py
@@ -8,6 +8,7 @@ import flask.wrappers
 import sentry_sdk
 from prometheus_flask_exporter import ConnexionPrometheusMetrics  # type: ignore
 from sentry_sdk.integrations.flask import FlaskIntegration
+from werkzeug.exceptions import MethodNotAllowed
 from werkzeug.exceptions import NotFound
 
 
@@ -59,6 +60,8 @@ def configure_sentry(app: flask.app.Flask) -> None:
             _exc_type, exc_value, _tb = hint["exc_info"]
             # NotFound is mostly from web crawlers
             if isinstance(exc_value, NotFound):
+                return None
+            if isinstance(exc_value, MethodNotAllowed):
                 return None
         return event
 


### PR DESCRIPTION
this can be triggered by just sending garbage to backend, which is something that scrapers, etc, do.
so just treat this like a 404, which we also try to avoid worrying about in terms of sentry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling by excluding certain exceptions, like `MethodNotAllowed`, from being sent to Sentry.
- **Refactor**
	- Updated monitoring service to handle `MethodNotAllowed` exceptions more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->