### PR TITLE
Start from diagram editor

### DIFF
--- a/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
+++ b/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
@@ -857,7 +857,7 @@ export default function ReactDiagramEditor({
               Save
             </Button>
           </Can>
-          <ProcessInstanceRun processModel={processModel} />
+          { processModel && <ProcessInstanceRun processModel={processModel} /> }
           <Can
             I="DELETE"
             a={targetUris.processModelFileShowPath}

--- a/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
+++ b/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
@@ -65,9 +65,10 @@ import {
   modifyProcessIdentifierForPathParam,
 } from '../helpers';
 import { useUriListForPermissions } from '../hooks/UriListForPermissions';
-import { PermissionsToCheck, ProcessReference, Task } from '../interfaces';
+import { PermissionsToCheck, ProcessModel, ProcessReference, Task } from '../interfaces';
 import { usePermissionFetcher } from '../hooks/PermissionService';
 import SpiffTooltip from './SpiffTooltip';
+import ProcessInstanceRun from '../components/ProcessInstanceRun';
 
 type OwnProps = {
   processModelId: string;
@@ -78,6 +79,7 @@ type OwnProps = {
   disableSaveButton?: boolean;
   fileName?: string;
   isPrimaryFile?: boolean;
+  processModel?: ProcessModel;
   onCallActivityOverlayClick?: (..._args: any[]) => any;
   onDataStoresRequested?: (..._args: any[]) => any;
   onDeleteFile?: (..._args: any[]) => any;
@@ -111,6 +113,7 @@ export default function ReactDiagramEditor({
   disableSaveButton,
   fileName,
   isPrimaryFile,
+  processModel,
   onCallActivityOverlayClick,
   onDataStoresRequested,
   onDeleteFile,
@@ -141,6 +144,7 @@ export default function ReactDiagramEditor({
   const permissionRequestData: PermissionsToCheck = {};
 
   if (diagramType !== 'readonly') {
+    permissionRequestData[targetUris.processInstanceCreatePath] = ['POST'];
     permissionRequestData[targetUris.processModelShowPath] = ['PUT'];
     permissionRequestData[targetUris.processModelFileShowPath] = [
       'POST',
@@ -853,6 +857,11 @@ export default function ReactDiagramEditor({
             >
               Save
             </Button>
+          </Can>
+          <Can I="POST" a={targetUris.processInstanceCreatePath} ability={ability}>
+	    {processModel?.primary_file_name && processModel?.is_executable && (
+              <ProcessInstanceRun processModel={processModel} />
+	    )}
           </Can>
           <Can
             I="DELETE"

--- a/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
+++ b/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
@@ -144,7 +144,6 @@ export default function ReactDiagramEditor({
   const permissionRequestData: PermissionsToCheck = {};
 
   if (diagramType !== 'readonly') {
-    permissionRequestData[targetUris.processInstanceCreatePath] = ['POST'];
     permissionRequestData[targetUris.processModelShowPath] = ['PUT'];
     permissionRequestData[targetUris.processModelFileShowPath] = [
       'POST',
@@ -858,11 +857,7 @@ export default function ReactDiagramEditor({
               Save
             </Button>
           </Can>
-          <Can I="POST" a={targetUris.processInstanceCreatePath} ability={ability}>
-	    {processModel?.primary_file_name && processModel?.is_executable && (
-              <ProcessInstanceRun processModel={processModel} />
-	    )}
-          </Can>
+          <ProcessInstanceRun processModel={processModel} />
           <Can
             I="DELETE"
             a={targetUris.processModelFileShowPath}

--- a/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
+++ b/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
@@ -65,10 +65,15 @@ import {
   modifyProcessIdentifierForPathParam,
 } from '../helpers';
 import { useUriListForPermissions } from '../hooks/UriListForPermissions';
-import { PermissionsToCheck, ProcessModel, ProcessReference, Task } from '../interfaces';
+import {
+  PermissionsToCheck,
+  ProcessModel,
+  ProcessReference,
+  Task,
+} from '../interfaces';
 import { usePermissionFetcher } from '../hooks/PermissionService';
 import SpiffTooltip from './SpiffTooltip';
-import ProcessInstanceRun from '../components/ProcessInstanceRun';
+import ProcessInstanceRun from './ProcessInstanceRun';
 
 type OwnProps = {
   processModelId: string;
@@ -857,7 +862,7 @@ export default function ReactDiagramEditor({
               Save
             </Button>
           </Can>
-          { processModel && <ProcessInstanceRun processModel={processModel} /> }
+          {processModel && <ProcessInstanceRun processModel={processModel} />}
           <Can
             I="DELETE"
             a={targetUris.processModelFileShowPath}

--- a/spiffworkflow-frontend/src/views/ProcessModelEditDiagram.tsx
+++ b/spiffworkflow-frontend/src/views/ProcessModelEditDiagram.tsx
@@ -1411,6 +1411,7 @@ export default function ProcessModelEditDiagram() {
         disableSaveButton={!diagramHasChanges}
         fileName={params.file_name}
         isPrimaryFile={params.file_name === processModel?.primary_file_name}
+        processModel={processModel}
         onDataStoresRequested={onDataStoresRequested}
         onDeleteFile={onDeleteFile}
         onDmnFilesRequested={onDmnFilesRequested}


### PR DESCRIPTION
Adds a start button to the right of the save button on the react diagram editor. Saves two clicks when wanting to start the diagram that you are editing. The `ProcessInstanceRun` component already has all the permission and logic checks baked in, so we just have to make sure we have a process model.