### PR TITLE
Ht assignment fix

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
@@ -468,6 +468,7 @@ class AuthorizationService:
         desired_group_identifiers = None
 
         if current_app.config["SPIFFWORKFLOW_BACKEND_OPEN_ID_IS_AUTHORITY_FOR_USER_GROUPS"]:
+            desired_group_identifiers = []
             if "groups" in user_info:
                 desired_group_identifiers = user_info["groups"]
 
@@ -502,7 +503,7 @@ class AuthorizationService:
 
         if desired_group_identifiers is not None:
             if not isinstance(desired_group_identifiers, list):
-                current_app.logger.error(
+                current_app.logger.error(  # type: ignore
                     f"Invalid groups property in token: {desired_group_identifiers}.If groups is specified, it must be a list"
                 )
             else:

--- a/spiffworkflow-backend/tests/data/model_with_lanes/lanes_with_extra_tasks.bpmn
+++ b/spiffworkflow-backend/tests/data/model_with_lanes/lanes_with_extra_tasks.bpmn
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:spiffworkflow="http://spiffworkflow.org/bpmn/schema/1.0/core" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_96f6665" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.0.0-dev">
+  <bpmn:collaboration id="Collaboration_0iyw0q7">
+    <bpmn:participant id="Participant_17eqap4" processRef="Process_yhito9d" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_yhito9d" isExecutable="true">
+    <bpmn:laneSet id="LaneSet_17rankp">
+      <bpmn:lane id="process_initiator" name="Process Initiator">
+        <bpmn:flowNodeRef>StartEvent_1</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>initiator_one</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_06f4e68</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>initiator_two</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="finance_team" name="Finance Team">
+        <bpmn:flowNodeRef>finance_approval</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>finance_confirmation</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1tbyols</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1tbyols" sourceRef="StartEvent_1" targetRef="initiator_one" />
+    <bpmn:sequenceFlow id="Flow_16ppta1" sourceRef="initiator_one" targetRef="finance_approval" />
+    <bpmn:manualTask id="initiator_one" name="Initiator One">
+      <bpmn:extensionElements>
+        <spiffworkflow:instructionsForEndUser>This is for the initiator user</spiffworkflow:instructionsForEndUser>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1tbyols</bpmn:incoming>
+      <bpmn:outgoing>Flow_16ppta1</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:endEvent id="Event_06f4e68">
+      <bpmn:incoming>Flow_0x92f7d</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0x92f7d" sourceRef="initiator_two" targetRef="Event_06f4e68" />
+    <bpmn:manualTask id="initiator_two" name="Initiator Two">
+      <bpmn:extensionElements>
+        <spiffworkflow:instructionsForEndUser>This is initiator again</spiffworkflow:instructionsForEndUser>
+        <spiffworkflow:postScript />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1q487da</bpmn:incoming>
+      <bpmn:outgoing>Flow_0x92f7d</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:manualTask id="finance_approval" name="Finance Approval">
+      <bpmn:extensionElements>
+        <spiffworkflow:instructionsForEndUser>This is for a Finance Team user</spiffworkflow:instructionsForEndUser>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_16ppta1</bpmn:incoming>
+      <bpmn:outgoing>Flow_0rug230</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="Flow_0rug230" sourceRef="finance_approval" targetRef="finance_confirmation" />
+    <bpmn:sequenceFlow id="Flow_1q487da" sourceRef="finance_confirmation" targetRef="initiator_two" />
+    <bpmn:manualTask id="finance_confirmation" name="Finance Confirmation">
+      <bpmn:incoming>Flow_0rug230</bpmn:incoming>
+      <bpmn:outgoing>Flow_1q487da</bpmn:outgoing>
+    </bpmn:manualTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0iyw0q7">
+      <bpmndi:BPMNShape id="Participant_17eqap4_di" bpmnElement="Participant_17eqap4" isHorizontal="true">
+        <dc:Bounds x="129" y="52" width="600" height="370" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_0irvyol_di" bpmnElement="finance_team" isHorizontal="true">
+        <dc:Bounds x="159" y="302" width="570" height="120" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1ewsife_di" bpmnElement="process_initiator" isHorizontal="true">
+        <dc:Bounds x="159" y="52" width="570" height="250" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1lm1ald_di" bpmnElement="initiator_one">
+        <dc:Bounds x="270" y="137" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_06f4e68_di" bpmnElement="Event_06f4e68">
+        <dc:Bounds x="572" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1c1xxe3_di" bpmnElement="initiator_two">
+        <dc:Bounds x="440" y="137" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1y566d5_di" bpmnElement="finance_approval">
+        <dc:Bounds x="270" y="320" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0c960hq_di" bpmnElement="finance_confirmation">
+        <dc:Bounds x="430" y="320" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1tbyols_di" bpmnElement="Flow_1tbyols">
+        <di:waypoint x="215" y="177" />
+        <di:waypoint x="270" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16ppta1_di" bpmnElement="Flow_16ppta1">
+        <di:waypoint x="320" y="217" />
+        <di:waypoint x="320" y="320" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0x92f7d_di" bpmnElement="Flow_0x92f7d">
+        <di:waypoint x="540" y="177" />
+        <di:waypoint x="572" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0rug230_di" bpmnElement="Flow_0rug230">
+        <di:waypoint x="370" y="360" />
+        <di:waypoint x="430" y="360" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1q487da_di" bpmnElement="Flow_1q487da">
+        <di:waypoint x="480" y="320" />
+        <di:waypoint x="480" y="217" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/spiffworkflow-backend/tests/data/model_with_lanes/lanes_with_lane_owners.bpmn
+++ b/spiffworkflow-backend/tests/data/model_with_lanes/lanes_with_lane_owners.bpmn
@@ -1,0 +1,266 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:spiffworkflow="http://spiffworkflow.org/bpmn/schema/1.0/core" id="Definitions_96f6665" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.0.0-dev">
+  <bpmn:collaboration id="Collaboration_FormAndLane">
+    <bpmn:participant id="Participant_1df0bwy" name="Item" processRef="Test_Process_io425991xx" />
+  </bpmn:collaboration>
+  <bpmn:process id="Test_Process_io425991xx" isExecutable="true">
+    <bpmn:laneSet id="LaneSet_06wu5sq">
+      <bpmn:lane id="Lane_Infra" name="/Infra">
+        <bpmn:flowNodeRef>Activity_GetMoreData</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_1chm5qn</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_09rkmlh</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_0t6257a</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_Review</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_12mvls1</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_0er19np</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_1y0gjbb</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_1v7vc1z</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_Initiator">
+        <bpmn:flowNodeRef>StartEvent_1</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_GetData</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_GetReviewers</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_0l5x84t</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+    <bpmn:sequenceFlow id="Flow_0c8hg1n" sourceRef="Activity_GetData" targetRef="Activity_GetMoreData" />
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1msk5h9</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:userTask id="Activity_GetData" name="Get Data">
+      <bpmn:extensionElements>
+        <spiffworkflow:properties>
+          <spiffworkflow:property name="formJsonSchemaFilename" value="get-item-info-schema.json" />
+          <spiffworkflow:property name="formUiSchemaFilename" value="get-item-info-uischema.json" />
+        </spiffworkflow:properties>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1loqmjv</bpmn:incoming>
+      <bpmn:incoming>Flow_0rydrx7</bpmn:incoming>
+      <bpmn:outgoing>Flow_0c8hg1n</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:scriptTask id="Activity_GetReviewers" name="Get Reviewers">
+      <bpmn:incoming>Flow_1msk5h9</bpmn:incoming>
+      <bpmn:outgoing>Flow_1loqmjv</bpmn:outgoing>
+      <bpmn:script>#lane_owners = {"Reviewer": ["core.contributor@status.im", "madhurya@sartography.com"]}
+
+current_approver_role = "/Infra"
+sme_group_members = get_group_members(current_approver_role)
+lane_owners = {"/Infra": sme_group_members}</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_1msk5h9" sourceRef="StartEvent_1" targetRef="Activity_GetReviewers" />
+    <bpmn:sequenceFlow id="Flow_1loqmjv" sourceRef="Activity_GetReviewers" targetRef="Activity_GetData" />
+    <bpmn:sequenceFlow id="Flow_1xtmg0t" sourceRef="Activity_GetMoreData" targetRef="Activity_Review" />
+    <bpmn:manualTask id="Activity_GetMoreData" name="Show Data">
+      <bpmn:extensionElements>
+        <spiffworkflow:properties>
+          <spiffworkflow:property name="formJsonSchemaFilename" value="get_more_data_form.json" />
+        </spiffworkflow:properties>
+        <spiffworkflow:preScript>data = {"item_id": itemId, "item_desc": itemName}</spiffworkflow:preScript>
+        <spiffworkflow:instructionsForEndUser>User entered data : {{data}}</spiffworkflow:instructionsForEndUser>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0c8hg1n</bpmn:incoming>
+      <bpmn:outgoing>Flow_1xtmg0t</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:exclusiveGateway id="Gateway_1chm5qn" default="Flow_0l3zw86">
+      <bpmn:incoming>Flow_10rvmdc</bpmn:incoming>
+      <bpmn:outgoing>Flow_1efovhl</bpmn:outgoing>
+      <bpmn:outgoing>Flow_19tmelr</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0l3zw86</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_10rvmdc" sourceRef="Activity_Review" targetRef="Gateway_1chm5qn" />
+    <bpmn:endEvent id="Event_09rkmlh">
+      <bpmn:incoming>Flow_0q4r19g</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1efovhl" sourceRef="Gateway_1chm5qn" targetRef="Event_0t6257a">
+      <bpmn:conditionExpression>approval == "Approve"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:intermediateThrowEvent id="Event_0t6257a" name="Approve">
+      <bpmn:incoming>Flow_1efovhl</bpmn:incoming>
+      <bpmn:outgoing>Flow_05xruvm</bpmn:outgoing>
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_19tmelr" sourceRef="Gateway_1chm5qn" targetRef="Event_0er19np">
+      <bpmn:conditionExpression>approval == "Reject"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:userTask id="Activity_Review" name="Review">
+      <bpmn:extensionElements>
+        <spiffworkflow:instructionsForEndUser>## Approve
+### Data
+{{ data }}</spiffworkflow:instructionsForEndUser>
+        <spiffworkflow:properties>
+          <spiffworkflow:property name="formJsonSchemaFilename" value="review-form-schema.json" />
+          <spiffworkflow:property name="formUiSchemaFilename" value="review-form-uischema.json" />
+        </spiffworkflow:properties>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1xtmg0t</bpmn:incoming>
+      <bpmn:outgoing>Flow_10rvmdc</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:intermediateThrowEvent id="Event_12mvls1" name="Need More Info">
+      <bpmn:incoming>Flow_0l3zw86</bpmn:incoming>
+      <bpmn:outgoing>Flow_12ty548</bpmn:outgoing>
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_0l3zw86" sourceRef="Gateway_1chm5qn" targetRef="Event_12mvls1" />
+    <bpmn:intermediateThrowEvent id="Event_0er19np" name="Reject">
+      <bpmn:incoming>Flow_19tmelr</bpmn:incoming>
+      <bpmn:outgoing>Flow_0zg89xt</bpmn:outgoing>
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_05xruvm" sourceRef="Event_0t6257a" targetRef="Gateway_1y0gjbb" />
+    <bpmn:sequenceFlow id="Flow_0zg89xt" sourceRef="Event_0er19np" targetRef="Gateway_1y0gjbb" />
+    <bpmn:sequenceFlow id="Flow_12ty548" sourceRef="Event_12mvls1" targetRef="Gateway_1y0gjbb" />
+    <bpmn:sequenceFlow id="Flow_1ohb8ht" sourceRef="Gateway_1y0gjbb" targetRef="Gateway_1v7vc1z" />
+    <bpmn:exclusiveGateway id="Gateway_1y0gjbb">
+      <bpmn:incoming>Flow_05xruvm</bpmn:incoming>
+      <bpmn:incoming>Flow_0zg89xt</bpmn:incoming>
+      <bpmn:incoming>Flow_12ty548</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ohb8ht</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:exclusiveGateway id="Gateway_1v7vc1z" default="Flow_0q4r19g">
+      <bpmn:incoming>Flow_1ohb8ht</bpmn:incoming>
+      <bpmn:outgoing>Flow_042vla2</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0q4r19g</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:exclusiveGateway id="Gateway_0l5x84t">
+      <bpmn:incoming>Flow_042vla2</bpmn:incoming>
+      <bpmn:outgoing>Flow_0rydrx7</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_042vla2" sourceRef="Gateway_1v7vc1z" targetRef="Gateway_0l5x84t">
+      <bpmn:conditionExpression>approval == "Needmoreinfo"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0rydrx7" sourceRef="Gateway_0l5x84t" targetRef="Activity_GetData" />
+    <bpmn:sequenceFlow id="Flow_0q4r19g" sourceRef="Gateway_1v7vc1z" targetRef="Event_09rkmlh" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_FormAndLane">
+      <bpmndi:BPMNShape id="Participant_1df0bwy_di" bpmnElement="Participant_1df0bwy" isHorizontal="true">
+        <dc:Bounds x="139" y="66" width="1311" height="462" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1vcali6_di" bpmnElement="Lane_Initiator" isHorizontal="true">
+        <dc:Bounds x="169" y="66" width="1281" height="188" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_10r7fce_di" bpmnElement="Lane_Infra" isHorizontal="true">
+        <dc:Bounds x="169" y="254" width="1281" height="274" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="189" y="142" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1r64ucz_di" bpmnElement="Activity_GetData">
+        <dc:Bounds x="440" y="120" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_07hx4o8_di" bpmnElement="Activity_GetReviewers">
+        <dc:Bounds x="280" y="120" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_16xsdrr_di" bpmnElement="Activity_GetMoreData">
+        <dc:Bounds x="440" y="300" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1chm5qn_di" bpmnElement="Gateway_1chm5qn" isMarkerVisible="true">
+        <dc:Bounds x="795" y="315" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_09rkmlh_di" bpmnElement="Event_09rkmlh">
+        <dc:Bounds x="1362" y="322" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0t6257a_di" bpmnElement="Event_0t6257a">
+        <dc:Bounds x="972" y="282" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="972" y="325" width="40" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0bf7hpx_di" bpmnElement="Activity_Review">
+        <dc:Bounds x="610" y="300" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_12mvls1_di" bpmnElement="Event_12mvls1">
+        <dc:Bounds x="972" y="432" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="953" y="475" width="76" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0er19np_di" bpmnElement="Event_0er19np">
+        <dc:Bounds x="972" y="362" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="974" y="405" width="33" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1y0gjbb_di" bpmnElement="Gateway_1y0gjbb" isMarkerVisible="true">
+        <dc:Bounds x="1075" y="335" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1v7vc1z_di" bpmnElement="Gateway_1v7vc1z" isMarkerVisible="true">
+        <dc:Bounds x="1195" y="335" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0l5x84t_di" bpmnElement="Gateway_0l5x84t" isMarkerVisible="true">
+        <dc:Bounds x="625" y="135" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0c8hg1n_di" bpmnElement="Flow_0c8hg1n">
+        <di:waypoint x="490" y="200" />
+        <di:waypoint x="490" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1msk5h9_di" bpmnElement="Flow_1msk5h9">
+        <di:waypoint x="225" y="160" />
+        <di:waypoint x="280" y="160" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1loqmjv_di" bpmnElement="Flow_1loqmjv">
+        <di:waypoint x="380" y="160" />
+        <di:waypoint x="440" y="160" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1xtmg0t_di" bpmnElement="Flow_1xtmg0t">
+        <di:waypoint x="540" y="340" />
+        <di:waypoint x="610" y="340" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10rvmdc_di" bpmnElement="Flow_10rvmdc">
+        <di:waypoint x="710" y="340" />
+        <di:waypoint x="795" y="340" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1efovhl_di" bpmnElement="Flow_1efovhl">
+        <di:waypoint x="820" y="315" />
+        <di:waypoint x="820" y="300" />
+        <di:waypoint x="972" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19tmelr_di" bpmnElement="Flow_19tmelr">
+        <di:waypoint x="820" y="365" />
+        <di:waypoint x="820" y="380" />
+        <di:waypoint x="972" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0l3zw86_di" bpmnElement="Flow_0l3zw86">
+        <di:waypoint x="820" y="365" />
+        <di:waypoint x="820" y="450" />
+        <di:waypoint x="972" y="450" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_05xruvm_di" bpmnElement="Flow_05xruvm">
+        <di:waypoint x="1008" y="300" />
+        <di:waypoint x="1100" y="300" />
+        <di:waypoint x="1100" y="335" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0zg89xt_di" bpmnElement="Flow_0zg89xt">
+        <di:waypoint x="1008" y="380" />
+        <di:waypoint x="1042" y="380" />
+        <di:waypoint x="1042" y="360" />
+        <di:waypoint x="1075" y="360" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_12ty548_di" bpmnElement="Flow_12ty548">
+        <di:waypoint x="1008" y="450" />
+        <di:waypoint x="1100" y="450" />
+        <di:waypoint x="1100" y="385" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ohb8ht_di" bpmnElement="Flow_1ohb8ht">
+        <di:waypoint x="1125" y="360" />
+        <di:waypoint x="1195" y="360" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_042vla2_di" bpmnElement="Flow_042vla2">
+        <di:waypoint x="1220" y="335" />
+        <di:waypoint x="1220" y="160" />
+        <di:waypoint x="675" y="160" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0rydrx7_di" bpmnElement="Flow_0rydrx7">
+        <di:waypoint x="625" y="160" />
+        <di:waypoint x="540" y="160" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0q4r19g_di" bpmnElement="Flow_0q4r19g">
+        <di:waypoint x="1245" y="360" />
+        <di:waypoint x="1304" y="360" />
+        <di:waypoint x="1304" y="340" />
+        <di:waypoint x="1362" y="340" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/helpers/base_test.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/helpers/base_test.py
@@ -603,14 +603,17 @@ class BaseTest:
         processor: ProcessInstanceProcessor,
         execution_mode: str | None = None,
         data: dict | None = None,
+        user: UserModel | None = None,
     ) -> None:
         user_task = processor.get_ready_user_tasks()[0]
         human_task = HumanTaskModel.query.filter_by(task_guid=str(user_task.id)).first()
+        if user is None:
+            user = processor.process_instance_model.process_initiator
         ProcessInstanceService.complete_form_task(
             processor=processor,
             spiff_task=user_task,
             data=data or {},
-            user=processor.process_instance_model.process_initiator,
+            user=user,
             human_task=human_task,
             execution_mode=execution_mode,
         )

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_authorization_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_authorization_service.py
@@ -733,3 +733,35 @@ class TestAuthorizationService(BaseTest):
             assert len(human_task_users) == 0
             tmp_group = GroupModel.query.filter_by(identifier="tmp_group").first()
             assert tmp_group is not None
+
+            ##### run test again but this time without the groups key at all to remove groups
+            user_two = AuthorizationService.create_user_from_sign_in(
+                {
+                    "username": "user_two",
+                    "sub": "user_two",
+                    "iss": "https://test.stuff",
+                    "email": "user_two@example.com",
+                    "groups": ["Finance Team", "tmp_group"],
+                }
+            )
+            assert len(user_two.groups) == 3
+            assert sorted([g.identifier for g in user_two.groups]) == sorted(["Finance Team", "everybody", "tmp_group"])
+            tmp_group = GroupModel.query.filter_by(identifier="tmp_group").first()
+            assert tmp_group is not None
+            assert tmp_group.source_is_open_id is True
+            human_task_users = HumanTaskUserModel.query.filter_by(user_id=user_two.id).all()
+            assert len(human_task_users) == 1
+            user_two = AuthorizationService.create_user_from_sign_in(
+                {
+                    "username": "user_two",
+                    "sub": "user_two",
+                    "iss": "https://test.stuff",
+                    "email": "user_two@example.com",
+                }
+            )
+            assert len(user_two.groups) == 1
+            assert user_two.groups[0].identifier == "everybody"
+            human_task_users = HumanTaskUserModel.query.filter_by(user_id=user_two.id).all()
+            assert len(human_task_users) == 0
+            tmp_group = GroupModel.query.filter_by(identifier="tmp_group").first()
+            assert tmp_group is not None


### PR DESCRIPTION
Supports #1981 

This fixes several issues with assigning users to tasks when they are added and removed from groups.

Fixes:
* users are properly removed from groups when no groups come back from open id server when its supposed to manage groups
* if using lane_owners to assign tasks to user and using open id server to manage groups, users will NOT be automatically assigned to tasks within lanes that are also defined in the lane_owners variable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced BPMN models for improved workflow visualization, including multi-participant processes and detailed task management.
	- Enhanced task assignment logic to include broader criteria for human tasks, improving user experience in task management.

- **Bug Fixes**
	- Improved error handling and type consistency for user group identifiers to prevent potential type errors.

- **Tests**
	- Expanded test coverage for user task assignments and completion scenarios to ensure correct functionality and user permissions.

- **Chores**
	- Updated test framework to enhance the validation of user scenarios related to task assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->