### PR TITLE
bpmn-event-throw-error-code

### DIFF
--- a/spiffworkflow-frontend/package-lock.json
+++ b/spiffworkflow-frontend/package-lock.json
@@ -8343,7 +8343,7 @@
     },
     "node_modules/bpmn-js-spiffworkflow": {
       "version": "0.0.8",
-      "resolved": "git+ssh://git@github.com/sartography/bpmn-js-spiffworkflow.git#a75437462e1d5282e87368f8865fd489f32a2792",
+      "resolved": "git+ssh://git@github.com/sartography/bpmn-js-spiffworkflow.git#eea82c3e9204de74bb0a2063a42bc9ebe41f9e80",
       "license": "LGPL",
       "dependencies": {
         "inherits": "^2.0.4",
@@ -32188,7 +32188,7 @@
       }
     },
     "bpmn-js-spiffworkflow": {
-      "version": "git+ssh://git@github.com/sartography/bpmn-js-spiffworkflow.git#a75437462e1d5282e87368f8865fd489f32a2792",
+      "version": "git+ssh://git@github.com/sartography/bpmn-js-spiffworkflow.git#eea82c3e9204de74bb0a2063a42bc9ebe41f9e80",
       "from": "bpmn-js-spiffworkflow@github:sartography/bpmn-js-spiffworkflow#main",
       "requires": {
         "inherits": "^2.0.4",


### PR DESCRIPTION
Updates the bpmn-js-spiffworkflow to allow for event codes to be used on throw events and not just boundary catch events.