### PR TITLE
Return from start

### DIFF
--- a/spiffworkflow-frontend/src/components/ProcessInstanceProgress.tsx
+++ b/spiffworkflow-frontend/src/components/ProcessInstanceProgress.tsx
@@ -76,7 +76,7 @@ export default function ProcessInstanceProgress({
         ) {
           navigate(processInstanceShowPageUrl);
         } else {
-	  const toUrl = getAndRemoveLastProcessInstanceRunLocation() ?? '/';
+          const toUrl = getAndRemoveLastProcessInstanceRunLocation() ?? '/';
           navigate(toUrl);
         }
       }

--- a/spiffworkflow-frontend/src/components/ProcessInstanceProgress.tsx
+++ b/spiffworkflow-frontend/src/components/ProcessInstanceProgress.tsx
@@ -16,6 +16,7 @@ import {
   errorDisplayStateless,
   errorForDisplayFromProcessInstanceErrorDetail,
 } from './ErrorDisplay';
+import { getAndRemoveLastProcessInstanceRunLocation } from '../services/LocalStorageService';
 
 type OwnProps = {
   processInstanceId: number;
@@ -75,7 +76,8 @@ export default function ProcessInstanceProgress({
         ) {
           navigate(processInstanceShowPageUrl);
         } else {
-          navigate('/');
+	  const toUrl = getAndRemoveLastProcessInstanceRunLocation() ?? '/';
+          navigate(toUrl);
         }
       }
 

--- a/spiffworkflow-frontend/src/components/ProcessInstanceRun.tsx
+++ b/spiffworkflow-frontend/src/components/ProcessInstanceRun.tsx
@@ -98,7 +98,7 @@ export default function ProcessInstanceRun({
   const onProcessInstanceRun = (processInstance: ProcessInstance) => {
     const processInstanceId = processInstance.id;
     setLastProcessInstanceRunLocation(window.location.pathname);
-    
+
     if (processInstance.process_model_uses_queued_execution) {
       navigate(
         `/process-instances/for-me/${modifiedProcessModelId}/${processInstanceId}/progress`,

--- a/spiffworkflow-frontend/src/components/ProcessInstanceRun.tsx
+++ b/spiffworkflow-frontend/src/components/ProcessInstanceRun.tsx
@@ -9,6 +9,7 @@ import {
   RecentProcessModel,
 } from '../interfaces';
 import HttpService from '../services/HttpService';
+import { setLastProcessInstanceRunLocation } from '../services/LocalStorageService';
 import { modifyProcessIdentifierForPathParam } from '../helpers';
 import { usePermissionFetcher } from '../hooks/PermissionService';
 import useAPIError from '../hooks/UseApiError';
@@ -96,6 +97,8 @@ export default function ProcessInstanceRun({
 
   const onProcessInstanceRun = (processInstance: ProcessInstance) => {
     const processInstanceId = processInstance.id;
+    setLastProcessInstanceRunLocation(window.location.pathname);
+    
     if (processInstance.process_model_uses_queued_execution) {
       navigate(
         `/process-instances/for-me/${modifiedProcessModelId}/${processInstanceId}/progress`,

--- a/spiffworkflow-frontend/src/components/ProcessInterstitial.tsx
+++ b/spiffworkflow-frontend/src/components/ProcessInterstitial.tsx
@@ -236,7 +236,9 @@ export default function ProcessInterstitial({
   if (state === 'CLOSED' && lastTask === null && allowRedirect) {
     // Favor redirecting to the process instance show page
     if (processInstance) {
-      const toUrl = getAndRemoveLastProcessInstanceRunLocation() ?? processInstanceShowPageUrl;
+      const toUrl =
+        getAndRemoveLastProcessInstanceRunLocation() ??
+        processInstanceShowPageUrl;
       navigate(toUrl);
     } else {
       const taskUrl = '/tasks';

--- a/spiffworkflow-frontend/src/components/ProcessInterstitial.tsx
+++ b/spiffworkflow-frontend/src/components/ProcessInterstitial.tsx
@@ -9,6 +9,7 @@ import InstructionsForEndUser from './InstructionsForEndUser';
 import { ProcessInstance, ProcessInstanceTask } from '../interfaces';
 import useAPIError from '../hooks/UseApiError';
 import { HUMAN_TASK_TYPES } from '../helpers';
+import { getAndRemoveLastProcessInstanceRunLocation } from '../services/LocalStorageService';
 
 type OwnProps = {
   processInstanceId: number;
@@ -235,7 +236,8 @@ export default function ProcessInterstitial({
   if (state === 'CLOSED' && lastTask === null && allowRedirect) {
     // Favor redirecting to the process instance show page
     if (processInstance) {
-      navigate(processInstanceShowPageUrl);
+      const toUrl = getAndRemoveLastProcessInstanceRunLocation() ?? processInstanceShowPageUrl;
+      navigate(toUrl);
     } else {
       const taskUrl = '/tasks';
       navigate(taskUrl);

--- a/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
+++ b/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
@@ -756,7 +756,7 @@ export default function ReactDiagramEditor({
     url,
   ]);
 
-  function handleSave() {
+  const handleSave = useCallback(() => {
     if (saveDiagram) {
       (diagramModelerState as any)
         .saveXML({ format: true })
@@ -764,7 +764,15 @@ export default function ReactDiagramEditor({
           saveDiagram(xmlObject.xml);
         });
     }
-  }
+  }, [diagramModelerState, saveDiagram]);
+
+  // save the diagram
+  useEffect(() => {
+    if (!diagramModelerState || disableSaveButton) {
+      return;
+    }
+    handleSave();
+  }, [diagramModelerState, disableSaveButton, handleSave]);
 
   function handleDelete() {
     if (onDeleteFile) {

--- a/spiffworkflow-frontend/src/services/LocalStorageService.ts
+++ b/spiffworkflow-frontend/src/services/LocalStorageService.ts
@@ -4,6 +4,7 @@
  * but for now all we need is the basic accessors.
  */
 
+const LAST_PROCESS_INSTANCE_RUN_LOCATION = "lastProcessInstanceRunLocation";
 const SPIFF_FAVORITES = 'spifffavorites';
 
 const getStorageValue = (key: string) => {
@@ -19,9 +20,21 @@ const removeStorageValue = (key: string) => {
   localStorage.removeItem(key);
 };
 
+const getAndRemoveLastProcessInstanceRunLocation = () => {
+  const location = localStorage.getItem(LAST_PROCESS_INSTANCE_RUN_LOCATION);
+  localStorage.removeItem(LAST_PROCESS_INSTANCE_RUN_LOCATION);
+  return location;
+};
+
+const setLastProcessInstanceRunLocation = (value: string) => {
+  localStorage.setItem(LAST_PROCESS_INSTANCE_RUN_LOCATION, value);
+};
+
 export {
   SPIFF_FAVORITES,
   getStorageValue,
   setStorageValue,
   removeStorageValue,
+  getAndRemoveLastProcessInstanceRunLocation,
+  setLastProcessInstanceRunLocation,
 };

--- a/spiffworkflow-frontend/src/services/LocalStorageService.ts
+++ b/spiffworkflow-frontend/src/services/LocalStorageService.ts
@@ -4,7 +4,7 @@
  * but for now all we need is the basic accessors.
  */
 
-const LAST_PROCESS_INSTANCE_RUN_LOCATION = "lastProcessInstanceRunLocation";
+const LAST_PROCESS_INSTANCE_RUN_LOCATION = 'lastProcessInstanceRunLocation';
 const SPIFF_FAVORITES = 'spifffavorites';
 
 const getStorageValue = (key: string) => {

--- a/spiffworkflow-frontend/src/views/ProcessModelEditDiagram.tsx
+++ b/spiffworkflow-frontend/src/views/ProcessModelEditDiagram.tsx
@@ -322,7 +322,6 @@ export default function ProcessModelEditDiagram() {
   const saveDiagram = (bpmnXML: any, fileName = params.file_name) => {
     setDisplaySaveFileMessage(false);
     removeError();
-    setBpmnXmlForDiagramRendering(bpmnXML);
 
     let url = `/process-models/${modifiedProcessModelId}/files`;
     let httpMethod = 'PUT';


### PR DESCRIPTION
This builds upon the pr #2348. With this change, when the start button is clicked and the process runs, when it completes the user will return to the location that they started the process from. For the bpmn author this is nice since in the current flow, you have to go back to the process model, hit start, get dropped into the home page, go back to your process model, open the bpmn file, make a change and repeat. This should greatly reduce clicks during bpmn development.

This change does not affect instance started from the process group/model list when "Start this process" is clicked.