### PR TITLE
Fix lazy load issue

### DIFF
--- a/spiff-arena-common/pyproject.toml
+++ b/spiff-arena-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spiff-arena-common"
-version = "0.1.2"
+version = "0.1.3"
 description = "Shared Python utilities for Spiff Arena frontend and backend components"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/spiff-arena-common/src/spiff_arena_common/runner.py
+++ b/spiff-arena-common/src/spiff_arena_common/runner.py
@@ -173,10 +173,7 @@ def hydrate_workflow(specs, state):
     return workflow
 
 def lazy_load_tasks(workflow):
-    return get_tasks(
-        workflow,
-        TaskFilter(TaskState.DEFINITE_MASK | TaskState.FINISHED_MASK, spec_class=CallActivity),
-    )
+    return get_tasks(workflow, TaskFilter(spec_class=CallActivity))
 
 def missing_lazy_load_specs(workflow):
     for t in lazy_load_tasks(workflow):


### PR DESCRIPTION
Lazy loading call activities works out less often in practice than hoped, so just load in all call activities. This fixes an issue where a called element's specs were not loaded in when the call activity was right after a gateway, but I'm sure more issues like this would surface as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Improvements
  - Task loading now includes all Call Activity items regardless of status, broadening the data set used across the app. Users may see additional tasks in task lists, dashboards, reports, and exports; ordering and counts may change accordingly.

- Chores
  - Updated spiff-arena-common version to 0.1.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->