### PR TITLE
pi-migration-use-correct-git-rev

### DIFF
--- a/spiffworkflow-frontend/src/routes/ProcessInstanceMigratePage.tsx
+++ b/spiffworkflow-frontend/src/routes/ProcessInstanceMigratePage.tsx
@@ -299,7 +299,6 @@ export default function ProcessInstanceMigratePage() {
       },
     ];
     const rows = migrationEvents.map((migrationEvent: MigrationEvent) => {
-      console.log('migrationEvent', migrationEvent);
       return migrationEvent;
     });
     return (


### PR DESCRIPTION
Fixes #1908 

This updates the process instance migration process to use the old git revision on revert for both the process instance and the migration event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Implemented logic to determine the appropriate Git revision for process instance migration.

- **Bug Fixes**
  - Enhanced process instance migration to correctly handle version control identifiers and associated hashes.

- **Refactor**
  - Removed unnecessary `console.log` statements from the Process Instance Migration page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->