### PR TITLE
Use a bundled copy of Monaco Editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "spiff-arena",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/spiffworkflow-frontend/package-lock.json
+++ b/spiffworkflow-frontend/package-lock.json
@@ -45,6 +45,7 @@
         "dmn-js-properties-panel": "^3.7.0",
         "jwt-decode": "^4.0.0",
         "lodash.merge": "^4.6.2",
+        "monaco-editor": "^0.52.2",
         "react": "^18.3.1",
         "react-datepicker": "^7.3.0",
         "react-dom": "^18.3.1",
@@ -13215,10 +13216,10 @@
       "integrity": "sha512-evumdlmIlg9mbRVPbC4F5FuRhNmcMS5pvuBUbqb1G9v09Ro0ImPEgz5n3khir83lFok1inKqVDjnKEg3GpDxQg=="
     },
     "node_modules/monaco-editor": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.49.0.tgz",
-      "integrity": "sha512-2I8/T3X/hLxB2oPHgqcNYUVdA/ZEFShT7IAujifIPMfKkNbLOqY8XCoyHCXrsdjb36dW9MwoTwBCFpXKMwNwaQ==",
-      "peer": true
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -26124,10 +26125,9 @@
       }
     },
     "monaco-editor": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.49.0.tgz",
-      "integrity": "sha512-2I8/T3X/hLxB2oPHgqcNYUVdA/ZEFShT7IAujifIPMfKkNbLOqY8XCoyHCXrsdjb36dW9MwoTwBCFpXKMwNwaQ==",
-      "peer": true
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ=="
     },
     "ms": {
       "version": "2.1.2",

--- a/spiffworkflow-frontend/package.json
+++ b/spiffworkflow-frontend/package.json
@@ -41,6 +41,7 @@
     "dmn-js-properties-panel": "^3.7.0",
     "jwt-decode": "^4.0.0",
     "lodash.merge": "^4.6.2",
+    "monaco-editor": "^0.52.2",
     "react": "^18.3.1",
     "react-datepicker": "^7.3.0",
     "react-dom": "^18.3.1",

--- a/spiffworkflow-frontend/src/components/ReactFormBuilder/ReactFormBuilder.tsx
+++ b/spiffworkflow-frontend/src/components/ReactFormBuilder/ReactFormBuilder.tsx
@@ -1,5 +1,8 @@
 import React, { useEffect, useState, useRef } from 'react';
-import Editor from '@monaco-editor/react';
+
+import Editor, { loader } from '@monaco-editor/react';
+import * as monaco from 'monaco-editor';
+
 // @ts-ignore
 // eslint-disable-next-line import/no-extraneous-dependencies
 import merge from 'lodash/merge';
@@ -20,6 +23,8 @@ import HttpService from '../../services/HttpService';
 import ExamplesTable from './ExamplesTable';
 import CustomForm from '../CustomForm';
 import { Notification } from '../Notification';
+
+loader.config({ monaco });
 
 type ErrorProps = {
   error: Error;


### PR DESCRIPTION
jsdelivr is blocked in a number of countries for some reason.  This change allows us to bundle the monaco code editor rather than pull it from the CDN.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the form builder with an advanced, interactive code editing experience, offering improved functionality and additional language support for a richer user interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->