### PR TITLE
Null script icon fix

### DIFF
--- a/spiffworkflow-frontend/package-lock.json
+++ b/spiffworkflow-frontend/package-lock.json
@@ -8343,7 +8343,7 @@
     },
     "node_modules/bpmn-js-spiffworkflow": {
       "version": "0.0.8",
-      "resolved": "git+ssh://git@github.com/sartography/bpmn-js-spiffworkflow.git#5ded6f52d8529ccf8318d65c35edc052dfc3e4e5",
+      "resolved": "git+ssh://git@github.com/sartography/bpmn-js-spiffworkflow.git#a75437462e1d5282e87368f8865fd489f32a2792",
       "license": "LGPL",
       "dependencies": {
         "inherits": "^2.0.4",
@@ -32188,7 +32188,7 @@
       }
     },
     "bpmn-js-spiffworkflow": {
-      "version": "git+ssh://git@github.com/sartography/bpmn-js-spiffworkflow.git#5ded6f52d8529ccf8318d65c35edc052dfc3e4e5",
+      "version": "git+ssh://git@github.com/sartography/bpmn-js-spiffworkflow.git#a75437462e1d5282e87368f8865fd489f32a2792",
       "from": "bpmn-js-spiffworkflow@github:sartography/bpmn-js-spiffworkflow#main",
       "requires": {
         "inherits": "^2.0.4",

--- a/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
+++ b/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
@@ -351,7 +351,7 @@ export default function ReactDiagramEditor({
         const overlays = diagramModeler.get('overlays');
         const scriptIcon = convertSvgElementToHtmlString(<BpmnJsScriptIcon />);
 
-        if (preScript) {
+        if (preScript?.value) {
           overlays.add(event.element.id, {
             position: {
               bottom: 25,
@@ -360,7 +360,7 @@ export default function ReactDiagramEditor({
             html: scriptIcon,
           });
         }
-        if (postScript) {
+        if (postScript?.value) {
           overlays.add(event.element.id, {
             position: {
               bottom: 25,


### PR DESCRIPTION
Supports https://github.com/sartography/bpmn-js-spiffworkflow/issues/114

This updates bpmn-js-spiffworkflow for the mentioned issue and removes the icon if the script value is falsy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the robustness of conditional checks for script variables to prevent potential runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->