### PR TITLE
pi-migration-reassign-ht

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/interfaces.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/interfaces.py
@@ -43,3 +43,8 @@ class GroupPermissionsDict(TypedDict):
     users: list[str]
     name: str
     permissions: list[DesiredGroupPermissionDict]
+
+
+class PotentialOwnerIdList(TypedDict):
+    potential_owner_ids: list[int]
+    lane_assignment_id: int | None

--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/human_task.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/human_task.py
@@ -8,6 +8,7 @@ from SpiffWorkflow.task import Task as SpiffTask  # type: ignore
 from sqlalchemy import ForeignKey
 from sqlalchemy.orm import relationship
 
+from spiffworkflow_backend.interfaces import PotentialOwnerIdList
 from spiffworkflow_backend.models.db import SpiffworkflowBaseDBModel
 from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.models.group import GroupModel
@@ -61,9 +62,10 @@ class HumanTaskModel(SpiffworkflowBaseDBModel):
         order_by="HumanTaskUserModel.id",
     )
 
-    def update_attributes_from_spiff_task(self, spiff_task: SpiffTask) -> None:
+    def update_attributes_from_spiff_task(self, spiff_task: SpiffTask, potential_owner_hash: PotentialOwnerIdList) -> None:
         # currently only used for process instance migrations where only the bpmn_name is allowed to be updated
         self.task_title = spiff_task.task_spec.bpmn_name
+        self.lane_assignment_id = potential_owner_hash["lane_assignment_id"]
 
     @classmethod
     def to_task(cls, task: HumanTaskModel) -> Task:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -17,7 +17,6 @@ from datetime import timedelta
 from hashlib import sha256
 from typing import Any
 from typing import NewType
-from typing import TypedDict
 from uuid import UUID
 from uuid import uuid4
 
@@ -66,6 +65,7 @@ from spiffworkflow_backend.data_stores.typeahead import TypeaheadDataStore
 from spiffworkflow_backend.data_stores.typeahead import TypeaheadDataStoreConverter
 from spiffworkflow_backend.exceptions.api_error import ApiError
 from spiffworkflow_backend.exceptions.error import TaskMismatchError
+from spiffworkflow_backend.interfaces import PotentialOwnerIdList
 from spiffworkflow_backend.models.bpmn_process import BpmnProcessModel
 from spiffworkflow_backend.models.bpmn_process_definition import BpmnProcessDefinitionModel
 from spiffworkflow_backend.models.bpmn_process_definition_relationship import BpmnProcessDefinitionRelationshipModel
@@ -142,11 +142,6 @@ WorkflowCompletedHandler = Callable[[ProcessInstanceModel], None]
 def _import(name: str, glbls: dict[str, Any], *args: Any) -> None:
     if name not in glbls:
         raise ImportError(f"Import not allowed: {name}", name=name)
-
-
-class PotentialOwnerIdList(TypedDict):
-    potential_owner_ids: list[int]
-    lane_assignment_id: int | None
 
 
 class ProcessInstanceProcessorError(Exception):


### PR DESCRIPTION
Addresses https://github.com/sartography/spiff-arena/issues/1671#issuecomment-2242570540

This allows for human task reassignment in a process instance migration. This way if a task is changed to or from a guest task, the appropriate users will get assigned the task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new data structure to manage potential owner IDs for better group permissions and ownership management.
	- Enhanced task migration functionality to dynamically assign and update user assignments based on potential owners.

- **Bug Fixes**
	- Improved transaction handling during updates to ensure coordinated changes in human task attributes and user assignments.

- **Refactor**
	- Simplified data models related to process instance ownership management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->