### PR TITLE
Try to fix pyodide install problem

### DIFF
--- a/spiff-arena-common/pyproject.toml
+++ b/spiff-arena-common/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "spiff-arena-common"
-version = "0.1.1"
+version = "0.1.2"
 description = "Shared Python utilities for Spiff Arena frontend and backend components"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"
 dependencies = [
-	"Jinja2 >= 3.1.6",
+	"Jinja2",
 	"SpiffWorkflow",
 ]
 

--- a/spiff-arena-common/pyproject.toml
+++ b/spiff-arena-common/pyproject.toml
@@ -4,10 +4,11 @@ version = "0.1.2"
 description = "Shared Python utilities for Spiff Arena frontend and backend components"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"
-dependencies = [
-	"Jinja2",
-	"SpiffWorkflow",
-]
+
+#dependencies = [
+#	"Jinja2",
+#	"SpiffWorkflow",
+#]
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
Trying to figure out why this package won't load in pyodide like it did before I added dependencies. Sadly have to get it up to pypi to test. Sideloading the wheel does work so i'll fall back to that if need be.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released version 0.1.2.
  * Removed explicit runtime dependency declarations, so package consumers may need to manage/install dependencies separately; this affects installation behavior but not runtime features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->