### PR TITLE
user the process initiator as default when setting a secret

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/scripts/set_secret.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/scripts/set_secret.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from flask import g
 
+from spiffworkflow_backend.models.process_instance import ProcessInstanceModel
 from spiffworkflow_backend.models.script_attributes_context import ScriptAttributesContext
 from spiffworkflow_backend.scripts.script import Script
 from spiffworkflow_backend.services.secret_service import SecretService
@@ -14,8 +15,17 @@ class SetSecret(Script):
     def run(self, script_attributes_context: ScriptAttributesContext, *args: Any, **kwargs: Any) -> Any:
         if len(args) < 2:
             raise ValueError("Expected at least two arguments: secret_key and secret_value")
-        if not hasattr(g, "user") or not g.user:
+
+        user = None
+        if hasattr(g, "user") and g.user:
+            user = g.user
+        if user is None:
+            process_instance = ProcessInstanceModel.query.filter_by(id=script_attributes_context.process_instance_id).first()
+            if process_instance is not None:
+                user = process_instance.process_initiator
+        if user is None:
             raise RuntimeError("User context is not set")
+
         secret_key = args[0]
         secret_value = args[1]
-        SecretService.update_secret(secret_key, secret_value, g.user.id, True)
+        SecretService.update_secret(secret_key, secret_value, user.id, True)

--- a/spiffworkflow-backend/uv.lock
+++ b/spiffworkflow-backend/uv.lock
@@ -1721,15 +1721,15 @@ wheels = [
 
 [[package]]
 name = "pytest-xdist"
-version = "3.6.1"
+version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "execnet" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/c4/3c310a19bc1f1e9ef50075582652673ef2bfc8cd62afef9585683821902f/pytest_xdist-3.6.1.tar.gz", hash = "sha256:ead156a4db231eec769737f57668ef58a2084a34b2e55c4a8fa20d861107300d", size = 84060 }
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/82/1d96bf03ee4c0fdc3c0cbe61470070e659ca78dc0086fb88b66c185e2449/pytest_xdist-3.6.1-py3-none-any.whl", hash = "sha256:9ed4adfb68a016610848639bb7e02c9352d5d9f03d04809919e2dafc3be4cca7", size = 46108 },
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396 },
 ]
 
 [[package]]
@@ -2459,7 +2459,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-flask-sqlalchemy", specifier = ">=1.1.0" },
     { name = "pytest-random-order", specifier = ">=1.1.0" },
-    { name = "pytest-xdist", specifier = "==3.6.1" },
+    { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "ruff", specifier = ">=0.11.5" },
     { name = "safety", specifier = ">=3.2.14" },
     { name = "setuptools", specifier = ">=78.1.1" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability in determining the user context when updating a secret, ensuring the correct user is identified even if the standard context is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->