### PR TITLE
hide-view-call-activity

### DIFF
--- a/spiffworkflow-frontend/src/routes/ProcessInstanceShow.tsx
+++ b/spiffworkflow-frontend/src/routes/ProcessInstanceShow.tsx
@@ -735,9 +735,7 @@ export default function ProcessInstanceShow({ variant }: OwnProps) {
   const initializeTaskDataToDisplay = (task: Task | null) => {
     if (
       task &&
-      (task.state === 'COMPLETED' ||
-        task.state === 'ERROR' ||
-        task.state === 'READY') &&
+      ['COMPLETED', 'ERROR', 'READY'].includes(task.state) &&
       ability.can('GET', targetUris.processInstanceTaskDataPath)
     ) {
       setShowTaskDataLoading(true);
@@ -1127,7 +1125,10 @@ export default function ProcessInstanceShow({ variant }: OwnProps) {
       );
     }
 
-    if (task.typename === 'CallActivity') {
+    if (
+      task.typename === 'CallActivity' &&
+      !['FUTURE', 'LIKELY', 'MAYBE'].includes(task.state)
+    ) {
       const taskDefinitionPropertiesJson: TaskDefinitionPropertiesJson =
         task.task_definition_properties_json;
       buttons.push(


### PR DESCRIPTION
Fixes #1963 

This hides the "View Call Activity Diagram" link from CallActivity tasks in a future type state. This is because while in that type of state the CallActivity has not created its subprocess task instances and therefore there is nothing to actually view and it errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved logic for displaying task data based on refined conditions for task states and types. 
- **Bug Fixes**
	- Enhanced control flow to prevent processing of certain tasks under specific states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->