### PR TITLE
fix-os-path-join

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_model_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_model_service.py
@@ -621,11 +621,11 @@ class ProcessModelService(FileSystemService):
     @classmethod
     def process_group_move(cls, original_process_group_id: str, new_location: str) -> ProcessGroup:
         original_group_path = cls.full_path_from_id(original_process_group_id)
-        _, original_group_id = os.path.split(original_group_path)
-        new_root = os.path.join(FileSystemService.root_path(), new_location)
-        new_group_path = os.path.abspath(os.path.join(FileSystemService.root_path(), new_root, original_group_id))
-        destination = shutil.move(original_group_path, new_group_path)
-        new_process_group = cls.get_process_group(destination)
+        _, original_base_group_id = os.path.split(original_group_path)
+        new_group_id = os.path.join(new_location, original_base_group_id)
+        new_group_path = os.path.abspath(os.path.join(FileSystemService.root_path(), new_location))
+        shutil.move(original_group_path, new_group_path)
+        new_process_group = cls.get_process_group(new_group_id)
         return new_process_group
 
     @classmethod

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_file_system_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_file_system_service.py
@@ -1,0 +1,13 @@
+from spiffworkflow_backend.services.file_system_service import FileSystemService
+from tests.spiffworkflow_backend.helpers.base_test import BaseTest
+
+
+class TestFileSystemService(BaseTest):
+    def test_path_join(self) -> None:
+        test_cases = {
+            "/root/path/hey": ["/root/path", "/hey"],
+            "/root/path/hey1": ["/root/path", "hey1"],
+            "/root/path/hey/bob": ["/root/path", "hey", "/bob"],
+        }
+        for expected_path, input in test_cases.items():
+            assert FileSystemService.path_join(*input) == expected_path

--- a/spiffworkflow-frontend/src/views/StartProcess/ProcessModelTreePage.tsx
+++ b/spiffworkflow-frontend/src/views/StartProcess/ProcessModelTreePage.tsx
@@ -452,7 +452,10 @@ export default function ProcessModelTreePage({
   const dataStoresForProcessGroup = dataStores.filter(
     (dataStore: DataStore) => {
       return (
-        currentProcessGroup && dataStore.location === currentProcessGroup.id
+        (currentProcessGroup &&
+          dataStore.location === currentProcessGroup.id) ||
+        (!currentProcessGroup &&
+          (!dataStore.location || dataStore.location === '/'))
       );
     },
   );


### PR DESCRIPTION
This adds in a new method to join path segments that strips off leading slashes. This will help to unmask some issues and unintended side effects of our code but could also cause bugs where we were relying on os.path.join to be handled in this way. The tests are passing now.