### PR TITLE
Fix for lost error/escalation events

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
@@ -610,8 +610,8 @@ class WorkflowExecutionService:
     def process_bpmn_events(self) -> None:
         bpmn_event_groups = self.group_bpmn_events()
         message_events = bpmn_event_groups.pop(MessageEventDefinition.__name__, [])
-
-        if bpmn_event_groups and self.bpmn_process_instance.is_completed():
+        
+        if bpmn_event_groups:
             raise WorkflowExecutionServiceError.from_completion_with_unhandled_events(
                 self.bpmn_process_instance.last_task, bpmn_event_groups
             )

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
@@ -610,7 +610,7 @@ class WorkflowExecutionService:
     def process_bpmn_events(self) -> None:
         bpmn_event_groups = self.group_bpmn_events()
         message_events = bpmn_event_groups.pop(MessageEventDefinition.__name__, [])
-        
+
         if bpmn_event_groups:
             raise WorkflowExecutionServiceError.from_completion_with_unhandled_events(
                 self.bpmn_process_instance.last_task, bpmn_event_groups


### PR DESCRIPTION
Work on #2037 

The bugs in this ticket were related to unhandled error/escalation events that were lost during serialization (they have the same lifetime as message events from Spiff). This could be seen if instructions or a human task were present between the unhandled event and the end event for instance. Fix is to not check if the workflow is complete since these events are only returned by `get_events` if nothing in the workflow can handle them. Confirmed this in a chat with @essweine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated error handling logic to improve the detection of workflow execution issues, potentially raising errors more frequently based on event presence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->