### PR TITLE
Handle another return from start location

### DIFF
--- a/spiffworkflow-frontend/src/components/ProcessInterstitial.tsx
+++ b/spiffworkflow-frontend/src/components/ProcessInterstitial.tsx
@@ -108,7 +108,10 @@ export default function ProcessInterstitial({
           'lastProcessInstanceId',
           processInstanceId.toString(),
         );
-        navigate(processInstanceShowPageUrl);
+        const toUrl =
+          getAndRemoveLastProcessInstanceRunLocation() ??
+          processInstanceShowPageUrl;
+        navigate(toUrl);
       }, 2000); // Adjust the timeout to match the CSS transition duration
     }
     return undefined;


### PR DESCRIPTION
Looks like I missed one of the navigation points that can happen when a process instance run finishes. This allows another return from start to help reduce the clicks needed during bpmn development. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved navigation behavior after process completion by redirecting users to a previously stored location when available, or to the default process instance page otherwise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->