### PR TITLE
Support dynamic items in forms

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
@@ -756,7 +756,7 @@ def _get_task_model_for_request(
 # originally from: https://bitcoden.com/answers/python-nested-dictionary-update-value-where-any-nested-key-matches
 def _update_form_schema_with_task_data_as_needed(in_dict: dict, task_data: dict) -> None:
     for k, value in in_dict.items():
-        if "anyOf" == k:
+        if k in {"anyOf", "items"}:
             # value will look like the array on the right of "anyOf": ["options_from_task_data_var:awesome_options"]
             if isinstance(value, list):
                 if len(value) == 1:
@@ -815,6 +815,8 @@ def _update_form_schema_with_task_data_as_needed(in_dict: dict, task_data: dict)
                                     )
 
                                     in_dict[k] = options_for_react_json_schema_form
+                                else:
+                                    in_dict[k] = select_options_from_task_data
         elif isinstance(value, dict):
             _update_form_schema_with_task_data_as_needed(value, task_data)
         elif isinstance(value, list):


### PR DESCRIPTION
Adds support for pulling an array field's items from task data, much like dynamic enumerations. The value in task data is in the same format as what the rjsf forms require. If we did the same thing for the enumerations we could drop this [block](https://github.com/sartography/spiff-arena/blob/main/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py#L799), but that would require diagram changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of form options by supporting both "anyOf" and "items" keys, ensuring select options from task data are correctly displayed in more scenarios.
  - Enhanced compatibility with various data formats for form options, allowing for broader support of different task data structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->