### PR TITLE
allow internal openid url as issuer

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
@@ -122,6 +122,7 @@ config_from_env("SPIFFWORKFLOW_BACKEND_OPEN_ID_VERIFY_IAT", default=True)
 config_from_env("SPIFFWORKFLOW_BACKEND_OPEN_ID_VERIFY_NBF", default=True)
 config_from_env("SPIFFWORKFLOW_BACKEND_OPEN_ID_VERIFY_AZP", default=True)
 config_from_env("SPIFFWORKFLOW_BACKEND_OPEN_ID_LEEWAY", default=5)
+config_from_env("SPIFFWORKFLOW_BACKEND_OPEN_ID_INTERNAL_URL_IS_VALID_ISSUER", default=False)
 
 # Open ID server
 # use "http://localhost:7000/openid" for running with simple openid

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authentication_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authentication_service.py
@@ -363,9 +363,19 @@ class AuthenticationService:
             audience_array_in_token = [aud]
         overlapping_aud_values = [x for x in audience_array_in_token if x in valid_audience_values]
 
-        if iss not in [cls.server_url(authentication_identifier), UserModel.spiff_generated_jwt_issuer()]:
+        internal_server_url = cls.server_url(authentication_identifier, internal=True)
+
+        trusted_issuer_urls = [
+            cls.server_url(authentication_identifier),
+            UserModel.spiff_generated_jwt_issuer(),
+        ]
+
+        if current_app.config["SPIFFWORKFLOW_BACKEND_OPEN_ID_INTERNAL_URL_IS_VALID_ISSUER"]:
+            trusted_issuer_urls.append(internal_server_url)
+
+        if iss not in trusted_issuer_urls:
             current_app.logger.error(
-                f"TOKEN INVALID because ISS '{iss}' does not match server url '{cls.server_url(authentication_identifier)}'"
+                f"TOKEN INVALID because ISS '{iss}' does not match any of the trusted issuer urls '{trusted_issuer_urls}'"
             )
             valid = False
         # aud could be an array or a string


### PR DESCRIPTION
set `SPIFFWORKFLOW_BACKEND_OPEN_ID_INTERNAL_URL_IS_VALID_ISSUER=true` in backend configuration to allow the url that backend uses to communicate with itself to be considered a valid openid token issuer. when backend through a browser looks different from backend as it sees itself from within the backend container, this configuration will likely to necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option for OpenID settings to validate internal URLs as trusted issuers.
  
- **Enhancements**
	- Improved validation logic for issuer claims in token validation, allowing for multiple trusted issuer URLs and clearer error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->