### PR TITLE
Refactor image build to use a matrix build, add security scanning

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -100,6 +100,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max          
       - name: Adding markdown
         run: echo 'TAGS ${{ steps.meta.outputs.tags }}' >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -34,11 +34,24 @@ on:
     tags: [v*]
 
 jobs:
-  create_frontend_docker_image:
+  create_docker_images:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - image_name: sartography/spiffworkflow-frontend
+            context: spiffworkflow-frontend
+            description: "Frontend component of SpiffWorkflow, a software development platform for building, running, and monitoring executable diagrams"
+          - image_name: sartography/spiffworkflow-backend
+            context: spiffworkflow-backend
+            description: "Backend component of SpiffWorkflow, a software development platform for building, running, and monitoring executable diagrams"
+          - image_name: sartography/connector-proxy-demo
+            context: connector-proxy-demo
+            description: "spiffworkflow-connector-proxy-demo"
+
     env:
       REGISTRY: ghcr.io
-      IMAGE_NAME: sartography/spiffworkflow-frontend
+      IMAGE_NAME: ${{ matrix.image_name }}
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
     permissions:
       contents: read
@@ -67,7 +80,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           labels: |
-            org.opencontainers.image.description=Frontend component of SpiffWorkflow, a software development platform for building, running, and monitoring executable diagrams
+            org.opencontainers.image.description=${{ matrix.description }}
             org.opencontainers.image.version=${{ env.BRANCH_NAME }}-${{ steps.date.outputs.date }}-${{ steps.commit_sha.outputs.sha_short }}
           tags: |
             type=ref,event=branch,branch=main,suffix=-latest
@@ -76,123 +89,13 @@ jobs:
             type=ref,event=tag,enable=true,format=latest
 
       - name: Write app version info
-        working-directory: spiffworkflow-frontend
+        working-directory: ${{ matrix.context }}
         run: echo "$DOCKER_METADATA_OUTPUT_JSON" | jq '.labels' > version_info.json
-      - name: Build and push Frontend Docker image
+
+      - name: Build and push Docker image
         uses: docker/build-push-action@v6.10.0
         with:
-          # this action doesn't seem to respect working-directory so set context
-          context: spiffworkflow-frontend
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-      - run: echo 'TAGS' >> "$GITHUB_STEP_SUMMARY"
-      - run: echo 'TAGS ${{ steps.meta.outputs.tags }}' >> "$GITHUB_STEP_SUMMARY"
-
-  create_backend_docker_image:
-    runs-on: ubuntu-latest
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: sartography/spiffworkflow-backend
-      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Check out the repository
-        uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3.3.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get current date
-        id: date
-        run: echo "date=$(date -u +'%Y-%m-%d_%H-%M-%S')" >> "$GITHUB_OUTPUT"
-      - name: Get short commit sha
-        id: commit_sha
-        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5.6.1
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          labels: |
-            org.opencontainers.image.description=Backend component of SpiffWorkflow, a software development platform for building, running, and monitoring executable diagrams
-            org.opencontainers.image.version=${{ env.BRANCH_NAME }}-${{ steps.date.outputs.date }}-${{ steps.commit_sha.outputs.sha_short }}
-          tags: |
-            type=ref,event=branch,branch=main,suffix=-latest
-            type=ref,event=branch,suffix=-${{ steps.date.outputs.date }}-${{ steps.commit_sha.outputs.sha_short }}
-            type=ref,event=tag,enable=true,format={{version}}
-            type=ref,event=tag,enable=true,format=latest
-
-      - name: Write app version info
-        working-directory: spiffworkflow-backend
-        run: echo "$DOCKER_METADATA_OUTPUT_JSON" | jq '.labels' > version_info.json
-      - name: Build and push Backend Docker image
-        uses: docker/build-push-action@v6.10.0
-        with:
-          # this action doesn't seem to respect working-directory so set context
-          context: spiffworkflow-backend
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-      - name: Adding markdown
-        run: echo 'TAGS ${{ steps.meta.outputs.tags }}' >> "$GITHUB_STEP_SUMMARY"
-
-  create_demo_proxy_docker_image:
-    runs-on: ubuntu-latest
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: sartography/connector-proxy-demo
-      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Check out the repository
-        uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3.3.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get current date
-        id: date
-        run: echo "date=$(date -u +'%Y-%m-%d_%H-%M-%S')" >> "$GITHUB_OUTPUT"
-      - name: Get short commit sha
-        id: commit_sha
-        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5.6.1
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          labels: |
-            org.opencontainers.image.description=spiffworkflow-connector-proxy-demo
-            org.opencontainers.image.version=${{ env.BRANCH_NAME }}-${{ steps.date.outputs.date }}-${{ steps.commit_sha.outputs.sha_short }}
-          tags: |
-            type=ref,event=branch,branch=main,suffix=-latest
-            type=ref,event=branch,suffix=-${{ steps.date.outputs.date }}-${{ steps.commit_sha.outputs.sha_short }}
-            type=ref,event=tag,enable=true,format={{version}}
-            type=ref,event=tag,enable=true,format=latest
-
-      - name: Build and push the connector proxy
-        uses: docker/build-push-action@v6.10.0
-        with:
-          # this action doesn't seem to respect working-directory so set context
-          context: connector-proxy-demo
+          context: ${{ matrix.context }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -203,12 +106,7 @@ jobs:
   quickstart-guide-test:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
-    needs:
-      [
-        create_frontend_docker_image,
-        create_backend_docker_image,
-        create_demo_proxy_docker_image,
-      ]
+    needs: [create_docker_images]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -56,6 +56,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4
@@ -91,8 +92,40 @@ jobs:
       - name: Write app version info
         working-directory: ${{ matrix.context }}
         run: echo "$DOCKER_METADATA_OUTPUT_JSON" | jq '.labels' > version_info.json
+      - name: Generate full image tag
+        id: full_tag
+        run: echo "full_tag=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.BRANCH_NAME }}-${{ steps.date.outputs.date }}-${{ steps.commit_sha.outputs.sha_short }}" >> "$GITHUB_OUTPUT"
+      - name: Build Docker image
+        uses: docker/build-push-action@v6.10.0
+        with:
+          context: ${{ matrix.context }}
+          push: false  # Don't push yet
+          load: true   # Load image to local Docker daemon
+          tags: ${{ steps.full_tag.outputs.full_tag }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
-      - name: Build and push Docker image
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.19.0
+        with:
+          image-ref: '${{ steps.full_tag.outputs.full_tag }}'
+          scan-type: 'image'
+          hide-progress: false
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          exit-code: 1  # Fail the workflow if critical or high vulnerabilities are found
+          timeout: 15m0s
+          ignore-unfixed: true
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()  # Run even if the Trivy scan fails
+        with:
+          sarif_file: 'trivy-results.sarif'
+
+      - name: Push Docker image
         uses: docker/build-push-action@v6.10.0
         with:
           context: ${{ matrix.context }}

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -47,7 +47,7 @@ jobs:
             description: "Backend component of SpiffWorkflow, a software development platform for building, running, and monitoring executable diagrams"
           - image_name: sartography/connector-proxy-demo
             context: connector-proxy-demo
-            description: "spiffworkflow-connector-proxy-demo"
+            description: "Connector proxy component of SpiffWorkflow, providing integration capabilities for external services"
 
     env:
       REGISTRY: ghcr.io

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -56,7 +56,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-      security-events: write
+      security-events: write # Required for uploading Trivy scan results to GitHub Security
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4
@@ -134,7 +134,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
-          cache-to: type=gha,mode=max          
+          cache-to: type=gha,mode=max
       - name: Adding markdown
         run: echo 'TAGS ${{ steps.meta.outputs.tags }}' >> "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
With a little help from Claude.AI...! This consolidates multiple jobs into a single `create_docker_images` job using a matrix strategy. Along the way it removed a couple of (hopefully innocuous) inconsistencies between the three versions of the process.

That turned out well so I also added security-scanning between image build and image push. Currently it doesn't push if there are any `critical` or `high` findings; you may want to adjust that. It also doesn't do anything to notify you when that happens; not sure if there's a good way to do that, or if GitHub Security will let you know on its own. 🤔

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Consolidated Docker image building into a single job for improved efficiency.
	- Added a vulnerability scanning step to enhance security checks.

- **Improvements**
	- Streamlined workflow for building and pushing Docker images.
	- Enhanced organization through a matrix strategy for managing multiple images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->