### PR TITLE
pi-migration-hide-revert-button

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
@@ -1344,6 +1344,12 @@ paths:
         description: The unique id of an existing process instance.
         schema:
           type: integer
+      - name: target_bpmn_process_hash
+        in: query
+        required: false
+        description: The full bpmn process hash of the target version of the process model.
+        schema:
+          type: string
     get:
       tags:
         - Process Instances

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_instances_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_instances_controller.py
@@ -551,6 +551,7 @@ def process_instance_reset(
 def process_instance_check_can_migrate(
     process_instance_id: int,
     modified_process_model_identifier: str,
+    target_bpmn_process_hash: str | None = None,
 ) -> flask.wrappers.Response:
     process_instance = _find_process_instance_by_id_or_raise(process_instance_id)
     return_dict: dict = {
@@ -560,7 +561,9 @@ def process_instance_check_can_migrate(
         "current_bpmn_process_hash": process_instance.bpmn_process.bpmn_process_definition.full_process_model_hash,
     }
     try:
-        ProcessInstanceService.check_process_instance_can_be_migrated(process_instance)
+        ProcessInstanceService.check_process_instance_can_be_migrated(
+            process_instance, target_bpmn_process_hash=target_bpmn_process_hash
+        )
     except (ProcessInstanceMigrationNotSafeError, ProcessInstanceMigrationUnnecessaryError) as exception:
         return_dict["can_migrate"] = False
         return_dict["exception_class"] = exception.__class__.__name__

--- a/spiffworkflow-frontend/src/interfaces.ts
+++ b/spiffworkflow-frontend/src/interfaces.ts
@@ -558,3 +558,9 @@ export interface MigrationEvent {
   timestamp: string;
   username: string;
 }
+export interface MigrationCheckResult {
+  can_migrate: boolean;
+  process_instance_id: number;
+  current_git_revision: string;
+  current_bpmn_process_hash: string;
+}


### PR DESCRIPTION
Addresses #1919 

This omits the Revert button the pi migration page if the migration check result fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new query parameter `target_bpmn_process_hash` to support process migration checks.
  - Added conditional rendering in the migration process based on the migration check results.

- **Refactor**
  - Updated migration functions and states to use `target_bpmn_process_hash` instead of the previous `migrationEvent` parameter.
  
- **Bug Fixes**
  - Improved backend validation during process instance migration.

- **Documentation**
  - Updated API documentation to include the new `target_bpmn_process_hash` parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->