### PR TITLE
Fix some warnings

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/process_instance_queue.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/process_instance_queue.py
@@ -19,7 +19,7 @@ class ProcessInstanceQueueModel(SpiffworkflowBaseDBModel):
     locked_at_in_seconds: int | None = db.Column(db.Integer, index=True, nullable=True)
     status: str = db.Column(db.String(50), index=True)
 
-    process_instance = relationship(ProcessInstanceModel)
+    process_instance = relationship(ProcessInstanceModel, overlaps="process_instance_queue")
 
     # for timers. right now the apscheduler jobs without celery check for waiting process instances.
     # if the instance's run_at_in_seconds is now or earlier, the instance will run.

--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/process_instance_queue.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/process_instance_queue.py
@@ -19,7 +19,7 @@ class ProcessInstanceQueueModel(SpiffworkflowBaseDBModel):
     locked_at_in_seconds: int | None = db.Column(db.Integer, index=True, nullable=True)
     status: str = db.Column(db.String(50), index=True)
 
-    process_instance = relationship(ProcessInstanceModel, overlaps="process_instance_queue")
+    process_instance = relationship(ProcessInstanceModel, overlaps="process_instance_queue")  # type: ignore
 
     # for timers. right now the apscheduler jobs without celery check for waiting process instances.
     # if the instance's run_at_in_seconds is now or earlier, the instance will run.

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
@@ -537,7 +537,7 @@ def _task_submit_shared(
         only_tasks_that_can_be_completed=True,
     )
 
-    with sentry_sdk.start_span(op="task", description="complete_form_task"):
+    with sentry_sdk.start_span(op="task", name="complete_form_task"):
         with ProcessInstanceQueueService.dequeued(processor.process_instance_model, max_attempts=3):
             ProcessInstanceService.complete_form_task(
                 processor=processor,

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/tasks_controller.py
@@ -442,7 +442,7 @@ def task_submit(
     body: dict[str, Any],
     execution_mode: str | None = None,
 ) -> flask.wrappers.Response:
-    with sentry_sdk.start_span(op="controller_action", description="tasks_controller.task_submit"):
+    with sentry_sdk.start_span(op="controller_action", name="tasks_controller.task_submit"):
         response_item = _task_submit_shared(process_instance_id, task_guid, body, execution_mode=execution_mode)
         if "next_task_assigned_to_me" in response_item:
             response_item = response_item["next_task_assigned_to_me"]

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
@@ -151,7 +151,7 @@ class ProcessInstanceService:
                 f"Failed to get the current git revision when attempting to create a process instance"
                 f" ({process_instance_model.id}) for process_model: '{process_model.id}'. Error was {str(git_revision_error)}"
             )
-            current_app.logger.warn(message)
+            current_app.logger.warning(message)
 
         if start_configuration is None:
             start_configuration = cls.next_start_event_configuration(process_instance_model)
@@ -729,7 +729,7 @@ class ProcessInstanceService:
             tasks = processor.bpmn_process_instance.get_tasks(state=TaskState.WAITING | TaskState.READY)
             JinjaService.add_instruction_for_end_user_if_appropriate(tasks, processor.process_instance_model.id, set())
         elif not ProcessInstanceTmpService.is_enqueued_to_run_in_the_future(processor.process_instance_model):
-            with sentry_sdk.start_span(op="task", description="backend_do_engine_steps"):
+            with sentry_sdk.start_span(op="task", name="backend_do_engine_steps"):
                 execution_strategy_name = None
                 if execution_mode == ProcessInstanceExecutionMode.synchronous.value:
                     execution_strategy_name = "greedy"

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/secret_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/secret_service.py
@@ -123,7 +123,7 @@ class SecretService:
             if spiff_secret_match is not None:
                 spiff_variable_name = spiff_secret_match.group("variable_name")
                 secret = cls.get_secret(spiff_variable_name)
-                with sentry_sdk.start_span(op="task", description="decrypt_secret"):
+                with sentry_sdk.start_span(op="task", name="decrypt_secret"):
                     decrypted_value = cls._decrypt(secret.value)
                     return re.sub(r"\bSPIFF_SECRET:\w+", decrypted_value, value)
         return value

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/service_task_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/service_task_service.py
@@ -72,7 +72,7 @@ class ServiceTaskDelegate:
             if value.startswith(secret_prefix):
                 key = value.removeprefix(secret_prefix)
                 secret = SecretService.get_secret(key)
-                with sentry_sdk.start_span(op="task", description="decrypt_secret"):
+                with sentry_sdk.start_span(op="task", name="decrypt_secret"):
                     return SecretService._decrypt(secret.value)
 
             file_prefix = "file:"
@@ -190,8 +190,8 @@ class ServiceTaskDelegate:
         call_url = f"{connector_proxy_url()}/v1/do/{operator_identifier}"
         current_app.logger.info(f"Calling connector proxy using connector: {operator_identifier}")
         task_data = spiff_task.data
-        with sentry_sdk.start_span(op="connector_by_name", description=operator_identifier):
-            with sentry_sdk.start_span(op="call-connector", description=call_url):
+        with sentry_sdk.start_span(op="connector_by_name", name=operator_identifier):
+            with sentry_sdk.start_span(op="call-connector", name=call_url):
                 params = {k: cls.value_with_secrets_replaced(v["value"]) for k, v in bpmn_params.items()}
                 params["spiff__task_data"] = task_data
                 params = DefaultRegistry().convert(params)  # Avoid serlization errors by using the same coverter as the core lib.


### PR DESCRIPTION
Noticed these when running the tests. Down to 96 from 240. Examples of the orm and sentry warnings can be seen here: https://github.com/sartography/spiff-arena/actions/runs/14472230965/job/40588897524?pr=2296#step:10:466

The remaining warnings are `DeprecationWarning: spiffworkflow:messagePayload and spiffworkflow:messageVariable have been moved to the bpmn:messageDefinition element`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved compatibility with Sentry monitoring by updating how tracing spans are labeled, ensuring better visibility in monitoring tools.
	- Corrected logging to use the appropriate method for warning messages, improving log accuracy.

- **Chores**
	- Enhanced internal relationship definitions to prevent potential warnings or conflicts, improving backend stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->