### PR TITLE
use command separated list for envs

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/__init__.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/__init__.py
@@ -109,6 +109,15 @@ def _check_extension_api_configs(app: Flask) -> None:
         )
 
 
+def _check_scopes_variable(app: Flask) -> None:
+    if app.config["SPIFFWORKFLOW_BACKEND_OPENID_SCOPE"] is not None:
+        app.logger.warning(
+            "SPIFFWORKFLOW_BACKEND_OPENID_SCOPE is deprecated. Please use SPIFFWORKFLOW_BACKEND_OPEN_ID_SCOPES instead"
+        )
+        if os.environ.get("SPIFFWORKFLOW_BACKEND_OPEN_ID_SCOPES") is None:
+            app.config["SPIFFWORKFLOW_BACKEND_OPEN_ID_SCOPES"] = ",".join(app.config["SPIFFWORKFLOW_BACKEND_OPENID_SCOPE"])
+
+
 # see the message in the ConfigurationError below for why we are checking this.
 # we really do not want this to raise when there is not a problem, so there are lots of return statements littered throughout.
 def _check_for_incompatible_frontend_and_backend_urls(app: Flask) -> None:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
@@ -123,6 +123,7 @@ config_from_env("SPIFFWORKFLOW_BACKEND_OPEN_ID_VERIFY_NBF", default=True)
 config_from_env("SPIFFWORKFLOW_BACKEND_OPEN_ID_VERIFY_AZP", default=True)
 config_from_env("SPIFFWORKFLOW_BACKEND_OPEN_ID_LEEWAY", default=5)
 config_from_env("SPIFFWORKFLOW_BACKEND_OPEN_ID_INTERNAL_URL_IS_VALID_ISSUER", default=False)
+config_from_env("SPIFFWORKFLOW_BACKEND_OPEN_ID_SCOPES", default="openid,profile,email")
 
 # Open ID server
 # use "http://localhost:7000/openid" for running with simple openid

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authentication_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authentication_service.py
@@ -296,7 +296,7 @@ class AuthenticationService:
             + f"?state={state}&"
             + "response_type=code&"
             + f"client_id={self.client_id(authentication_identifier)}&"
-            + f"scope={current_app.config['SPIFFWORKFLOW_BACKEND_OPENID_SCOPE']}&"
+            + f"scope={current_app.config['SPIFFWORKFLOW_BACKEND_OPEN_ID_SCOPES'].replace(",", ' ')}&"
             + f"redirect_uri={redirect_url_to_use}"
         )
         return login_redirect_url


### PR DESCRIPTION
This deprecrates old `SPIFFWORKFLOW_BACKEND_OPENID_SCOPE` env var in favor of `SPIFFWORKFLOW_BACKEND_OPEN_ID_SCOPES` which is a comma separated list of space separated so it's safer to define as an env var.