### PR TITLE
Provide setting for multiple OIDC issuers

### DIFF
--- a/docs/how_to_guides/deployment/configure_azure_as_an_openid_provider.md
+++ b/docs/how_to_guides/deployment/configure_azure_as_an_openid_provider.md
@@ -1,0 +1,77 @@
+# Configure Azure Entra as an OpenID Provider
+
+## Register your app
+
+1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com/).
+2. Browse to _Applications > App registrations_ using the sidebar.
+3. Enter the name of your application, like `spiffworkflow-backend`.
+4. Under _supported account types,_ you will likely want "Accounts in this organizational directory only"
+5. Skip the redirect URL. We will do that later.
+6. Click _Register._
+7. In the new view, copy and note the following:
+    - _Application (client) ID._ It is your **Client ID.**
+    - _Directory (tenant) ID._ This is part of your server URL.
+ 
+
+### Configure your app
+
+1. Select _Authentication_ from the sidebar.
+2. Under _Platform configurations,_ select "+ Add a platform"
+3. In the pane that opens, select _Web_.
+4. Under _Redirect URIs,_ add `http://localhost:8000/v1.0/login_return`
+5. Leave _Front-chanel logout URL_ blank.
+6. Leave the checkboxes unchecked under _Implicit grant and hybrid flows._
+7. Click _Configure._
+
+### Add additional Redirect URLs
+
+You will need to add more redirect URLs.
+
+Follow these instructions for the following URL patterns:
+
+- `http://localhost:8000/v1.0/login_api_return`
+- `https://<domainname>/v1.0/login_return`
+- `https://<domainname>/v1.0/login_api_return`
+
+1. Under _Web > Redirect URIs,_ click _Add URI._
+2. Type in the URL pattern.
+
+### Create a Client Secret
+
+1. Select _Certificates & Secrets_ from the sidebar.
+2. Click _+ New client secret_
+3. In the pane that opens, enter a description and expiration, then click _Add._
+4. Copy the _Value_ using the icon after the string and note this value. This is your **Client Secret Key.**
+
+### Add groups claim to the token
+
+The basic steps are:
+
+1. Select _Token configuration_ from the sidebar.
+2. Select _Add groups claim._
+3. Select the group types to return (Security groups, or Directory roles, All groups, and/or Groups assigned to the application)
+4. Select _Save._
+
+For more information about these settings read the [Microsoft documentation](https://learn.microsoft.com/en-us/entra/identity-platform/optional-claims?tabs=appui#configure-groups-optional-claims)
+
+## Configure Spiff Workflow
+
+Set the following environment variables on your SpiffWorkflow backend server to connect with your Azure Entra instance:
+
+```bash
+# OpenID Server URL
+SPIFFWORKFLOW_BACKEND_OPEN_ID_SERVER_URL=https://login.microsoftonline.com/<YOUR_DIRECTORY_(TENANT)_ID>
+
+# Client ID and Secret Key from Okta
+SPIFFWORKFLOW_BACKEND_OPEN_ID_CLIENT_ID=<YOUR_CLIENT_ID>
+SPIFFWORKFLOW_BACKEND_OPEN_ID_CLIENT_SECRET_KEY=<YOUR_CLIENT_SECRET_KEY>
+
+# Additional valid issuers (don't forget the trailing slash)
+SPIFFWORKFLOW_BACKEND_OPEN_ID_ADDITIONAL_VALID_ISSUERS: "https://sts.windows.net/<YOUR_DIRECTORY_(TENANT)_ID>/"
+
+# OpenID Scopes (includes groups)
+SPIFFWORKFLOW_BACKEND_OPENID_SCOPE="openid profile email groups"
+
+# Allow OpenID Provider to manage user groups
+SPIFFWORKFLOW_BACKEND_OPEN_ID_IS_AUTHORITY_FOR_USER_GROUPS: true
+```

--- a/docs/how_to_guides/deployment/index.md
+++ b/docs/how_to_guides/deployment/index.md
@@ -6,6 +6,7 @@ deploy
 configure_secrets
 manage_permissions
 configure_okta_as_an_openid_provider
+configure_azure_as_an_openid_provider
 use_pathbased_routing
 work_with_redis_celery_broker
 deploy_a_connector_proxy_as_an_aws_lambda_function

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/__init__.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/__init__.py
@@ -251,10 +251,13 @@ def setup_config(app: Flask) -> None:
         app.config["SPIFFWORKFLOW_BACKEND_MAX_INSTANCE_LOCK_DURATION_IN_SECONDS"]
     )
 
+    additional_valid_issuers = app.config.get("SPIFFWORKFLOW_BACKEND_OPEN_ID_ADDITIONAL_VALID_ISSUERS", "").split(",")
+
     if app.config.get("SPIFFWORKFLOW_BACKEND_AUTH_CONFIGS") is None:
         app.config["SPIFFWORKFLOW_BACKEND_AUTH_CONFIGS"] = [
             {
                 "additional_valid_client_ids": app.config.get("SPIFFWORKFLOW_BACKEND_OPEN_ID_ADDITIONAL_VALID_CLIENT_IDS"),
+                "additional_valid_issuers": additional_valid_issuers,
                 "client_id": app.config.get("SPIFFWORKFLOW_BACKEND_OPEN_ID_CLIENT_ID"),
                 "client_secret": app.config.get("SPIFFWORKFLOW_BACKEND_OPEN_ID_CLIENT_SECRET_KEY"),
                 "identifier": "default",

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
@@ -144,7 +144,7 @@ else:
         # comma-separated list of issuer URLs to validate against
         # This is useful for Azure Entra which has a server URL of
         # https://login.microsoftonline.com/<tenant-id>/v2.0 but the iss url is https://sts.windows.net/<tenant-id>/
-        config_from_env("SPIFFWORKFLOW_BACKEND_OPEN_ID_ADDITIONAL_VALID_ISSUERS")
+        config_from_env("SPIFFWORKFLOW_BACKEND_OPEN_ID_ADDITIONAL_VALID_ISSUERS", default="")
 
         # comma-separated list of client ids that can be successfully validated against.
         # useful for api users that will login to a different client on the same realm but from something external to backend.

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
@@ -144,7 +144,7 @@ else:
         # comma-separated list of issuer URLs to validate against
         # This is useful for Azure Entra which has a server URL of
         # https://login.microsoftonline.com/<tenant-id>/v2.0 but the iss url is https://sts.windows.net/<tenant-id>/
-        config_from_env("SPIFFWORKFLOW_BACKEND_OPEN_ID_ADDITIONAL_VALID_ISSUERS", default="")
+        config_from_env("SPIFFWORKFLOW_BACKEND_OPEN_ID_ADDITIONAL_VALID_ISSUERS")
 
         # comma-separated list of client ids that can be successfully validated against.
         # useful for api users that will login to a different client on the same realm but from something external to backend.
@@ -164,7 +164,7 @@ else:
                 "client_id": "spiffworkflow-backend",
                 "client_secret": "JXeQExm0JhQPLumgHtIIqf52bDalHz0q",
                 "additional_valid_client_ids": None,
-                "additional_valid_issuers": None,
+                "additional_valid_issuers": [],
             }
         ]
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
@@ -141,6 +141,11 @@ else:
         config_from_env("SPIFFWORKFLOW_BACKEND_OPEN_ID_CLIENT_SECRET_KEY", default="JXeQExm0JhQPLumgHtIIqf52bDalHz0q")
         config_from_env("SPIFFWORKFLOW_BACKEND_OPEN_ID_SERVER_INTERNAL_URL")
 
+        # comma-separated list of issuer URLs to validate against
+        # This is useful for Azure Entra which has a server URL of
+        # https://login.microsoftonline.com/<tenant-id>/v2.0 but the iss url is https://sts.windows.net/<tenant-id>/
+        config_from_env("SPIFFWORKFLOW_BACKEND_OPEN_ID_ADDITIONAL_VALID_ISSUERS")
+
         # comma-separated list of client ids that can be successfully validated against.
         # useful for api users that will login to a different client on the same realm but from something external to backend.
         # Example:
@@ -159,6 +164,7 @@ else:
                 "client_id": "spiffworkflow-backend",
                 "client_secret": "JXeQExm0JhQPLumgHtIIqf52bDalHz0q",
                 "additional_valid_client_ids": None,
+                "additional_valid_issuers": None,
             }
         ]
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authentication_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authentication_service.py
@@ -380,7 +380,7 @@ class AuthenticationService:
             overlapping_aud_values = [x for x in audience_array_in_token if x in valid_audience_values]
 
         internal_server_url = cls.server_url(authentication_identifier, internal=True)
-        additional_valid_issuer_urls = current_app.config["SPIFFWORKFLOW_BACKEND_OPEN_ID_ADDITIONAL_VALID_ISSUERS"] or []
+        additional_valid_issuer_urls = current_app.config["SPIFFWORKFLOW_BACKEND_OPEN_ID_ADDITIONAL_VALID_ISSUERS"].split(",")
         trusted_issuer_urls = [
             cls.server_url(authentication_identifier),
             UserModel.spiff_generated_jwt_issuer(),

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authentication_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authentication_service.py
@@ -380,10 +380,11 @@ class AuthenticationService:
             overlapping_aud_values = [x for x in audience_array_in_token if x in valid_audience_values]
 
         internal_server_url = cls.server_url(authentication_identifier, internal=True)
-
+        additional_valid_issuer_urls = current_app.config["SPIFFWORKFLOW_BACKEND_OPEN_ID_ADDITIONAL_VALID_ISSUERS"] or []
         trusted_issuer_urls = [
             cls.server_url(authentication_identifier),
             UserModel.spiff_generated_jwt_issuer(),
+            *additional_valid_issuer_urls,
         ]
 
         if current_app.config["SPIFFWORKFLOW_BACKEND_OPEN_ID_INTERNAL_URL_IS_VALID_ISSUER"]:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authentication_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authentication_service.py
@@ -80,6 +80,7 @@ class AuthenticationOptionForApi(TypedDict):
 class AuthenticationOption(AuthenticationOptionForApi):
     client_id: str
     client_secret: str
+    additional_valid_issuers: list[str]
 
 
 class AuthenticationOptionNotFoundError(Exception):
@@ -121,6 +122,11 @@ class AuthenticationService:
     @classmethod
     def valid_audiences(cls, authentication_identifier: str) -> list[str]:
         return [cls.client_id(authentication_identifier), "account"]
+
+    @classmethod
+    def valid_issuers(cls, authentication_identifier: str) -> list[str]:
+        issuers: list[str] = cls.authentication_option_for_identifier(authentication_identifier)["additional_valid_issuers"]
+        return issuers
 
     @classmethod
     def server_url(cls, authentication_identifier: str, internal: bool = False) -> str:
@@ -380,7 +386,7 @@ class AuthenticationService:
             overlapping_aud_values = [x for x in audience_array_in_token if x in valid_audience_values]
 
         internal_server_url = cls.server_url(authentication_identifier, internal=True)
-        additional_valid_issuer_urls = current_app.config["SPIFFWORKFLOW_BACKEND_OPEN_ID_ADDITIONAL_VALID_ISSUERS"].split(",")
+        additional_valid_issuer_urls = cls.valid_audiences(authentication_identifier)
         trusted_issuer_urls = [
             cls.server_url(authentication_identifier),
             UserModel.spiff_generated_jwt_issuer(),


### PR DESCRIPTION
This provides a new setting: `SPIFFWORKFLOW_BACKEND_OPEN_ID_ADDITIONAL_VALID_ISSUERS`

This setting fixes #2373.

It includes documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying additional valid issuer URLs for OpenID authentication, improving compatibility with providers like Azure Entra.
- **Documentation**
  - Introduced a new guide detailing how to configure Azure Entra as an OpenID Provider.
  - Updated the deployment documentation index to include the new Azure Entra configuration guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->