### PR TITLE
Bump some dev packages

### DIFF
--- a/spiffworkflow-backend/dev.Dockerfile
+++ b/spiffworkflow-backend/dev.Dockerfile
@@ -10,6 +10,6 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 RUN pip install --upgrade pip
-RUN pip install poetry==1.8.1 pytest-xdist==3.5.0
+RUN pip install poetry==2.1.1 pytest-xdist==3.6.1
 
 CMD ["./bin/run_server_locally"]


### PR DESCRIPTION
When running `make be-poetry-i` noticed the dev container poetry version didn't match the lock file. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the versions of Python packages used in the development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->