### PR TITLE
update retention policy to hopefully not delete all images

### DIFF
--- a/.github/workflows/container_retention_policy.yml
+++ b/.github/workflows/container_retention_policy.yml
@@ -20,4 +20,3 @@ jobs:
           keep-n-most-recent: 1
           # see https://github.com/settings/tokens/1335541013 under burnettk, classic personal access token with write:packages, read:packages, and delete:packages
           token: ${{ secrets.PERSONAL_TOKEN_FOR_CONTAINER_CLEANUP }}
-          dry-run: true


### PR DESCRIPTION
Supports #2395 

This attempts to fix the retention policy so it doesn't delete too many images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container image cleanup workflow to use the latest action version and revised configuration parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->