### PR TITLE
fix(fade): increase time for reading before redirection

### DIFF
--- a/spiffworkflow-frontend/src/assets/styles/transitions.css
+++ b/spiffworkflow-frontend/src/assets/styles/transitions.css
@@ -8,7 +8,7 @@
 }
 
 .fade-out {
-  animation: fadeOutStandard 2s ease-in-out;
+  animation: fadeOutStandard 5s ease-in-out;
 }
 
 @keyframes fadeInStandard {

--- a/spiffworkflow-frontend/src/components/ProcessInterstitial.tsx
+++ b/spiffworkflow-frontend/src/components/ProcessInterstitial.tsx
@@ -112,7 +112,7 @@ export default function ProcessInterstitial({
           getAndRemoveLastProcessInstanceRunLocation() ??
           processInstanceShowPageUrl;
         navigate(toUrl);
-      }, 2000); // Adjust the timeout to match the CSS transition duration
+      }, 4000); // Adjust the timeout to match the CSS transition duration
     }
     return undefined;
   }, [


### PR DESCRIPTION
Consider changing constant for fade out of the "task done, next assigned user is ..." box

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Extended the fade-out animation duration for smoother visual transitions.

- **Refactor**
  - Increased the delay before navigating away from the interstitial screen to better align with the updated fade-out animation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->