### PR TITLE
Only scan amd64-arch image for vulns

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -103,7 +103,7 @@ jobs:
           load: true   # Load image to local Docker daemon
           tags: ${{ steps.full_tag.outputs.full_tag }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -103,7 +103,10 @@ jobs:
           load: true   # Load image to local Docker daemon
           tags: ${{ steps.full_tag.outputs.full_tag }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64
+          # While we ultimately push multi-arch images (amd64/arm64) to registries, we don't want to do that before we scan for vulns.
+          # The Action can only load a single arch image into the local dockerd at a time, so we only build and test one arch here. 
+          # It's pretty likely that any vuln in amd64 is also in arm64, and vice-versa, so the trade-off seems reasonable.
+          platforms: linux/amd64 
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
Addresses [the problem identfied here](https://github.com/sartography/spiff-arena/pull/2174#issuecomment-2518118100). There's an option when calling buildx directly to use containerd for loading the image into the local dockerd, and containerd can handle multiple archs for the same tag. However, that's not exposed through the GH Action, at least not yet. This solution results in only scanning the amd64 arch, but it's pretty likely that any vuln in amd64 is also in arm64, and vice-versa, so the trade-off seems reasonable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the Docker image build workflow to focus on `linux/amd64` architecture, simplifying the build process.
	- Maintained multi-platform support during the image push step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->