### PR TITLE
Fix errors in keycloak_setup.md

### DIFF
--- a/docs/how_to_guides/deployment/keycloak_setup.md
+++ b/docs/how_to_guides/deployment/keycloak_setup.md
@@ -49,7 +49,7 @@ https://keycloak-civitos.spiff.works/admin/spiffworkflow/console/#/spiffworkflow
 
 For localhost, it would be:
 ```
-https://localhost:7002/admin/[REALM_NAME]/console
+http://localhost:7002/admin/[REALM_NAME]/console
 ```
 
 ## **2. Allowing Everyone from Your Domain to Log into an Instance**  
@@ -138,7 +138,7 @@ To authenticate a user and get a valid access token, send a POST request to Keyc
 curl -X POST https://keycloak-[client].spiff.works/realms/spiffworkflow/protocol/openid-connect/token \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "grant_type=password" \
-  -d "client_id=spiff-frontend" \
+  -d "client_id=spiffworkflow-frontend" \
   -d "username=<user_email>" \
   -d "password=<user_password>"
 ```

--- a/docs/how_to_guides/deployment/keycloak_setup.md
+++ b/docs/how_to_guides/deployment/keycloak_setup.md
@@ -25,7 +25,7 @@ To grant a user admin access for adding/managing users:
 
 ![Image](/images/Keycloak_setup3.png)
 
-- Open the user’s profile and go to the **Role Mapping** tab.Add the following roles:  
+- Open the user’s profile and go to the **Role Mapping** tab. Add the following roles:  
    - `view-users`  
    - `manage-users`  
    
@@ -176,7 +176,7 @@ To revoke a session and log out a user via the Keycloak API:
 
 ```bash
 curl -X POST https://keycloak-[client].spiff.works/realms/spiffworkflow/protocol/openid-connect/logout \
-  -d "client_id=spiff-frontend" \
+  -d "client_id=spiffworkflow-frontend" \
   -d "client_secret=<client_secret>" \
   -d "refresh_token=<refresh_token>"
 ```


### PR DESCRIPTION
Curse you, Dan. Curse you.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Keycloak setup guide: localhost Admin Console URL shown as http://localhost:7002/admin/[REALM_NAME]/console (http instead of https).
  * Updated password grant token examples: client_id changed to spiffworkflow-frontend in example requests.
  * Ensured examples are consistent across the guide; documentation-only changes, no functional updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->