### PR TITLE
form-editor-allow-readonly

### DIFF
--- a/spiffworkflow-frontend/src/routes/ProcessModelEditDiagram.tsx
+++ b/spiffworkflow-frontend/src/routes/ProcessModelEditDiagram.tsx
@@ -122,8 +122,11 @@ export default function ProcessModelEditDiagram() {
   const { targetUris } = useUriListForPermissions();
   const permissionRequestData: PermissionsToCheck = {
     [targetUris.messageModelListPath]: ['GET'],
+    [targetUris.processModelFileCreatePath]: ['PUT', 'POST'],
   };
-  const { ability } = usePermissionFetcher(permissionRequestData);
+  const { ability, permissionsLoaded } = usePermissionFetcher(
+    permissionRequestData,
+  );
 
   function handleEditorDidMount(editor: any, monaco: any) {
     // here is the editor instance
@@ -1251,7 +1254,7 @@ export default function ProcessModelEditDiagram() {
   };
 
   const jsonSchemaEditor = () => {
-    if (!showJsonSchemaEditor) {
+    if (!showJsonSchemaEditor || !permissionsLoaded) {
       return null;
     }
     return (
@@ -1267,6 +1270,14 @@ export default function ProcessModelEditDiagram() {
           processModelId={params.process_model_id || ''}
           fileName={jsonScehmaFileName}
           onFileNameSet={setJsonScehmaFileName}
+          canUpdateFiles={ability.can(
+            'POST',
+            targetUris.processModelFileCreatePath,
+          )}
+          canCreateFiles={ability.can(
+            'PUT',
+            targetUris.processModelFileCreatePath,
+          )}
         />
       </Modal>
     );


### PR DESCRIPTION
Fixes #1199

Check for update and create file permissions on the ReactFormBuilder before attempting to make the calls or allowing users to make any changes when they cannot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new permissions-based controls for file creation and updates in form builder components.
  - Enhanced `ProcessModelEditDiagram` with additional permission checks for rendering components.

- **Improvements**
  - Conditional rendering of UI elements based on user permissions to improve user experience and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->