### PR TITLE
Bump Jinja2 for security, arena poetry

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -18,4 +18,4 @@ RUN adduser --uid $USER_ID --gid $GROUP_ID $USER_NAME
 RUN git config --global --add safe.directory *
 
 RUN pip install --upgrade pip
-RUN pip install poetry==1.8.1
+RUN pip install poetry==2.1.1

--- a/spiffworkflow-backend/poetry.lock
+++ b/spiffworkflow-backend/poetry.lock
@@ -1295,14 +1295,14 @@ files = [
 
 [[package]]
 name = "jinja2"
-version = "3.1.5"
+version = "3.1.6"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
 groups = ["main", "dev"]
 files = [
-    {file = "jinja2-3.1.5-py3-none-any.whl", hash = "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb"},
-    {file = "jinja2-3.1.5.tar.gz", hash = "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb"},
+    {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
+    {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
 ]
 
 [package.dependencies]
@@ -3832,4 +3832,4 @@ boto3 = ["boto3"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "b1488bca0181182b6eca956adc8c50747ef2c50e24c56b7aa6a19762a56b5743"
+content-hash = "013f3417c6f8c494b8d17ca34da8debb662752d96670b00baac68608686d4e40"

--- a/spiffworkflow-backend/pyproject.toml
+++ b/spiffworkflow-backend/pyproject.toml
@@ -49,7 +49,7 @@ lxml = "^5.3.1"
 marshmallow-enum = "^1.5.1"
 PyJWT = "^2.10.1"
 APScheduler = "*"
-Jinja2 = "^3.1.5"
+Jinja2 = "^3.1.6"
 RestrictedPython = "^8.0"
 Flask-SQLAlchemy = "^3"
 


### PR DESCRIPTION
Two of the changes from my previous pr - the Jinja2 one is a security scan fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Poetry to version 2.1.1 in the development environment.
  - Updated Jinja2 dependency to version 3.1.6 or higher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->