### PR TITLE
fix-spiff-log-in-celery

### DIFF
--- a/spiffworkflow-backend/bin/create_and_run_process_instance.py
+++ b/spiffworkflow-backend/bin/create_and_run_process_instance.py
@@ -8,7 +8,7 @@ from spiffworkflow_backend.services.user_service import UserService
 
 def main() -> None:
     app = create_app()
-    process_model_identifier = sys.argv[1]
+    process_model_identifier = sys.argv[1].replace(":", "/")
 
     with app.app_context():
         user = UserModel.query.first()

--- a/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/celery_worker.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/celery_worker.py
@@ -26,6 +26,3 @@ def setup_loggers(logger: Any, *args: Any, **kwargs: Any) -> None:
     stdout_handler.setFormatter(log_formatter)
     logger.addHandler(stdout_handler)
     setup_logger_for_app(the_flask_app, logger, force_run_with_celery=True)
-    # this handler is getting added somewhere but not sure where so set its
-    # level really high since we do not need it
-    logging.getLogger("spiff").setLevel(logging.CRITICAL)


### PR DESCRIPTION
Do not set the log level for the spiff logger anymore. It's not as verbose as it once was and we need it available so the `spiff.events` logger can send events to the listener.