### PR TITLE
feat(username): record username to db instead of email

### DIFF
--- a/docs/reference/bpmn/script_tasks.md
+++ b/docs/reference/bpmn/script_tasks.md
@@ -179,6 +179,7 @@ Please see the [implementing files themselves](https://github.com/sartography/sp
 | get_toplevel_process_info              | Returns information about the currently running process.                                                                                                       |
 | get_url_for_task_with_bpmn_identifier  | Returns the URL to the task show page for a task with the given BPMN identifier. The script task calling this MUST be in the same process as the desired task. |
 | get_user_properties                    | Gets the user properties for the current user.                                                                                                                 |
+| get_user                    | Gets the user by username.                                                                                                                 |
 | markdown_file_download_link            | Returns a markdown format string for a file download link.                                                                                                     |
 | refresh_permissions                    | Adds permissions using a dictionary.                                                                                                                           |
 | set_user_properties                    | Sets given user properties on the current user.                                                                                                                |

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/openid_blueprint/openid_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/openid_blueprint/openid_blueprint.py
@@ -135,6 +135,7 @@ def token() -> Response | dict:
             "iat": math.floor(time.time()),
             "exp": round(time.time()) + two_days,
             "sub": user_name,
+            "username": user_name,
             "email": user_details["email"],
             "preferred_username": user_details.get("preferred_username", user_name),
         },

--- a/spiffworkflow-backend/src/spiffworkflow_backend/scripts/get_user.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/scripts/get_user.py
@@ -1,0 +1,26 @@
+from typing import Any
+
+from flask import g
+
+from spiffworkflow_backend.models.script_attributes_context import ScriptAttributesContext
+from spiffworkflow_backend.models.user import UserModel
+from spiffworkflow_backend.scripts.script import Script
+
+
+class GetUser(Script):
+    @staticmethod
+    def requires_privileged_permissions() -> bool:
+        """We have deemed this function safe to run without elevated permissions."""
+        return False
+
+    def get_description(self) -> str:
+        return """Gets user by username."""
+
+    def run(self, script_attributes_context: ScriptAttributesContext, *args: Any, **kwargs: Any) -> Any:
+        if "username" in kwargs:
+            user = UserModel.query.filter_by(username=kwargs["username"]).first()
+        else:
+            user = UserModel.query.filter_by(username=args[0]).first()
+        if user is not None:
+            return user.as_dict()
+        return None

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
@@ -449,7 +449,10 @@ class AuthorizationService:
         user_attributes = {}
 
         if "email" in user_info:
-            user_attributes["username"] = user_info["email"]
+            if "username" in user_info:
+                user_attributes["username"] = user_info["username"]
+            else:
+                user_attributes["username"] = user_info["email"]
             user_attributes["email"] = user_info["email"]
         else:  # we fall back to the sub, which may be very ugly.
             fallback_username = user_info["sub"] + "@" + user_info["iss"]

--- a/spiffworkflow-frontend/src/components/TaskTable.tsx
+++ b/spiffworkflow-frontend/src/components/TaskTable.tsx
@@ -221,7 +221,7 @@ export default function TaskTable({
   }
 
   const regex = new RegExp(
-    `\\b(${UserService.getPreferredUsername()}|${UserService.getUserEmail()})\\b`,
+    `\\b(${UserService.getPreferredUsername()}|${UserService.getUserEmail()}|${UserService.getUserName()})\\b`,
   );
 
   const records = entries.map((entry) => {

--- a/spiffworkflow-frontend/src/services/UserService.ts
+++ b/spiffworkflow-frontend/src/services/UserService.ts
@@ -113,6 +113,15 @@ const getUserEmail = () => {
   return null;
 };
 
+const getUserName = () => {
+  const idToken = getIdToken();
+  if (idToken) {
+    const idObject = jwtDecode(idToken);
+    return (idObject as any).username;
+  }
+  return null;
+};
+
 const authenticationDisabled = () => {
   const idToken = getIdToken();
   if (idToken) {
@@ -170,6 +179,7 @@ const UserService = {
   getCurrentLocation,
   getPreferredUsername,
   getUserEmail,
+  getUserName,
   isLoggedIn,
   isPublicUser,
   loginIfNeeded,


### PR DESCRIPTION
Not sure what is the story behind, but I am proposing to use `username` column for username field from openid provider instead of email.

The use case is to have a multiple accounts for one email.