### PR TITLE
pi-no-run-if-non-active

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/celery_tasks/process_instance_task.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/celery_tasks/process_instance_task.py
@@ -7,6 +7,7 @@ from spiffworkflow_backend.background_processing.celery_tasks.process_instance_t
 )
 from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.models.future_task import FutureTaskModel
+from spiffworkflow_backend.models.process_instance import ProcessInstanceCannotBeRunError
 from spiffworkflow_backend.models.process_instance import ProcessInstanceModel
 from spiffworkflow_backend.models.task import TaskModel  # noqa: F401
 from spiffworkflow_backend.services.process_instance_lock_service import ProcessInstanceLockService
@@ -84,7 +85,7 @@ def celery_task_process_instance_run(self, process_instance_id: int, task_guid: 
         if task_runnability == TaskRunnability.has_ready_tasks:
             queue_process_instance_if_appropriate(process_instance, task_guid=task_guid_for_requeueing)
         return {"ok": True, "process_instance_id": process_instance_id, "task_guid": task_guid}
-    except ProcessInstanceIsAlreadyLockedError as exception:
+    except (ProcessInstanceIsAlreadyLockedError, ProcessInstanceCannotBeRunError) as exception:
         current_app.logger.info(
             f"{logger_prefix}: Could not run process instance with worker: {current_app.config['PROCESS_UUID']}"
             f" - {proc_index}. Error was: {str(exception)}"

--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/process_instance.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/process_instance.py
@@ -33,6 +33,10 @@ class ProcessInstanceCannotBeDeletedError(Exception):
     pass
 
 
+class ProcessInstanceCannotBeRunError(Exception):
+    pass
+
+
 class ProcessInstanceStatus(SpiffEnum):
     complete = "complete"
     error = "error"

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
@@ -627,7 +627,8 @@ def _dequeued_interstitial_stream(
         if execute_tasks:
             try:
                 if not ProcessInstanceTmpService.is_enqueued_to_run_in_the_future(process_instance):
-                    with ProcessInstanceQueueService.dequeued(process_instance):
+                    # let interstitial page handle this issue on its own
+                    with ProcessInstanceQueueService.dequeued(process_instance, ignore_cannot_be_run_error=True):
                         ProcessInstanceMigrator.run(process_instance)
                         yield from _interstitial_stream(process_instance, execute_tasks=execute_tasks)
             except ProcessInstanceIsAlreadyLockedError:
@@ -639,7 +640,7 @@ def _dequeued_interstitial_stream(
                 and process_instance.spiff_serializer_version < SPIFFWORKFLOW_BACKEND_SERIALIZER_VERSION
             ):
                 try:
-                    with ProcessInstanceQueueService.dequeued(process_instance):
+                    with ProcessInstanceQueueService.dequeued(process_instance, ignore_cannot_be_run_error=True):
                         ProcessInstanceMigrator.run(process_instance)
                 except ProcessInstanceIsAlreadyLockedError:
                     pass

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
@@ -628,7 +628,7 @@ def _dequeued_interstitial_stream(
             try:
                 if not ProcessInstanceTmpService.is_enqueued_to_run_in_the_future(process_instance):
                     # let interstitial page handle this issue on its own
-                    with ProcessInstanceQueueService.dequeued(process_instance, ignore_cannot_be_run_error=True):
+                    with ProcessInstanceQueueService.dequeued(process_instance):
                         ProcessInstanceMigrator.run(process_instance)
                         yield from _interstitial_stream(process_instance, execute_tasks=execute_tasks)
             except ProcessInstanceIsAlreadyLockedError:
@@ -640,7 +640,7 @@ def _dequeued_interstitial_stream(
                 and process_instance.spiff_serializer_version < SPIFFWORKFLOW_BACKEND_SERIALIZER_VERSION
             ):
                 try:
-                    with ProcessInstanceQueueService.dequeued(process_instance, ignore_cannot_be_run_error=True):
+                    with ProcessInstanceQueueService.dequeued(process_instance):
                         ProcessInstanceMigrator.run(process_instance)
                 except ProcessInstanceIsAlreadyLockedError:
                     pass

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
@@ -627,7 +627,6 @@ def _dequeued_interstitial_stream(
         if execute_tasks:
             try:
                 if not ProcessInstanceTmpService.is_enqueued_to_run_in_the_future(process_instance):
-                    # let interstitial page handle this issue on its own
                     with ProcessInstanceQueueService.dequeued(process_instance):
                         ProcessInstanceMigrator.run(process_instance)
                         yield from _interstitial_stream(process_instance, execute_tasks=execute_tasks)

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_tasks_controller.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_tasks_controller.py
@@ -260,6 +260,7 @@ class TestTasksController(BaseTest):
             f"/v1.0/tasks/{process_instance_id}/{json_results[0]['task']['id']}?with_form_data=true",
             headers=self.logged_in_headers(finance_user),
         )
+        assert response.status_code == 200
 
         # We should now be on the end task with a valid message, even after loading it many times.
         list(_dequeued_interstitial_stream(process_instance_id))

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_dot_notation.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_dot_notation.py
@@ -1,5 +1,6 @@
 from flask.app import Flask
 from flask.testing import FlaskClient
+from spiffworkflow_backend.models.process_instance import ProcessInstanceStatus
 from spiffworkflow_backend.services.process_instance_processor import ProcessInstanceProcessor
 from spiffworkflow_backend.services.process_instance_service import ProcessInstanceService
 
@@ -41,6 +42,7 @@ class TestDotNotation(BaseTest):
             "invoice.dueDate": "09/30/2022",
         }
         ProcessInstanceService.complete_form_task(processor, user_task, form_data, process_instance.process_initiator, human_task)
+        assert process_instance.status == ProcessInstanceStatus.complete.value
 
         expected = {
             "invoice.contibutorName": "Elizabeth",
@@ -49,7 +51,5 @@ class TestDotNotation(BaseTest):
             "invoice.invoiceAmount": "1000.00",
             "invoice.dueDate": "09/30/2022",
         }
-
-        processor.do_engine_steps(save=True)
         actual_data = processor.get_data()
         assert actual_data == expected

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_processor.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_processor.py
@@ -382,8 +382,6 @@ class TestProcessInstanceProcessor(BaseTest):
         human_task_one = process_instance.active_human_tasks[0]
         spiff_manual_task = processor.bpmn_process_instance.get_task_from_id(UUID(human_task_one.task_id))
         ProcessInstanceService.complete_form_task(processor, spiff_manual_task, {}, initiator_user, human_task_one)
-        processor.do_engine_steps(save=True, execution_strategy_name="greedy")
-
         assert process_instance.status == "complete"
 
     def test_properly_resets_process_on_tasks_with_boundary_events(
@@ -525,11 +523,6 @@ class TestProcessInstanceProcessor(BaseTest):
         human_task_one = process_instance.active_human_tasks[0]
         spiff_manual_task = processor.bpmn_process_instance.get_task_from_id(UUID(human_task_one.task_id))
         ProcessInstanceService.complete_form_task(processor, spiff_manual_task, {}, initiator_user, human_task_one)
-
-        # recreate variables to ensure all bpmn json was recreated from scratch from the db
-        process_instance_relookup = ProcessInstanceModel.query.filter_by(id=process_instance.id).first()
-        processor_last_tasks = ProcessInstanceProcessor(process_instance_relookup)
-        processor_last_tasks.do_engine_steps(save=True, execution_strategy_name="greedy")
 
         process_instance_relookup = ProcessInstanceModel.query.filter_by(id=process_instance.id).first()
         processor_final = ProcessInstanceProcessor(process_instance_relookup, include_completed_subprocesses=True)


### PR DESCRIPTION
This adds a raise if do_engine_steps is called on a process instance that does not have an active status. This is to help avoid processing instances from celery that are suspended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new exception `ProcessInstanceCannotBeRunError` to handle specific error cases during process execution.

- **Bug Fixes**
  - Improved exception handling in process instance queuing to prevent unhandled errors.

- **Tests**
  - Added new assertions and modified existing tests to ensure robust error handling and process instance status verification.

- **Refactor**
  - Updated various methods to include an `ignore_cannot_be_run_error` parameter for more flexible error management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->