### PR TITLE
update bpmn subprocess map in complete_task

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -631,14 +631,14 @@ class ProcessInstanceProcessor:
             bpmn_definition_to_task_definitions_mappings[bpmn_process_definition_identifier] = {}
 
         if task_definition is not None:
-            bpmn_definition_to_task_definitions_mappings[bpmn_process_definition_identifier][
-                task_definition.bpmn_identifier
-            ] = task_definition
+            bpmn_definition_to_task_definitions_mappings[bpmn_process_definition_identifier][task_definition.bpmn_identifier] = (
+                task_definition
+            )
 
         if bpmn_process_definition is not None:
-            bpmn_definition_to_task_definitions_mappings[bpmn_process_definition_identifier][
-                "bpmn_process_definition"
-            ] = bpmn_process_definition
+            bpmn_definition_to_task_definitions_mappings[bpmn_process_definition_identifier]["bpmn_process_definition"] = (
+                bpmn_process_definition
+            )
 
     @classmethod
     def _get_definition_dict_for_bpmn_process_definition(
@@ -690,9 +690,9 @@ class ProcessInstanceProcessor:
             bpmn_process_definition_dict: dict = bpmn_subprocess_definition.properties_json
             spiff_bpmn_process_dict["subprocess_specs"][bpmn_subprocess_definition.bpmn_identifier] = bpmn_process_definition_dict
             spiff_bpmn_process_dict["subprocess_specs"][bpmn_subprocess_definition.bpmn_identifier]["task_specs"] = {}
-            bpmn_subprocess_definition_bpmn_identifiers[
-                bpmn_subprocess_definition.id
-            ] = bpmn_subprocess_definition.bpmn_identifier
+            bpmn_subprocess_definition_bpmn_identifiers[bpmn_subprocess_definition.id] = (
+                bpmn_subprocess_definition.bpmn_identifier
+            )
 
         task_definitions = TaskDefinitionModel.query.filter(
             TaskDefinitionModel.bpmn_process_definition_id.in_(bpmn_subprocess_definition_bpmn_identifiers.keys())  # type: ignore

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -631,14 +631,14 @@ class ProcessInstanceProcessor:
             bpmn_definition_to_task_definitions_mappings[bpmn_process_definition_identifier] = {}
 
         if task_definition is not None:
-            bpmn_definition_to_task_definitions_mappings[bpmn_process_definition_identifier][task_definition.bpmn_identifier] = (
-                task_definition
-            )
+            bpmn_definition_to_task_definitions_mappings[bpmn_process_definition_identifier][
+                task_definition.bpmn_identifier
+            ] = task_definition
 
         if bpmn_process_definition is not None:
-            bpmn_definition_to_task_definitions_mappings[bpmn_process_definition_identifier]["bpmn_process_definition"] = (
-                bpmn_process_definition
-            )
+            bpmn_definition_to_task_definitions_mappings[bpmn_process_definition_identifier][
+                "bpmn_process_definition"
+            ] = bpmn_process_definition
 
     @classmethod
     def _get_definition_dict_for_bpmn_process_definition(
@@ -690,9 +690,9 @@ class ProcessInstanceProcessor:
             bpmn_process_definition_dict: dict = bpmn_subprocess_definition.properties_json
             spiff_bpmn_process_dict["subprocess_specs"][bpmn_subprocess_definition.bpmn_identifier] = bpmn_process_definition_dict
             spiff_bpmn_process_dict["subprocess_specs"][bpmn_subprocess_definition.bpmn_identifier]["task_specs"] = {}
-            bpmn_subprocess_definition_bpmn_identifiers[bpmn_subprocess_definition.id] = (
-                bpmn_subprocess_definition.bpmn_identifier
-            )
+            bpmn_subprocess_definition_bpmn_identifiers[
+                bpmn_subprocess_definition.id
+            ] = bpmn_subprocess_definition.bpmn_identifier
 
         task_definitions = TaskDefinitionModel.query.filter(
             TaskDefinitionModel.bpmn_process_definition_id.in_(bpmn_subprocess_definition_bpmn_identifiers.keys())  # type: ignore
@@ -1829,6 +1829,7 @@ class ProcessInstanceProcessor:
         for spiff_task_to_update in tasks_to_update:
             if spiff_task_to_update.id != spiff_task.id:
                 task_service.update_task_model_with_spiff_task(spiff_task_to_update)
+        self.task_model_mapping, self.bpmn_subprocess_mapping = task_service.get_guid_to_db_object_mappings()
 
         task_service.save_objects_to_database()
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/task_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/task_service.py
@@ -145,6 +145,9 @@ class TaskService:
             db.session.bulk_save_objects(self.process_instance_events.values())
         JsonDataModel.insert_or_update_json_data_records(self.json_data_dicts)
 
+    def get_guid_to_db_object_mappings(self) -> tuple[dict[str, TaskModel], dict[str, BpmnProcessModel]]:
+        return (self.task_model_mapping, self.bpmn_subprocess_mapping)
+
     def process_parents_and_children_and_save_to_database(
         self,
         spiff_task: SpiffTask,

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
@@ -362,7 +362,7 @@ class TaskModelSavingDelegate(EngineStepDelegate):
         self.after_engine_steps(bpmn_process_instance)
 
     def get_guid_to_db_object_mappings(self) -> tuple[dict[str, TaskModel], dict[str, BpmnProcessModel]]:
-        return (self.task_service.task_model_mapping, self.task_service.bpmn_subprocess_mapping)
+        return self.task_service.get_guid_to_db_object_mappings()
 
     def _should_update_task_model(self) -> bool:
         """No reason to save task model stuff if the process instance isn't persistent."""

--- a/spiffworkflow-backend/tests/data/basic_call_activity_series/call-activity-1.bpmn
+++ b/spiffworkflow-backend/tests/data/basic_call_activity_series/call-activity-1.bpmn
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_96f6665" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.0.0-dev">
+  <bpmn:process id="Process_call_activity_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_17db3yp</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_17db3yp" sourceRef="StartEvent_1" targetRef="Activity_1w9hd2i" />
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_0yb35nr</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0yb35nr" sourceRef="Activity_1l3sfen" targetRef="EndEvent_1" />
+    <bpmn:sequenceFlow id="Flow_1706dpg" sourceRef="Activity_1w9hd2i" targetRef="Activity_1l3sfen" />
+    <bpmn:manualTask id="Activity_1w9hd2i" name="Manual Task 1">
+      <bpmn:incoming>Flow_17db3yp</bpmn:incoming>
+      <bpmn:outgoing>Flow_1706dpg</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:callActivity id="Activity_1l3sfen" name="Call activity 1" calledElement="Process_call_activity_2">
+      <bpmn:incoming>Flow_1706dpg</bpmn:incoming>
+      <bpmn:outgoing>Flow_0yb35nr</bpmn:outgoing>
+    </bpmn:callActivity>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_call_activity_test_1_az94iwq">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="2" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_14za570_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="432" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0u7be9i_di" bpmnElement="Activity_1w9hd2i">
+        <dc:Bounds x="80" y="137" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1f490xu_di" bpmnElement="Activity_1l3sfen">
+        <dc:Bounds x="260" y="137" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_17db3yp_di" bpmnElement="Flow_17db3yp">
+        <di:waypoint x="38" y="177" />
+        <di:waypoint x="80" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0yb35nr_di" bpmnElement="Flow_0yb35nr">
+        <di:waypoint x="360" y="177" />
+        <di:waypoint x="432" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1706dpg_di" bpmnElement="Flow_1706dpg">
+        <di:waypoint x="180" y="177" />
+        <di:waypoint x="260" y="177" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/spiffworkflow-backend/tests/data/basic_call_activity_series/call-activity-2.bpmn
+++ b/spiffworkflow-backend/tests/data/basic_call_activity_series/call-activity-2.bpmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:spiffworkflow="http://spiffworkflow.org/bpmn/schema/1.0/core" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_96f6665" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.0.0-dev">
+  <bpmn:process id="Process_call_activity_2" name="Process_call_activity_2" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start Process">
+      <bpmn:outgoing>Flow_02pymet</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_02pymet" sourceRef="StartEvent_1" targetRef="Activity_1s0zolw" />
+    <bpmn:endEvent id="Event_1xwu325" name="End Process">
+      <bpmn:extensionElements>
+        <spiffworkflow:instructionsForEndUser>End Call Activity with Manual Task Unit Test</spiffworkflow:instructionsForEndUser>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0p08lwv</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0p08lwv" sourceRef="Activity_1s0zolw" targetRef="Event_1xwu325" />
+    <bpmn:callActivity id="Activity_1s0zolw" name="Call Activity with Manual Task" calledElement="Process_final_model">
+      <bpmn:incoming>Flow_02pymet</bpmn:incoming>
+      <bpmn:outgoing>Flow_0p08lwv</bpmn:outgoing>
+    </bpmn:callActivity>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Unit_Test_Call_Activity_with_Manual_Task">
+      <bpmndi:BPMNShape id="Event_1xwu325_di" bpmnElement="Event_1xwu325">
+        <dc:Bounds x="432" y="159" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="419" y="202" width="62" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0es9ftq_di" bpmnElement="Activity_1s0zolw">
+        <dc:Bounds x="270" y="137" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="172" y="159" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="158" y="202" width="67" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_02pymet_di" bpmnElement="Flow_02pymet">
+        <di:waypoint x="208" y="177" />
+        <di:waypoint x="270" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0p08lwv_di" bpmnElement="Flow_0p08lwv">
+        <di:waypoint x="370" y="177" />
+        <di:waypoint x="432" y="177" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/spiffworkflow-backend/tests/data/basic_call_activity_series/final-model.bpmn
+++ b/spiffworkflow-backend/tests/data/basic_call_activity_series/final-model.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:spiffworkflow="http://spiffworkflow.org/bpmn/schema/1.0/core" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_96f6665" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.0.0-dev">
+  <bpmn:process id="Process_final_model" name="Process_final_model" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_0j6aw3u</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0j6aw3u" sourceRef="StartEvent_1" targetRef="ScriptTask1" />
+    <bpmn:scriptTask id="ScriptTask1">
+      <bpmn:incoming>Flow_0j6aw3u</bpmn:incoming>
+      <bpmn:outgoing>Flow_1qv7n0a</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:endEvent id="Event_0kh8ixq" name="End">
+      <bpmn:incoming>Flow_1qv7n0a</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1qv7n0a" sourceRef="ScriptTask1" targetRef="Event_0kh8ixq" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Unit_Test_Manual_Task">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="154" y="202" width="87" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1la3apb_di" bpmnElement="ScriptTask1">
+        <dc:Bounds x="270" y="137" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0kh8ixq_di" bpmnElement="Event_0kh8ixq">
+        <dc:Bounds x="432" y="159" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="409" y="202" width="82" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0j6aw3u_di" bpmnElement="Flow_0j6aw3u">
+        <di:waypoint x="215" y="177" />
+        <di:waypoint x="270" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1qv7n0a_di" bpmnElement="Flow_1qv7n0a">
+        <di:waypoint x="370" y="177" />
+        <di:waypoint x="432" y="177" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/helpers/example_data.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/helpers/example_data.py
@@ -16,6 +16,7 @@ class ExampleDataLoader:
         description: str = "",
         display_order: int = 0,
         bpmn_file_name: str | None = None,
+        primary_file_name: str | None = None,
         process_model_source_directory: str | None = None,
     ) -> ProcessModelInfo:
         """Assumes that process_model_source_directory exists in static/bpmn and contains bpmn_file_name.
@@ -71,7 +72,7 @@ class ExampleDataLoader:
 
             filename = os.path.basename(file_path)
             # since there are multiple bpmn files in a test data directory, ensure we set the correct one as the primary
-            is_primary = filename.lower() == bpmn_file_name_with_extension
+            is_primary = filename.lower() in [primary_file_name, bpmn_file_name_with_extension]
             file = None
             try:
                 file = open(file_path, "rb")

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/helpers/test_data.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/helpers/test_data.py
@@ -31,6 +31,7 @@ def assure_process_group_exists(process_group_id: str | None = None) -> ProcessG
 def load_test_spec(
     process_model_id: str,
     bpmn_file_name: str | None = None,
+    primary_file_name: str | None = None,
     process_model_source_directory: str | None = None,
 ) -> ProcessModelInfo:
     """Loads a bpmn file into the process model dir based on a directory in tests/data."""
@@ -42,5 +43,6 @@ def load_test_spec(
         display_name=process_model_id,
         bpmn_file_name=bpmn_file_name,
         process_model_source_directory=process_model_source_directory,
+        primary_file_name=primary_file_name,
     )
     return spec

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_processor.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_processor.py
@@ -1,4 +1,3 @@
-import uuid
 from uuid import UUID
 
 import pytest
@@ -24,7 +23,6 @@ from spiffworkflow_backend.services.authorization_service import AuthorizationSe
 from spiffworkflow_backend.services.process_instance_processor import ProcessInstanceProcessor
 from spiffworkflow_backend.services.process_instance_service import ProcessInstanceService
 from spiffworkflow_backend.services.workflow_execution_service import WorkflowExecutionServiceError
-import random
 
 from tests.spiffworkflow_backend.helpers.base_test import BaseTest
 from tests.spiffworkflow_backend.helpers.test_data import load_test_spec
@@ -1125,10 +1123,6 @@ class TestProcessInstanceProcessor(BaseTest):
         client: FlaskClient,
         with_db_and_bpmn_file_cleanup: None,
     ) -> None:
-        rd = random.Random()
-        rd.seed(0)
-        uuid.uuid4 = lambda: uuid.UUID(int=rd.getrandbits(128))
-
         initiator_user = self.find_or_create_user("initiator_user")
         process_model = load_test_spec(
             process_model_id="test_group/basic_call_activity_series",


### PR DESCRIPTION
Fixes #1951 

Ensures the task and bpmn process mappings are updated properly in complete_task so the proper items will be cached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for BPMN processes with call activities.
  - Added new BPMN process definitions for testing call activities.

- **Bug Fixes**
  - Ensured task and subprocess mappings are correctly updated during task completion.

- **Tests**
  - Added tests for BPMN processes with call activities.
  - Enhanced test data loading with new parameters for improved flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->