### PR TITLE
support /api/v1.0 like we have previously supported /v1.0 paths

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/helpers/api_version.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/helpers/api_version.py
@@ -1,1 +1,10 @@
+from flask import current_app
+
 V1_API_PATH_PREFIX = "/v1.0"
+
+
+def remove_api_prefix(path: str) -> str:
+    api_path_prefix = current_app.config["SPIFFWORKFLOW_BACKEND_API_PATH_PREFIX"]
+    if path.startswith(api_path_prefix):
+        return path.removeprefix(api_path_prefix)
+    return path

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/authentication_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/authentication_controller.py
@@ -15,7 +15,6 @@ from spiffworkflow_backend.exceptions.api_error import ApiError
 from spiffworkflow_backend.exceptions.error import InvalidRedirectUrlError
 from spiffworkflow_backend.exceptions.error import MissingAccessTokenError
 from spiffworkflow_backend.exceptions.error import TokenExpiredError
-from spiffworkflow_backend.helpers.api_version import V1_API_PATH_PREFIX
 from spiffworkflow_backend.models.group import SPIFF_NO_AUTH_GROUP
 from spiffworkflow_backend.models.group import GroupModel
 from spiffworkflow_backend.models.service_account import ServiceAccountModel
@@ -208,7 +207,8 @@ def login_api_return(code: str, state: str, session_state: str) -> str:
     # state_dict = ast.literal_eval(base64.b64decode(state).decode("utf-8"))
     # state_dict["final_url"]
 
-    auth_token_object = AuthenticationService().get_auth_token_object(code, "/v1.0/login_api_return")
+    redirect_path = f"{current_app.config['SPIFFWORKFLOW_BACKEND_API_PATH_PREFIX']}/login_api_return"
+    auth_token_object = AuthenticationService().get_auth_token_object(code, redirect_path)
     access_token: str = auth_token_object["access_token"]
     if access_token is None:
         raise MissingAccessTokenError("Cannot find the access token for the request")
@@ -298,8 +298,9 @@ def _find_token_from_request(token: str | None) -> dict[str, str | None]:
         token = request.headers["Authorization"].removeprefix("Bearer ")
 
     if not token and "access_token" in request.cookies:
-        if request.path.startswith(f"{V1_API_PATH_PREFIX}/process-data-file-download/") or request.path.startswith(
-            f"{V1_API_PATH_PREFIX}/extensions-get-data/"
+        api_path_prefix = current_app.config["SPIFFWORKFLOW_BACKEND_API_PATH_PREFIX"]
+        if request.path.startswith(f"{api_path_prefix}/process-data-file-download/") or request.path.startswith(
+            f"{api_path_prefix}/extensions-get-data/"
         ):
             token = request.cookies["access_token"]
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
@@ -29,6 +29,7 @@ from spiffworkflow_backend.exceptions.error import HumanTaskAlreadyCompletedErro
 from spiffworkflow_backend.exceptions.error import HumanTaskNotFoundError
 from spiffworkflow_backend.exceptions.error import UserDoesNotHaveAccessToTaskError
 from spiffworkflow_backend.exceptions.process_entity_not_found_error import ProcessEntityNotFoundError
+from spiffworkflow_backend.helpers.api_version import V1_API_PATH_PREFIX
 from spiffworkflow_backend.models.bpmn_process import BpmnProcessModel
 from spiffworkflow_backend.models.bpmn_process_definition import BpmnProcessDefinitionModel
 from spiffworkflow_backend.models.db import db
@@ -115,7 +116,7 @@ def process_list() -> Any:
     permitted_process_model_identifiers = ProcessModelService.process_model_identifiers_with_permission_for_user(
         user=g.user,
         permission_to_check="create",
-        permission_base_uri="/v1.0/process-instances",
+        permission_base_uri=f"{V1_API_PATH_PREFIX}/process-instances",
         process_model_identifiers=process_model_identifiers,
     )
     permitted_references = []
@@ -419,7 +420,7 @@ def _find_process_instance_for_me_or_raise(
         modified_process_model_identifier = ProcessModelInfo.modify_process_identifier_for_path_param(
             process_instance.process_model_identifier
         )
-        target_uri = f"/v1.0/process-instances/for-me/{modified_process_model_identifier}/{process_instance.id}"
+        target_uri = f"{V1_API_PATH_PREFIX}/process-instances/for-me/{modified_process_model_identifier}/{process_instance.id}"
         has_permission = AuthorizationService.user_has_permission(
             user=g.user,
             permission="read",

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
@@ -29,7 +29,6 @@ from spiffworkflow_backend.exceptions.error import HumanTaskAlreadyCompletedErro
 from spiffworkflow_backend.exceptions.error import HumanTaskNotFoundError
 from spiffworkflow_backend.exceptions.error import UserDoesNotHaveAccessToTaskError
 from spiffworkflow_backend.exceptions.process_entity_not_found_error import ProcessEntityNotFoundError
-from spiffworkflow_backend.helpers.api_version import V1_API_PATH_PREFIX
 from spiffworkflow_backend.models.bpmn_process import BpmnProcessModel
 from spiffworkflow_backend.models.bpmn_process_definition import BpmnProcessDefinitionModel
 from spiffworkflow_backend.models.db import db
@@ -116,7 +115,7 @@ def process_list() -> Any:
     permitted_process_model_identifiers = ProcessModelService.process_model_identifiers_with_permission_for_user(
         user=g.user,
         permission_to_check="create",
-        permission_base_uri=f"{V1_API_PATH_PREFIX}/process-instances",
+        permission_base_uri=f"{current_app.config['SPIFFWORKFLOW_BACKEND_API_PATH_PREFIX']}/process-instances",
         process_model_identifiers=process_model_identifiers,
     )
     permitted_references = []
@@ -420,7 +419,8 @@ def _find_process_instance_for_me_or_raise(
         modified_process_model_identifier = ProcessModelInfo.modify_process_identifier_for_path_param(
             process_instance.process_model_identifier
         )
-        target_uri = f"{V1_API_PATH_PREFIX}/process-instances/for-me/{modified_process_model_identifier}/{process_instance.id}"
+        api_path_prefix = current_app.config["SPIFFWORKFLOW_BACKEND_API_PATH_PREFIX"]
+        target_uri = f"{api_path_prefix}/process-instances/for-me/{modified_process_model_identifier}/{process_instance.id}"
         has_permission = AuthorizationService.user_has_permission(
             user=g.user,
             permission="read",

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/service_tasks_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/service_tasks_controller.py
@@ -11,6 +11,7 @@ from flask import request
 from flask.wrappers import Response
 
 from spiffworkflow_backend.exceptions.api_error import ApiError
+from spiffworkflow_backend.helpers.api_version import V1_API_PATH_PREFIX
 from spiffworkflow_backend.routes.authentication_controller import verify_token
 from spiffworkflow_backend.services.oauth_service import OAuthService
 from spiffworkflow_backend.services.secret_service import SecretService
@@ -30,7 +31,7 @@ def authentication_list() -> flask.wrappers.Response:
         "results": available_authentications,
         "resultsV2": available_v2_authentications,
         "connector_proxy_base_url": current_app.config["SPIFFWORKFLOW_BACKEND_CONNECTOR_PROXY_URL"],
-        "redirect_url": f"{current_app.config['SPIFFWORKFLOW_BACKEND_URL']}/v1.0/authentication_callback",
+        "redirect_url": f"{current_app.config['SPIFFWORKFLOW_BACKEND_URL']}{V1_API_PATH_PREFIX}/authentication_callback",
     }
 
     return Response(json.dumps(response_json), status=200, mimetype="application/json")
@@ -56,7 +57,7 @@ def authentication_begin(
     if not OAuthService.supported_service(service):
         raise ApiError("unknown_authentication_service", f"Unknown authentication service: {service}", status_code=400)
     remote_app = OAuthService.remote_app(service, token)
-    callback = f"{current_app.config['SPIFFWORKFLOW_BACKEND_URL']}/v1.0/authentication_callback/{service}/oauth"
+    callback = f"{current_app.config['SPIFFWORKFLOW_BACKEND_URL']}{V1_API_PATH_PREFIX}/authentication_callback/{service}/oauth"
     return remote_app.authorize(callback=callback, _external=True)  # type: ignore
 
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/service_tasks_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/service_tasks_controller.py
@@ -11,7 +11,6 @@ from flask import request
 from flask.wrappers import Response
 
 from spiffworkflow_backend.exceptions.api_error import ApiError
-from spiffworkflow_backend.helpers.api_version import V1_API_PATH_PREFIX
 from spiffworkflow_backend.routes.authentication_controller import verify_token
 from spiffworkflow_backend.services.oauth_service import OAuthService
 from spiffworkflow_backend.services.secret_service import SecretService
@@ -27,11 +26,12 @@ def authentication_list() -> flask.wrappers.Response:
     available_authentications = ServiceTaskService.authentication_list()
     available_v2_authentications = OAuthService.authentication_list()
 
+    api_path_prefix = current_app.config["SPIFFWORKFLOW_BACKEND_API_PATH_PREFIX"]
     response_json = {
         "results": available_authentications,
         "resultsV2": available_v2_authentications,
         "connector_proxy_base_url": current_app.config["SPIFFWORKFLOW_BACKEND_CONNECTOR_PROXY_URL"],
-        "redirect_url": f"{current_app.config['SPIFFWORKFLOW_BACKEND_URL']}{V1_API_PATH_PREFIX}/authentication_callback",
+        "redirect_url": f"{current_app.config['SPIFFWORKFLOW_BACKEND_URL']}{api_path_prefix}/authentication_callback",
     }
 
     return Response(json.dumps(response_json), status=200, mimetype="application/json")
@@ -57,7 +57,8 @@ def authentication_begin(
     if not OAuthService.supported_service(service):
         raise ApiError("unknown_authentication_service", f"Unknown authentication service: {service}", status_code=400)
     remote_app = OAuthService.remote_app(service, token)
-    callback = f"{current_app.config['SPIFFWORKFLOW_BACKEND_URL']}{V1_API_PATH_PREFIX}/authentication_callback/{service}/oauth"
+    api_path_prefix = current_app.config["SPIFFWORKFLOW_BACKEND_API_PATH_PREFIX"]
+    callback = f"{current_app.config['SPIFFWORKFLOW_BACKEND_URL']}{api_path_prefix}/authentication_callback/{service}/oauth"
     return remote_app.authorize(callback=callback, _external=True)  # type: ignore
 
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/scripts/markdown_file_download_link.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/scripts/markdown_file_download_link.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from flask import current_app
 
+from spiffworkflow_backend.helpers.api_version import V1_API_PATH_PREFIX
 from spiffworkflow_backend.models.process_model import ProcessModelInfo
 from spiffworkflow_backend.models.script_attributes_context import ScriptAttributesContext
 from spiffworkflow_backend.scripts.script import Script
@@ -36,7 +37,10 @@ class GetMarkdownFileDownloadLink(Script):
         if process_instance_id is None:
             raise self.get_proces_instance_id_is_missing_error("save_process_instance_metadata")
         url = current_app.config["SPIFFWORKFLOW_BACKEND_URL"]
-        url += f"/v1.0/process-data-file-download/{modified_process_model_identifier}/" + f"{process_instance_id}/{digest}"
+        url += (
+            f"{V1_API_PATH_PREFIX}/process-data-file-download/{modified_process_model_identifier}/"
+            + f"{process_instance_id}/{digest}"
+        )
         link = f"[{label}]({url})"
 
         return link

--- a/spiffworkflow-backend/src/spiffworkflow_backend/scripts/markdown_file_download_link.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/scripts/markdown_file_download_link.py
@@ -2,7 +2,6 @@ from typing import Any
 
 from flask import current_app
 
-from spiffworkflow_backend.helpers.api_version import V1_API_PATH_PREFIX
 from spiffworkflow_backend.models.process_model import ProcessModelInfo
 from spiffworkflow_backend.models.script_attributes_context import ScriptAttributesContext
 from spiffworkflow_backend.scripts.script import Script
@@ -38,7 +37,7 @@ class GetMarkdownFileDownloadLink(Script):
             raise self.get_proces_instance_id_is_missing_error("save_process_instance_metadata")
         url = current_app.config["SPIFFWORKFLOW_BACKEND_URL"]
         url += (
-            f"{V1_API_PATH_PREFIX}/process-data-file-download/{modified_process_model_identifier}/"
+            f"{current_app.config['SPIFFWORKFLOW_BACKEND_API_PATH_PREFIX']}/process-data-file-download/{modified_process_model_identifier}/"
             + f"{process_instance_id}/{digest}"
         )
         link = f"[{label}]({url})"

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authentication_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authentication_service.py
@@ -43,7 +43,6 @@ from spiffworkflow_backend.exceptions.error import RefreshTokenStorageError
 from spiffworkflow_backend.exceptions.error import TokenExpiredError
 from spiffworkflow_backend.exceptions.error import TokenInvalidError
 from spiffworkflow_backend.exceptions.error import TokenNotProvidedError
-from spiffworkflow_backend.helpers.api_version import V1_API_PATH_PREFIX
 from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.models.refresh_token import RefreshTokenModel
 from spiffworkflow_backend.services.authorization_service import AuthorizationService
@@ -278,7 +277,7 @@ class AuthenticationService:
 
     def logout(self, id_token: str, authentication_identifier: str, redirect_url: str | None = None) -> Response:
         if redirect_url is None:
-            redirect_url = f"{self.get_backend_url()}{V1_API_PATH_PREFIX}/logout_return"
+            redirect_url = f"{self.get_backend_url()}{current_app.config['SPIFFWORKFLOW_BACKEND_API_PATH_PREFIX']}/logout_return"
         request_url = (
             self.__class__.open_id_endpoint_for_name("end_session_endpoint", authentication_identifier=authentication_identifier)
             + f"?post_logout_redirect_uri={redirect_url}&"

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authentication_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authentication_service.py
@@ -43,6 +43,7 @@ from spiffworkflow_backend.exceptions.error import RefreshTokenStorageError
 from spiffworkflow_backend.exceptions.error import TokenExpiredError
 from spiffworkflow_backend.exceptions.error import TokenInvalidError
 from spiffworkflow_backend.exceptions.error import TokenNotProvidedError
+from spiffworkflow_backend.helpers.api_version import V1_API_PATH_PREFIX
 from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.models.refresh_token import RefreshTokenModel
 from spiffworkflow_backend.services.authorization_service import AuthorizationService
@@ -277,7 +278,7 @@ class AuthenticationService:
 
     def logout(self, id_token: str, authentication_identifier: str, redirect_url: str | None = None) -> Response:
         if redirect_url is None:
-            redirect_url = f"{self.get_backend_url()}/v1.0/logout_return"
+            redirect_url = f"{self.get_backend_url()}{V1_API_PATH_PREFIX}/logout_return"
         request_url = (
             self.__class__.open_id_endpoint_for_name("end_session_endpoint", authentication_identifier=authentication_identifier)
             + f"?post_logout_redirect_uri={redirect_url}&"

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
@@ -19,7 +19,7 @@ from spiffworkflow_backend.exceptions.error import NotAuthorizedError
 from spiffworkflow_backend.exceptions.error import PermissionsFileNotSetError
 from spiffworkflow_backend.exceptions.error import UserDoesNotHaveAccessToTaskError
 from spiffworkflow_backend.exceptions.error import UserNotLoggedInError
-from spiffworkflow_backend.helpers.api_version import V1_API_PATH_PREFIX
+from spiffworkflow_backend.helpers.api_version import remove_api_prefix
 from spiffworkflow_backend.interfaces import AddedPermissionDict
 from spiffworkflow_backend.interfaces import GroupPermissionsDict
 from spiffworkflow_backend.interfaces import UserToGroupDict
@@ -95,7 +95,7 @@ class AuthorizationService:
     @classmethod
     def has_permission(cls, principals: list[PrincipalModel], permission: str, target_uri: str) -> bool:
         principal_ids = [p.id for p in principals]
-        target_uri_normalized = target_uri.removeprefix(V1_API_PATH_PREFIX)
+        target_uri_normalized = remove_api_prefix(target_uri)
 
         permission_assignments = (
             PermissionAssignmentModel.query.filter(PermissionAssignmentModel.principal_id.in_(principal_ids))
@@ -148,7 +148,7 @@ class AuthorizationService:
         cls, permission_assignments: list[PermissionAssignmentModel], permission: str, target_uri: str
     ) -> bool:
         uri_with_percent = re.sub(r"\*", "%", target_uri)
-        target_uri_normalized = uri_with_percent.removeprefix(V1_API_PATH_PREFIX)
+        target_uri_normalized = remove_api_prefix(uri_with_percent)
 
         matching_permission_assignments = []
         for permission_assignment in permission_assignments:
@@ -229,7 +229,7 @@ class AuthorizationService:
     @classmethod
     def find_or_create_permission_target(cls, uri: str) -> PermissionTargetModel:
         uri_with_percent = re.sub(r"\*", "%", uri)
-        target_uri_normalized = uri_with_percent.removeprefix(V1_API_PATH_PREFIX)
+        target_uri_normalized = remove_api_prefix(uri_with_percent)
         permission_target: PermissionTargetModel | None = PermissionTargetModel.query.filter_by(uri=target_uri_normalized).first()
         if permission_target is None:
             permission_target = PermissionTargetModel(uri=target_uri_normalized)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/monitoring_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/monitoring_service.py
@@ -44,8 +44,8 @@ def traces_sampler(sampling_context: Any) -> Any:
     #     # tasks_controller.task_submit
     #     # this is the current pain point as of 31 jan 2023.
     #     if path_info and (
-    #         (path_info.startswith("/v1.0/tasks/") and request_method == "PUT")
-    #         or (path_info.startswith("/v1.0/task-data/") and request_method == "GET")
+    #         (path_info.startswith(f"{V1_API_PATH_PREFIX}/tasks/") and request_method == "PUT")
+    #         or (path_info.startswith(f"{V1_API_PATH_PREFIX}/task-data/") and request_method == "GET")
     #     ):
     #         return 1
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_model_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_model_service.py
@@ -11,7 +11,6 @@ from flask import current_app
 
 from spiffworkflow_backend.exceptions.api_error import ApiError
 from spiffworkflow_backend.exceptions.process_entity_not_found_error import ProcessEntityNotFoundError
-from spiffworkflow_backend.helpers.api_version import V1_API_PATH_PREFIX
 from spiffworkflow_backend.interfaces import ProcessGroupLite
 from spiffworkflow_backend.interfaces import ProcessGroupLitesWithCache
 from spiffworkflow_backend.models.file import File
@@ -286,14 +285,14 @@ class ProcessModelService(FileSystemService):
         process_model_identifiers = [p.id for p in process_models]
 
         permission_to_check = "read"
-        permission_base_uri = f"{V1_API_PATH_PREFIX}/process-models"
+        permission_base_uri = f"{current_app.config['SPIFFWORKFLOW_BACKEND_API_PATH_PREFIX']}/process-models"
         extension_prefix = current_app.config["SPIFFWORKFLOW_BACKEND_EXTENSIONS_PROCESS_MODEL_PREFIX"]
         if filter_runnable_by_user:
             permission_to_check = "create"
-            permission_base_uri = f"{V1_API_PATH_PREFIX}/process-instances"
+            permission_base_uri = f"{current_app.config['SPIFFWORKFLOW_BACKEND_API_PATH_PREFIX']}/process-instances"
         if filter_runnable_as_extension:
             permission_to_check = "create"
-            permission_base_uri = f"{V1_API_PATH_PREFIX}/extensions"
+            permission_base_uri = f"{current_app.config['SPIFFWORKFLOW_BACKEND_API_PATH_PREFIX']}/extensions"
             process_model_identifiers = [p.id.replace(f"{extension_prefix}/", "") for p in process_models]
 
         # these are the ones (identifiers, at least) you are allowed to start

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_model_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_model_service.py
@@ -11,6 +11,7 @@ from flask import current_app
 
 from spiffworkflow_backend.exceptions.api_error import ApiError
 from spiffworkflow_backend.exceptions.process_entity_not_found_error import ProcessEntityNotFoundError
+from spiffworkflow_backend.helpers.api_version import V1_API_PATH_PREFIX
 from spiffworkflow_backend.interfaces import ProcessGroupLite
 from spiffworkflow_backend.interfaces import ProcessGroupLitesWithCache
 from spiffworkflow_backend.models.file import File
@@ -285,14 +286,14 @@ class ProcessModelService(FileSystemService):
         process_model_identifiers = [p.id for p in process_models]
 
         permission_to_check = "read"
-        permission_base_uri = "/v1.0/process-models"
+        permission_base_uri = f"{V1_API_PATH_PREFIX}/process-models"
         extension_prefix = current_app.config["SPIFFWORKFLOW_BACKEND_EXTENSIONS_PROCESS_MODEL_PREFIX"]
         if filter_runnable_by_user:
             permission_to_check = "create"
-            permission_base_uri = "/v1.0/process-instances"
+            permission_base_uri = f"{V1_API_PATH_PREFIX}/process-instances"
         if filter_runnable_as_extension:
             permission_to_check = "create"
-            permission_base_uri = "/v1.0/extensions"
+            permission_base_uri = f"{V1_API_PATH_PREFIX}/extensions"
             process_model_identifiers = [p.id.replace(f"{extension_prefix}/", "") for p in process_models]
 
         # these are the ones (identifiers, at least) you are allowed to start

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/spec_file_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/spec_file_service.py
@@ -5,11 +5,11 @@ import shutil
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+from flask import current_app
 from lxml import etree  # type: ignore
 from SpiffWorkflow.bpmn.parser.BpmnParser import BpmnValidator  # type: ignore
 
 from spiffworkflow_backend.exceptions.error import NotAuthorizedError
-from spiffworkflow_backend.helpers.api_version import V1_API_PATH_PREFIX
 from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.models.file import File
 from spiffworkflow_backend.models.file import FileType
@@ -205,7 +205,7 @@ class SpecFileService(FileSystemService):
                 permitted_process_model_identifiers = ProcessModelService.process_model_identifiers_with_permission_for_user(
                     user=user,
                     permission_to_check="create",
-                    permission_base_uri=f"{V1_API_PATH_PREFIX}/process-instances",
+                    permission_base_uri=f"{current_app.config['SPIFFWORKFLOW_BACKEND_API_PATH_PREFIX']}/process-instances",
                     process_model_identifiers=process_model_identifiers,
                 )
                 unpermitted_process_model_identifiers = set(process_model_identifiers) - set(permitted_process_model_identifiers)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/spec_file_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/spec_file_service.py
@@ -9,6 +9,7 @@ from lxml import etree  # type: ignore
 from SpiffWorkflow.bpmn.parser.BpmnParser import BpmnValidator  # type: ignore
 
 from spiffworkflow_backend.exceptions.error import NotAuthorizedError
+from spiffworkflow_backend.helpers.api_version import V1_API_PATH_PREFIX
 from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.models.file import File
 from spiffworkflow_backend.models.file import FileType
@@ -204,7 +205,7 @@ class SpecFileService(FileSystemService):
                 permitted_process_model_identifiers = ProcessModelService.process_model_identifiers_with_permission_for_user(
                     user=user,
                     permission_to_check="create",
-                    permission_base_uri="/v1.0/process-instances",
+                    permission_base_uri=f"{V1_API_PATH_PREFIX}/process-instances",
                     process_model_identifiers=process_model_identifiers,
                 )
                 unpermitted_process_model_identifiers = set(process_model_identifiers) - set(permitted_process_model_identifiers)


### PR DESCRIPTION
since the flask app now sees /api/v1.0 in some cases, where fronting servers (not always nginx) used to strip it off.