### PR TITLE
pi-migration-dedup-events

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
@@ -259,6 +259,7 @@ class ProcessInstanceService:
                 bpmn_definition_to_task_definitions_mappings={},
                 process_instance_model=process_instance,
                 bpmn_process_instance=processor.bpmn_process_instance,
+                store_process_instance_events=False,
             )
             git_revision_to_use = cls.get_appropriate_git_revision(
                 process_instance, initial_bpmn_process_hash, target_bpmn_process_hash

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_service.py
@@ -209,6 +209,11 @@ class TestProcessInstanceService(BaseTest):
         mock_get_current_revision.return_value = "rev2"
         ProcessInstanceService.migrate_process_instance(process_instance, user=initiator_user)
 
+        # there should only be 5 events after the migration. anymore indicates that events are getting duplicated.
+        process_instance_events = ProcessInstanceEventModel.query.filter_by(process_instance_id=process_instance.id).all()
+        # NOTE: this would be 5 but for some reason we are not storing the event for the spiff created subprocess start task
+        assert len(process_instance_events) == 4
+
         for initial_task in initial_tasks:
             new_task = processor.bpmn_process_instance.get_task_from_id(initial_task.id)
             assert new_task is not None


### PR DESCRIPTION
Fixes #1928 

We should not store process instance events when updating tasks in a pi migration. Those events are just duplicates of previously entered events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an option to store process instance events during migration.

- **Tests**
  - Updated tests to verify the correct number of events after migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->