### PR TITLE
pi-migration-update-human-task

### DIFF
--- a/spiffworkflow-backend/bin/run_ci_session
+++ b/spiffworkflow-backend/bin/run_ci_session
@@ -71,7 +71,7 @@ elif [[ "${session_type}" == "mypy" ]]; then
   poetry run mypy src tests
 
 elif [[ "${session_type}" == "safety" ]]; then
-  poetry run safety check --full-report --ignore=70624 --ignore=70612
+  poetry run safety check --full-report --ignore=70624 --ignore=70612 --ignore=71600 --ignore=71594
 
 elif [[ "${session_type}" == "coverage" ]]; then
   if ls .coverage.* 1>/dev/null 2>&1; then

--- a/spiffworkflow-backend/poetry.lock
+++ b/spiffworkflow-backend/poetry.lock
@@ -3329,13 +3329,13 @@ devenv = ["check-manifest", "pytest (>=4.3)", "pytest-cov", "pytest-mock (>=3.3)
 
 [[package]]
 name = "urllib3"
-version = "2.2.1"
+version = "2.2.2"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "urllib3-2.2.1-py3-none-any.whl", hash = "sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d"},
-    {file = "urllib3-2.2.1.tar.gz", hash = "sha256:d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19"},
+    {file = "urllib3-2.2.2-py3-none-any.whl", hash = "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472"},
+    {file = "urllib3-2.2.2.tar.gz", hash = "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"},
 ]
 
 [package.extras]

--- a/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
@@ -1748,7 +1748,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/OkTrue"
 
-  # NOT USED
   /tasks:
     parameters:
       - name: process_instance_id

--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/human_task.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/human_task.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from flask import g
+from SpiffWorkflow.task import Task as SpiffTask  # type: ignore
 from sqlalchemy import ForeignKey
 from sqlalchemy.orm import relationship
 
@@ -59,6 +60,10 @@ class HumanTaskModel(SpiffworkflowBaseDBModel):
         overlaps="human_task_user,users",
         order_by="HumanTaskUserModel.id",
     )
+
+    def update_attributes_from_spiff_task(self, spiff_task: SpiffTask) -> None:
+        # currently only used for process instance migrations where only the bpmn_name is allowed to be updated
+        self.task_title = spiff_task.task_spec.bpmn_name
 
     @classmethod
     def to_task(cls, task: HumanTaskModel) -> Task:

--- a/spiffworkflow-backend/tests/data/migration-test-with-subprocess/migration-initial.bpmn
+++ b/spiffworkflow-backend/tests/data/migration-test-with-subprocess/migration-initial.bpmn
@@ -20,7 +20,7 @@
         <bpmn:incoming>Flow_0s7769x</bpmn:incoming>
       </bpmn:endEvent>
       <bpmn:sequenceFlow id="Flow_0s7769x" sourceRef="manual_task_one" targetRef="Event_0fx2psf" />
-      <bpmn:manualTask id="manual_task_one">
+      <bpmn:manualTask id="manual_task_one" name="Manual Task 1">
         <bpmn:incoming>Flow_01eckoj</bpmn:incoming>
         <bpmn:outgoing>Flow_0s7769x</bpmn:outgoing>
       </bpmn:manualTask>

--- a/spiffworkflow-backend/tests/data/migration-test-with-subprocess/migration-new.bpmn
+++ b/spiffworkflow-backend/tests/data/migration-test-with-subprocess/migration-new.bpmn
@@ -20,7 +20,7 @@
         <bpmn:incoming>Flow_17fvyk2</bpmn:incoming>
       </bpmn:endEvent>
       <bpmn:sequenceFlow id="Flow_0s7769x" sourceRef="manual_task_one" targetRef="manual_task_two" />
-      <bpmn:manualTask id="manual_task_one">
+      <bpmn:manualTask id="manual_task_one" name="Manual Task One">
         <bpmn:incoming>Flow_01eckoj</bpmn:incoming>
         <bpmn:outgoing>Flow_0s7769x</bpmn:outgoing>
       </bpmn:manualTask>

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_service.py
@@ -182,6 +182,11 @@ class TestProcessInstanceService(BaseTest):
         initial_bpmn_process_hash = process_instance.bpmn_process_definition.full_process_model_hash
         assert initial_bpmn_process_hash is not None
 
+        human_task_one = process_instance.active_human_tasks[0]
+        assert human_task_one.task_model.task_definition.bpmn_identifier == "manual_task_one"
+        assert human_task_one.task_title == "Manual Task 1"
+        assert human_task_one.task_name == "manual_task_one"
+
         initial_tasks = processor.bpmn_process_instance.get_tasks()
         spiff_task = processor.__class__.get_task_by_bpmn_identifier("manual_task_two", processor.bpmn_process_instance)
         assert spiff_task is None
@@ -224,6 +229,7 @@ class TestProcessInstanceService(BaseTest):
 
         human_task_one = process_instance.active_human_tasks[0]
         assert human_task_one.task_model.task_definition.bpmn_identifier == "manual_task_one"
+        assert human_task_one.task_title == "Manual Task One"
         self.complete_next_manual_task(processor)
 
         human_task_one = process_instance.active_human_tasks[0]


### PR DESCRIPTION
Fixes #1945 

This ensures the current human tasks get updated bpmn_names when running process instance migrations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved readability and clarity of BPMN workflows by adding descriptive names to manual tasks.

- **Bug Fixes**
  - Enhanced the process instance migration logic to update attributes of human tasks correctly.

- **Tests**
  - Added and corrected assertions in process instance migration tests to ensure `task_title` and `task_name` values are accurate.

- **Chores**
  - Updated safety check commands in CI scripts to include additional ignore flags based on session type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->