### PR TITLE
Remove link target and search process parent display names

### DIFF
--- a/spiffworkflow-frontend/src/components/InstructionsForEndUser.tsx
+++ b/spiffworkflow-frontend/src/components/InstructionsForEndUser.tsx
@@ -106,7 +106,7 @@ export default function InstructionsForEndUser({
           https://www.npmjs.com/package/@uiw/react-md-editor switches to dark mode by default by respecting @media (prefers-color-scheme: dark)
           This makes it look like our site is broken, so until the rest of the site supports dark mode, turn off dark mode for this component.
         */}
-          <MarkdownRenderer linkTarget="_blank" source={instructions} />
+          <MarkdownRenderer source={instructions} />
         </div>
         {showCollapseToggle()}
       </div>

--- a/spiffworkflow-frontend/src/components/MarkdownDisplayForFile.tsx
+++ b/spiffworkflow-frontend/src/components/MarkdownDisplayForFile.tsx
@@ -27,7 +27,6 @@ export default function MarkdownDisplayForFile({ apiPath }: OwnProps) {
   if (markdownContents) {
     return (
       <MarkdownRenderer
-        linkTarget="_blank"
         source={markdownContents}
         wrapperClassName="with-bottom-margin"
       />

--- a/spiffworkflow-frontend/src/views/Extension.tsx
+++ b/spiffworkflow-frontend/src/views/Extension.tsx
@@ -365,7 +365,6 @@ export default function Extension({
     if (markdownContentsToRender.length > 0) {
       componentsToDisplay.push(
         <MarkdownRenderer
-          linkTarget={mdEditorLinkTarget}
           source={markdownContentsToRender.join('\n')}
           wrapperClassName="with-bottom-margin"
         />,
@@ -396,7 +395,6 @@ export default function Extension({
         componentsToDisplay.push(
           <MarkdownRenderer
             className="onboarding"
-            linkTarget="_blank"
             source={markdownToRenderOnSubmit}
             wrapperClassName="with-top-margin"
           />,

--- a/spiffworkflow-frontend/src/views/Extension.tsx
+++ b/spiffworkflow-frontend/src/views/Extension.tsx
@@ -357,11 +357,6 @@ export default function Extension({
       markdownContentsToRender.push(markdownToRenderOnLoad);
     }
 
-    let mdEditorLinkTarget: string | undefined = '_blank';
-    if (uiSchemaPageDefinition.open_links_in_new_tab === false) {
-      mdEditorLinkTarget = undefined;
-    }
-
     if (markdownContentsToRender.length > 0) {
       componentsToDisplay.push(
         <MarkdownRenderer

--- a/spiffworkflow-frontend/src/views/OnboardingView.tsx
+++ b/spiffworkflow-frontend/src/views/OnboardingView.tsx
@@ -42,7 +42,6 @@ export default function OnboardingView() {
       return (
         <MarkdownRenderer
           className="onboarding"
-          linkTarget="_blank"
           source={onboarding.instructions}
         />
       );

--- a/spiffworkflow-frontend/src/views/StartProcess/ProcessModelTreePage.tsx
+++ b/spiffworkflow-frontend/src/views/StartProcess/ProcessModelTreePage.tsx
@@ -360,6 +360,40 @@ export default function ProcessModelTreePage({
     return false;
   };
 
+  // taken from ProcessModelSearch
+  const getParentGroupsDisplayName = (
+    processItem: ProcessModel | ProcessGroup,
+  ) => {
+    if (processItem.parent_groups) {
+      return processItem.parent_groups
+        .map((parentGroup: ProcessGroupLite) => {
+          return parentGroup.display_name;
+        })
+        .join(' / ');
+    }
+    return '';
+  };
+  const getProcessModelLabelForSearch = (
+    processItem: ProcessModel | ProcessGroup,
+  ) => {
+    return `${processItem.display_name} ${
+      processItem.id
+    } ${getParentGroupsDisplayName(processItem)}`;
+  };
+  const shouldFilterProcessModel = (
+    processItem: ProcessModel,
+    inputValue: string,
+  ) => {
+    const inputValueArray = inputValue.split(' ');
+    const processModelLowerCase =
+      getProcessModelLabelForSearch(processItem).toLowerCase();
+
+    return inputValueArray.every((i: any) => {
+      return processModelLowerCase.includes((i || '').toLowerCase());
+    });
+  };
+  /// ////
+
   /**
    * For now, we're just pasting together some info fields that make sense.
    * This is simple and works and is easily expanded,
@@ -372,16 +406,11 @@ export default function ProcessModelTreePage({
     ]);
     // Search the flattened items for the search term.
     const foundGroups = flatItems.filter((item: any) => {
-      return (
-        item.id.toLowerCase().includes(search.toLowerCase()) &&
-        item?.process_groups
-      );
+      return shouldFilterProcessModel(item, search) && 'process_groups' in item;
     });
     const foundModels = flatItems.filter((item: any) => {
       return (
-        (item.id + item.display_name + item.description)
-          .toLowerCase()
-          .includes(search.toLowerCase()) && !item?.process_groups
+        shouldFilterProcessModel(item, search) && !('process_groups' in item)
       );
     });
 

--- a/spiffworkflow-frontend/src/views/public/PublicForm.tsx
+++ b/spiffworkflow-frontend/src/views/public/PublicForm.tsx
@@ -121,9 +121,7 @@ export default function PublicForm() {
     }
 
     if (confirmationMessage) {
-      return (
-        <MarkdownRenderer linkTarget="_blank" source={confirmationMessage} />
-      );
+      return <MarkdownRenderer source={confirmationMessage} />;
     }
     if (publicTask) {
       let jsonSchema = publicTask.form.form_schema;


### PR DESCRIPTION
This removes the linkTarget attribute from MDEditor since it is no longer supported: https://github.com/remarkjs/react-markdown/issues/789

It also updates the search on the PROCESSES page to also search display names of self and parents if possible for both models and groups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Standardized how markdown links behave by removing custom settings that forced links to open in new tabs, allowing them to follow default behavior.
- **New Features**
  - Enhanced search functionality in the process model view with new filtering logic and label generation, improving the accuracy of search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->