### PR TITLE
turn off uv sync when running in docker

### DIFF
--- a/spiffworkflow-backend/Dockerfile
+++ b/spiffworkflow-backend/Dockerfile
@@ -48,7 +48,7 @@ RUN apt-get update \
   && apt-get install -y -q gcc git libssl-dev libpq-dev default-libmysqlclient-dev pkg-config libffi-dev
 
 COPY . /app
-RUN uv sync --no-dev
+RUN uv sync --no-dev --frozen
 
 ######################## - FINAL
 

--- a/spiffworkflow-backend/bin/boot_server_in_docker
+++ b/spiffworkflow-backend/bin/boot_server_in_docker
@@ -18,6 +18,8 @@ if [[ -z "${FLASK_DEBUG:-}" ]]; then
   export FLASK_DEBUG=0
 fi
 
+export UV_NO_SYNC=true
+
 if [[ "${SPIFFWORKFLOW_BACKEND_WAIT_FOR_DB_TO_BE_READY:-}" == "true" ]]; then
   echo 'Waiting for db to be ready...'
   uv run python ./bin/wait_for_db_to_be_ready.py


### PR DESCRIPTION
Avoid running syncing in uv when running in docker since that is done at image build time.