### PR TITLE
Refactor bpmn diagram component

### DIFF
--- a/spiffworkflow-frontend/cypress/e2e/process_instances.cy.js
+++ b/spiffworkflow-frontend/cypress/e2e/process_instances.cy.js
@@ -111,29 +111,31 @@ describe('process-instances', () => {
     cy.contains(originalDmnOutputForKevin).should('not.exist');
     cy.runPrimaryBpmnFile();
 
+    const processModelFiles = 'process-model-files';
+
     // Change dmn
-    cy.getBySel('process-model-files').click();
+    cy.getBySel(processModelFiles).click();
     cy.getBySel(`edit-file-${dmnFile.replace('.', '-')}`).click();
     updateDmnText(originalDmnOutputForKevin, newDmnOutputForKevin);
 
     cy.contains(acceptanceTestOneDisplayName).click();
     cy.runPrimaryBpmnFile();
 
-    cy.getBySel('process-model-files').click();
+    cy.getBySel(processModelFiles).click();
     cy.getBySel(`edit-file-${dmnFile.replace('.', '-')}`).click();
     updateDmnText(newDmnOutputForKevin, originalDmnOutputForKevin);
     cy.contains(acceptanceTestOneDisplayName).click();
     cy.runPrimaryBpmnFile();
 
     // Change bpmn
-    cy.getBySel('process-model-files').click();
+    cy.getBySel(processModelFiles).click();
     cy.getBySel(`edit-file-${bpmnFile.replace('.', '-')}`).click();
     cy.contains(`Process Model File: ${bpmnFile}`);
     updateBpmnPythonScript(newPythonScript);
     cy.contains(acceptanceTestOneDisplayName).click();
     cy.runPrimaryBpmnFile();
 
-    cy.getBySel('process-model-files').click();
+    cy.getBySel(processModelFiles).click();
     cy.getBySel(`edit-file-${bpmnFile.replace('.', '-')}`).click();
     updateBpmnPythonScript(originalPythonScript);
     cy.contains(acceptanceTestOneDisplayName).click();

--- a/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
+++ b/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
@@ -19,7 +19,7 @@ import {
 
 import React, { useEffect, useState, useCallback } from 'react';
 // @ts-ignore
-import { Button, ButtonSet, Modal, UnorderedList, Link } from '@carbon/react';
+import { Button, ButtonSet, Modal, UnorderedList } from '@carbon/react';
 
 import 'bpmn-js/dist/assets/diagram-js.css';
 import 'bpmn-js/dist/assets/bpmn-font/css/bpmn-embedded.css';
@@ -35,6 +35,7 @@ import 'dmn-js/dist/assets/dmn-js-literal-expression.css';
 import 'dmn-js/dist/assets/dmn-js-shared.css';
 import 'dmn-js/dist/assets/dmn-font/css/dmn-embedded.css';
 import 'dmn-js-properties-panel/dist/assets/properties-panel.css';
+import { Link, useNavigate } from 'react-router-dom';
 
 // @ts-expect-error TS(7016) FIXME
 import spiffworkflow from 'bpmn-js-spiffworkflow/app/spiffworkflow';
@@ -51,8 +52,6 @@ import ZoomScrollModule from 'diagram-js/lib/navigation/zoomscroll';
 
 // @ts-expect-error TS(7016) FIXME
 import TouchModule from 'diagram-js/lib/navigation/touch';
-
-import { useNavigate } from 'react-router-dom';
 
 import { Can } from '@casl/react';
 import { ZoomIn, ZoomOut, ZoomFit } from '@carbon/icons-react';
@@ -527,27 +526,22 @@ export default function ReactDiagramEditor({
       ) {
         return;
       }
-      function domify(htmlString: string) {
-        const template = document.createElement('template');
-        template.innerHTML = htmlString.trim();
-        return template.content.firstChild;
-      }
       const createCallActivityOverlay = () => {
         const overlays = diagramModelerState.get('overlays');
         const ARROW_DOWN_SVG =
           '<svg width="20" height="20" viewBox="0 0 24.00 24.00" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="#ffffff"> <g id="SVGRepo_bgCarrier" stroke-width="0"> <rect x="0" y="0" width="24.00" height="24.00" rx="0" fill="#2196f3" strokewidth="0"/> </g> <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round" stroke="#CCCCCC" stroke-width="0.048"/> <g id="SVGRepo_iconCarrier"> <path d="M7 17L17 7M17 7H8M17 7V16" stroke="#ffffff" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/> </g> </svg>';
-        const button: any = domify(
-          `<button class="bjs-drilldown">${ARROW_DOWN_SVG}</button>`,
-        );
-        button.addEventListener('click', () => {
-          onCallActivityOverlayClick(task);
-        });
+        const processIdentifierToUse =
+          task.task_definition_properties_json.spec;
+        const callActivityUrl = `${window.location.pathname}?process_identifier=${processIdentifierToUse}&bpmn_process_guid=${task.guid}`;
+
+        // using a string because bpmn-js overlay requires a string and react-router-dom's Link is too magical to be converted to a string
+        const link = `<a href=${callActivityUrl}>${ARROW_DOWN_SVG}</a>`;
         overlays.add(task.bpmn_identifier, 'drilldown', {
           position: {
-            bottom: -10,
-            right: -8,
+            bottom: -8,
+            right: 12,
           },
-          html: button,
+          html: link,
         });
       };
       try {
@@ -750,10 +744,10 @@ export default function ReactDiagramEditor({
       >
         <UnorderedList>
           {callers.map((ref: ProcessReference) => (
-            <li key={`list-${ref.relative_location}`}>
+            <li key={`list-${ref.display_name}-${ref.relative_location}`}>
               <Link
                 size="lg"
-                href={`/process-models/${modifyProcessIdentifierForPathParam(
+                to={`/process-models/${modifyProcessIdentifierForPathParam(
                   ref.relative_location,
                 )}`}
               >

--- a/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
+++ b/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
@@ -19,7 +19,7 @@ import {
 
 import React, { useEffect, useState, useCallback } from 'react';
 // @ts-ignore
-import { Button, ButtonSet, Modal, UnorderedList } from '@carbon/react';
+import { Button, ButtonSet, Modal, UnorderedList, Link } from '@carbon/react';
 
 import 'bpmn-js/dist/assets/diagram-js.css';
 import 'bpmn-js/dist/assets/bpmn-font/css/bpmn-embedded.css';
@@ -35,7 +35,6 @@ import 'dmn-js/dist/assets/dmn-js-literal-expression.css';
 import 'dmn-js/dist/assets/dmn-js-shared.css';
 import 'dmn-js/dist/assets/dmn-font/css/dmn-embedded.css';
 import 'dmn-js-properties-panel/dist/assets/properties-panel.css';
-import { Link, useNavigate } from 'react-router-dom';
 
 // @ts-expect-error TS(7016) FIXME
 import spiffworkflow from 'bpmn-js-spiffworkflow/app/spiffworkflow';
@@ -52,6 +51,8 @@ import ZoomScrollModule from 'diagram-js/lib/navigation/zoomscroll';
 
 // @ts-expect-error TS(7016) FIXME
 import TouchModule from 'diagram-js/lib/navigation/touch';
+
+import { useNavigate } from 'react-router-dom';
 
 import { Can } from '@casl/react';
 import { ZoomIn, ZoomOut, ZoomFit } from '@carbon/icons-react';
@@ -526,22 +527,27 @@ export default function ReactDiagramEditor({
       ) {
         return;
       }
+      function domify(htmlString: string) {
+        const template = document.createElement('template');
+        template.innerHTML = htmlString.trim();
+        return template.content.firstChild;
+      }
       const createCallActivityOverlay = () => {
         const overlays = diagramModelerState.get('overlays');
         const ARROW_DOWN_SVG =
           '<svg width="20" height="20" viewBox="0 0 24.00 24.00" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="#ffffff"> <g id="SVGRepo_bgCarrier" stroke-width="0"> <rect x="0" y="0" width="24.00" height="24.00" rx="0" fill="#2196f3" strokewidth="0"/> </g> <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round" stroke="#CCCCCC" stroke-width="0.048"/> <g id="SVGRepo_iconCarrier"> <path d="M7 17L17 7M17 7H8M17 7V16" stroke="#ffffff" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/> </g> </svg>';
-        const processIdentifierToUse =
-          task.task_definition_properties_json.spec;
-        const callActivityUrl = `${window.location.pathname}?process_identifier=${processIdentifierToUse}&bpmn_process_guid=${task.guid}`;
-
-        // using a string because bpmn-js overlay requires a string and react-router-dom's Link is too magical to be converted to a string
-        const link = `<a href=${callActivityUrl}>${ARROW_DOWN_SVG}</a>`;
+        const button: any = domify(
+          `<button class="bjs-drilldown">${ARROW_DOWN_SVG}</button>`,
+        );
+        button.addEventListener('click', () => {
+          onCallActivityOverlayClick(task);
+        });
         overlays.add(task.bpmn_identifier, 'drilldown', {
           position: {
-            bottom: -8,
-            right: 12,
+            bottom: -10,
+            right: -8,
           },
-          html: link,
+          html: button,
         });
       };
       try {
@@ -744,10 +750,10 @@ export default function ReactDiagramEditor({
       >
         <UnorderedList>
           {callers.map((ref: ProcessReference) => (
-            <li key={`list-${ref.display_name}-${ref.relative_location}`}>
+            <li key={`list-${ref.relative_location}`}>
               <Link
                 size="lg"
-                to={`/process-models/${modifyProcessIdentifierForPathParam(
+                href={`/process-models/${modifyProcessIdentifierForPathParam(
                   ref.relative_location,
                 )}`}
               >

--- a/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
+++ b/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
@@ -443,8 +443,8 @@ export default function ReactDiagramEditor({
     onLaunchDmnEditor,
     onLaunchJsonSchemaEditor,
     onLaunchMarkdownEditor,
-    onLaunchScriptEditor,
     onLaunchMessageEditor,
+    onLaunchScriptEditor,
     onMessagesRequested,
     onSearchProcessModels,
     onServiceTasksRequested,
@@ -578,12 +578,11 @@ export default function ReactDiagramEditor({
         return;
       }
 
-      let modeler = diagramModelerState;
       if (diagramType === 'dmn') {
-        modeler = (diagramModelerState as any).getActiveViewer();
+        return;
       }
 
-      const canvas = (modeler as any).get('canvas');
+      const canvas = diagramModelerState.get('canvas');
       canvas.zoom(FitViewport, 'auto'); // Concerned this might bug out somehow.
 
       // highlighting a field

--- a/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
+++ b/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
@@ -539,8 +539,11 @@ export default function ReactDiagramEditor({
         const button: any = domify(
           `<button class="bjs-drilldown">${ARROW_DOWN_SVG}</button>`,
         );
-        button.addEventListener('click', () => {
-          onCallActivityOverlayClick(task);
+        button.addEventListener('click', (newEvent: any) => {
+          onCallActivityOverlayClick(task, newEvent);
+        });
+        button.addEventListener('auxclick', (newEvent: any) => {
+          onCallActivityOverlayClick(task, newEvent);
         });
         overlays.add(task.bpmn_identifier, 'drilldown', {
           position: {

--- a/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
+++ b/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
@@ -687,14 +687,12 @@ export default function ReactDiagramEditor({
     diagramModelerState,
     diagramType,
     diagramXML,
-    diagramXMLString,
     fileName,
     onCallActivityOverlayClick,
     performingXmlUpdates,
     processModelId,
     tasks,
     url,
-    zoom,
   ]);
 
   function handleSave() {

--- a/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
+++ b/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
@@ -17,7 +17,7 @@ import {
   // @ts-expect-error TS(7016) FIXME: Could not find a declaration file for module 'dmn-... Remove this comment to see the full error message
 } from 'dmn-js-properties-panel';
 
-import React, { useRef, useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 // @ts-ignore
 import { Button, ButtonSet, Modal, UnorderedList, Link } from '@carbon/react';
 
@@ -134,8 +134,6 @@ export default function ReactDiagramEditor({
   const [diagramModelerState, setDiagramModelerState] = useState(null);
   const [performingXmlUpdates, setPerformingXmlUpdates] = useState(false);
 
-  const alreadyImportedXmlRef = useRef(false);
-
   const { targetUris } = useUriListForPermissions();
   const permissionRequestData: PermissionsToCheck = {};
 
@@ -204,9 +202,10 @@ export default function ReactDiagramEditor({
   };
 
   useEffect(() => {
-    if (diagramModelerState) {
-      return;
-    }
+    // if (diagramModelerState) {
+    //   return;
+    // }
+    console.log('WE IN THIS USE EFFECT');
 
     let canvasClass = 'diagram-editor-canvas';
     if (diagramType === 'readonly') {
@@ -319,6 +318,7 @@ export default function ReactDiagramEditor({
 
     function handleElementClick(event: any) {
       if (onElementClick) {
+        console.log('WE SET HANDL');
         const canvas = diagramModeler.get('canvas');
         const bpmnProcessIdentifiers = getBpmnProcessIdentifiers(
           canvas.getRootElement(),
@@ -436,22 +436,22 @@ export default function ReactDiagramEditor({
       }
     });
   }, [
-    diagramModelerState,
-    diagramType,
+    // diagramModelerState,
+    // diagramType,
     onDataStoresRequested,
-    onDmnFilesRequested,
+    // onDmnFilesRequested,
     onElementClick,
-    onElementsChanged,
-    onJsonSchemaFilesRequested,
-    onLaunchBpmnEditor,
-    onLaunchDmnEditor,
-    onLaunchJsonSchemaEditor,
-    onLaunchMarkdownEditor,
-    onLaunchScriptEditor,
-    onLaunchMessageEditor,
-    onMessagesRequested,
-    onSearchProcessModels,
-    onServiceTasksRequested,
+    // onElementsChanged,
+    // onJsonSchemaFilesRequested,
+    // onLaunchBpmnEditor,
+    // onLaunchDmnEditor,
+    // onLaunchJsonSchemaEditor,
+    // onLaunchMarkdownEditor,
+    // onLaunchScriptEditor,
+    // onLaunchMessageEditor,
+    // onMessagesRequested,
+    // onSearchProcessModels,
+    // onServiceTasksRequested,
   ]);
 
   useEffect(() => {
@@ -557,15 +557,16 @@ export default function ReactDiagramEditor({
       diagramModelerToUse: any,
       diagramXMLToDisplay: any,
     ) {
-      if (alreadyImportedXmlRef.current) {
+      if (diagramXMLToDisplay === diagramXMLString) {
         return;
       }
+      // console.log('diagramXMLToDisplay', diagramXMLToDisplay);
+      setDiagramXMLString(diagramXMLToDisplay);
       diagramModelerToUse.importXML(diagramXMLToDisplay);
       zoom(0);
       if (diagramType !== 'dmn') {
         fixUnresolvedReferences(diagramModelerToUse);
       }
-      alreadyImportedXmlRef.current = true;
     }
 
     function dmnTextHandler(text: string) {
@@ -604,9 +605,6 @@ export default function ReactDiagramEditor({
 
     const diagramXMLToUse = diagramXML || diagramXMLString;
     if (diagramXMLToUse) {
-      if (!diagramXMLString) {
-        setDiagramXMLString(diagramXMLToUse);
-      }
       displayDiagram(diagramModelerState, diagramXMLToUse);
 
       return undefined;

--- a/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
+++ b/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
@@ -202,11 +202,6 @@ export default function ReactDiagramEditor({
   };
 
   useEffect(() => {
-    // if (diagramModelerState) {
-    //   return;
-    // }
-    console.log('WE IN THIS USE EFFECT');
-
     let canvasClass = 'diagram-editor-canvas';
     if (diagramType === 'readonly') {
       canvasClass = 'diagram-viewer-canvas';
@@ -318,7 +313,6 @@ export default function ReactDiagramEditor({
 
     function handleElementClick(event: any) {
       if (onElementClick) {
-        console.log('WE SET HANDL');
         const canvas = diagramModeler.get('canvas');
         const bpmnProcessIdentifiers = getBpmnProcessIdentifiers(
           canvas.getRootElement(),
@@ -436,22 +430,21 @@ export default function ReactDiagramEditor({
       }
     });
   }, [
-    // diagramModelerState,
-    // diagramType,
+    diagramType,
     onDataStoresRequested,
-    // onDmnFilesRequested,
+    onDmnFilesRequested,
     onElementClick,
-    // onElementsChanged,
-    // onJsonSchemaFilesRequested,
-    // onLaunchBpmnEditor,
-    // onLaunchDmnEditor,
-    // onLaunchJsonSchemaEditor,
-    // onLaunchMarkdownEditor,
-    // onLaunchScriptEditor,
-    // onLaunchMessageEditor,
-    // onMessagesRequested,
-    // onSearchProcessModels,
-    // onServiceTasksRequested,
+    onElementsChanged,
+    onJsonSchemaFilesRequested,
+    onLaunchBpmnEditor,
+    onLaunchDmnEditor,
+    onLaunchJsonSchemaEditor,
+    onLaunchMarkdownEditor,
+    onLaunchScriptEditor,
+    onLaunchMessageEditor,
+    onMessagesRequested,
+    onSearchProcessModels,
+    onServiceTasksRequested,
   ]);
 
   useEffect(() => {
@@ -560,7 +553,6 @@ export default function ReactDiagramEditor({
       if (diagramXMLToDisplay === diagramXMLString) {
         return;
       }
-      // console.log('diagramXMLToDisplay', diagramXMLToDisplay);
       setDiagramXMLString(diagramXMLToDisplay);
       diagramModelerToUse.importXML(diagramXMLToDisplay);
       zoom(0);
@@ -610,7 +602,7 @@ export default function ReactDiagramEditor({
       return undefined;
     }
 
-    if (!diagramXMLString) {
+    if (!diagramXMLToUse) {
       if (url) {
         fetchDiagramFromURL(url);
         return undefined;

--- a/spiffworkflow-frontend/src/routes/ProcessInstanceShow.tsx
+++ b/spiffworkflow-frontend/src/routes/ProcessInstanceShow.tsx
@@ -880,7 +880,7 @@ export default function ProcessInstanceShow({ variant }: OwnProps) {
   );
 
   const handleCallActivityNavigate = useCallback(
-    (task: Task) => {
+    (task: Task, event: any) => {
       if (
         task &&
         task.typename === 'CallActivity' &&
@@ -889,8 +889,11 @@ export default function ProcessInstanceShow({ variant }: OwnProps) {
         const processIdentifierToUse =
           task.task_definition_properties_json.spec;
         const url = `${window.location.pathname}?process_identifier=${processIdentifierToUse}&bpmn_process_guid=${task.guid}`;
-        navigate(url);
-        // window.open(url);
+        if (event.type === 'auxclick') {
+          window.open(url);
+        } else {
+          navigate(url);
+        }
       }
     },
     [navigate],

--- a/spiffworkflow-frontend/src/routes/ProcessInstanceShow.tsx
+++ b/spiffworkflow-frontend/src/routes/ProcessInstanceShow.tsx
@@ -1170,23 +1170,6 @@ export default function ProcessInstanceShow({ variant }: OwnProps) {
         />,
       );
     }
-    //
-    // if (
-    //   task.typename === 'CallActivity' &&
-    //   !['FUTURE', 'LIKELY', 'MAYBE'].includes(task.state)
-    // ) {
-    //   const taskDefinitionPropertiesJson: TaskDefinitionPropertiesJson =
-    //     task.task_definition_properties_json;
-    //   buttons.push(
-    //     <Link
-    //       data-qa="go-to-call-activity-result"
-    //       to={`${window.location.pathname}?process_identifier=${taskDefinitionPropertiesJson.spec}&bpmn_process_guid=${task.guid}`}
-    //       // target="_blank"
-    //     >
-    //       View Call Activity Diagram
-    //     </Link>,
-    //   );
-    // }
 
     if (canEditTaskData(task)) {
       buttons.push(

--- a/spiffworkflow-frontend/src/routes/ProcessInstanceShow.tsx
+++ b/spiffworkflow-frontend/src/routes/ProcessInstanceShow.tsx
@@ -880,23 +880,19 @@ export default function ProcessInstanceShow({ variant }: OwnProps) {
   );
 
   const handleCallActivityNavigate = useCallback(
-    (shapeElement: any, bpmnProcessIdentifiers: any) => {
-      const matchingTask = findMatchingTaskFromShapeElement(
-        shapeElement,
-        bpmnProcessIdentifiers,
-      );
+    (task: Task) => {
       if (
-        matchingTask &&
-        matchingTask.typename === 'CallActivity' &&
-        !['FUTURE', 'LIKELY', 'MAYBE'].includes(matchingTask.state)
+        task &&
+        task.typename === 'CallActivity' &&
+        !['FUTURE', 'LIKELY', 'MAYBE'].includes(task.state)
       ) {
         const processIdentifierToUse =
-          shapeElement.businessObject.calledElement;
-        const url = `${window.location.pathname}?process_identifier=${processIdentifierToUse}&bpmn_process_guid=${matchingTask.guid}`;
+          task.task_definition_properties_json.spec;
+        const url = `${window.location.pathname}?process_identifier=${processIdentifierToUse}&bpmn_process_guid=${task.guid}`;
         navigate(url);
       }
     },
-    [navigate, findMatchingTaskFromShapeElement],
+    [navigate],
   );
 
   const handleClickedDiagramTask = useCallback(

--- a/spiffworkflow-frontend/src/routes/ProcessInstanceShow.tsx
+++ b/spiffworkflow-frontend/src/routes/ProcessInstanceShow.tsx
@@ -890,6 +890,7 @@ export default function ProcessInstanceShow({ variant }: OwnProps) {
           task.task_definition_properties_json.spec;
         const url = `${window.location.pathname}?process_identifier=${processIdentifierToUse}&bpmn_process_guid=${task.guid}`;
         navigate(url);
+        // window.open(url);
       }
     },
     [navigate],

--- a/spiffworkflow-frontend/src/routes/ProcessModelEditDiagram.tsx
+++ b/spiffworkflow-frontend/src/routes/ProcessModelEditDiagram.tsx
@@ -1336,12 +1336,12 @@ export default function ProcessModelEditDiagram() {
     if (isDmn()) {
       return (
         <ReactDiagramEditor
-          processModelId={params.process_model_id || ''}
-          saveDiagram={saveDiagram}
-          onDeleteFile={onDeleteFile}
+          diagramType="dmn"
           diagramXML={bpmnXmlForDiagramRendering}
           fileName={params.file_name}
-          diagramType="dmn"
+          onDeleteFile={onDeleteFile}
+          processModelId={params.process_model_id || ''}
+          saveDiagram={saveDiagram}
         />
       );
     }
@@ -1373,8 +1373,8 @@ export default function ProcessModelEditDiagram() {
         onLaunchDmnEditor={onLaunchDmnEditor}
         onLaunchJsonSchemaEditor={onLaunchJsonSchemaEditor}
         onLaunchMarkdownEditor={onLaunchMarkdownEditor}
-        onLaunchScriptEditor={onLaunchScriptEditor}
         onLaunchMessageEditor={onLaunchMessageEditor}
+        onLaunchScriptEditor={onLaunchScriptEditor}
         onMessagesRequested={onMessagesRequested}
         onSearchProcessModels={onSearchProcessModels}
         onServiceTasksRequested={onServiceTasksRequested}


### PR DESCRIPTION
This adds an overlay to call activities on the process instance show page that will navigate to that call activity. This navigation will happen in the same tab instead of creating a new one.

Changes:
* refactored ReactDiagramEditor to recognize the bpmn xml as a state so it will reload the diagram when xml changes
* add overly to call activities on process instance show page only so it can be used to navigate instead of clicking on the call activity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a callback prop for interactive call activity overlays in the diagram editor.

- **Performance Improvements**
  - Refactored multiple functions to use memoization for enhanced performance in the ProcessInstanceShow component.

- **Bug Fixes**
  - Streamlined XML handling logic in the diagram editor for improved clarity and performance.

- **Documentation**
  - Added comments for clarity on task states and navigation logic in the ProcessInstanceShow component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->