### PR TITLE
raise if too many tasks were generate for a process instance

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -141,7 +141,6 @@ def _import(name: str, glbls: dict[str, Any], *args: Any) -> None:
 
 
 # This number is a little arbitrary but seems like a good number.
-# We know 700,000 does take the system.
 MAX_PROCESS_INSTANCE_TASK_COUNT = 20000
 
 


### PR DESCRIPTION
This is to help avoid issues where a high number of generated tasks can take down the system and are generally unneeded since they are predicted tasks that are never run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a limit on the maximum number of tasks allowed in a process instance.
  * Added clear error messaging when this task limit is exceeded, including guidance on how to reduce task count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->