### PR TITLE
Enable having created files match the local user:group

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,9 @@ services:
   spiffworkflow-backend:
     container_name: spiffworkflow-backend
     image: ghcr.io/sartography/spiffworkflow-backend:latest
+    # Enable setting the ownership of created files to match the local user:group. For example:
+    #     UGID="$(id -u):$(id -g)" docker compose up -d
+    user: ${UGID:-0:0}
     environment:
       SPIFFWORKFLOW_BACKEND_ENV: "local_docker"
       FLASK_DEBUG: "0"


### PR DESCRIPTION
If you run `docker compose up` with no other arguments, the `process_models` directory and everything in it will be created with `root:root` ownership. That's not great for the local editing use-case, because then you've got to use root permissions to work with those files. 

With this proposed change, running `UGID="$(id -u):$(id -g)" docker compose up` should result in any created files matching the ownership of the invoking user. If the user doesn't set `UGID` and just runs `docker compose up`, then the existing behavior (owner `root:root`) is the the default.

---

NOTE: This is currently a _draft_ PR because I haven't yet figured out how to get around [the invocation of `git config` on startup](hhttps://github.com/sartography/spiff-arena/blob/main/spiffworkflow-backend/bin/boot_server_in_docker#L89)... That command wants to write to `/root/.gitconfig`, which has `root:root` ownership in the image. 🤔  