### PR TITLE
Support config SQLAlchemy pool_pre_ping option from env (#1883)

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/__init__.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/__init__.py
@@ -72,8 +72,13 @@ def setup_database_configs(app: Flask) -> None:
             # this is a sqlalchemy default, if we don't have any better ideas
             pool_size = 5
 
+    pool_pre_ping = app.config.get("SPIFFWORKFLOW_BACKEND_DATABASE_POOL_PRE_PING")
+    if pool_pre_ping is None:
+        pool_pre_ping = True
+
     app.config["SQLALCHEMY_ENGINE_OPTIONS"] = {}
     app.config["SQLALCHEMY_ENGINE_OPTIONS"]["pool_size"] = pool_size
+    app.config["SQLALCHEMY_ENGINE_OPTIONS"]["pool_pre_ping"] = pool_pre_ping
 
 
 def load_config_file(app: Flask, env_config_module: str) -> None:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
@@ -107,6 +107,9 @@ config_from_env("SPIFFWORKFLOW_BACKEND_DATABASE_URI")
 config_from_env("SPIFFWORKFLOW_BACKEND_DATABASE_PASSWORD")
 # we only use this in one place, and it checks to see if it is None.
 config_from_env("SPIFFWORKFLOW_BACKEND_DATABASE_POOL_SIZE")
+# check sqlalchemy's doc for more info about pool_pre_ping:
+# https://docs.sqlalchemy.org/en/20/core/pooling.html#disconnect-handling-pessimistic
+config_from_env("SPIFFWORKFLOW_BACKEND_DATABASE_POOL_PRE_PING", default=True)
 
 ### open id
 config_from_env("SPIFFWORKFLOW_BACKEND_AUTHENTICATION_DISABLED", default=False)


### PR DESCRIPTION
Add support for config SQLAlchemy pool_pre_ping option from env, and defaults to be true.

This will make app more robust, when an idle connection in pool is closed form server side, the app will not checkout that connection and throw an error to end user.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new database configuration parameter `SPIFFWORKFLOW_BACKEND_DATABASE_POOL_PRE_PING` to improve connection reliability. The default setting is `True` for seamless database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->