### PR TITLE
fix markdown_file_download_link script in cases when site is mounted on api

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/helpers/api_version.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/helpers/api_version.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlparse
+
 from flask import current_app
 
 V1_API_PATH_PREFIX = "/v1.0"
@@ -13,3 +15,32 @@ def remove_api_prefix(path: str) -> str:
         return path.removeprefix(V1_API_PATH_PREFIX)
 
     return path
+
+
+def build_api_url(backend_url: str, api_path_prefix: str, endpoint: str) -> str:
+    """Build a URL ensuring no duplicate API path segments.
+
+    This function handles cases where the backend_url might end with a path segment
+    that matches the beginning of the api_path_prefix (e.g., '/api') to prevent
+    duplicate path segments in the resulting URL.
+
+    Args:
+        backend_url: Base URL for the backend (e.g., 'http://example.com/api')
+        api_path_prefix: API path prefix (e.g., '/api/v1.0')
+        endpoint: The specific endpoint to access (e.g., 'process-data-file-download/123')
+
+    Returns:
+        A properly constructed URL without duplicate path segments
+    """
+    parsed_url = urlparse(backend_url)
+    backend_path = parsed_url.path
+
+    # Check if backend URL ends with a segment that API path prefix starts with
+    if backend_path.endswith("/api") and api_path_prefix.startswith("/api"):
+        # Replace the ending /api with empty string to avoid duplication
+        backend_path = backend_path[:-4]
+        url = parsed_url._replace(path=backend_path).geturl() + api_path_prefix + "/" + endpoint
+    else:
+        url = backend_url + api_path_prefix + "/" + endpoint
+
+    return url

--- a/spiffworkflow-backend/src/spiffworkflow_backend/scripts/markdown_file_download_link.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/scripts/markdown_file_download_link.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from flask import current_app
 
+from spiffworkflow_backend.helpers.api_version import build_api_url
 from spiffworkflow_backend.models.process_model import ProcessModelInfo
 from spiffworkflow_backend.models.script_attributes_context import ScriptAttributesContext
 from spiffworkflow_backend.scripts.script import Script
@@ -35,11 +36,11 @@ class GetMarkdownFileDownloadLink(Script):
         process_instance_id = script_attributes_context.process_instance_id
         if process_instance_id is None:
             raise self.get_proces_instance_id_is_missing_error("save_process_instance_metadata")
-        url = current_app.config["SPIFFWORKFLOW_BACKEND_URL"]
-        url += (
-            f"{current_app.config['SPIFFWORKFLOW_BACKEND_API_PATH_PREFIX']}/process-data-file-download/{modified_process_model_identifier}/"
-            + f"{process_instance_id}/{digest}"
-        )
+        backend_url = current_app.config["SPIFFWORKFLOW_BACKEND_URL"]
+        api_path_prefix = current_app.config["SPIFFWORKFLOW_BACKEND_API_PATH_PREFIX"]
+        endpoint = f"process-data-file-download/{modified_process_model_identifier}/{process_instance_id}/{digest}"
+
+        url = build_api_url(backend_url, api_path_prefix, endpoint)
         link = f"[{label}]({url})"
 
         return link


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Resolved issues where markdown file download links could break or include duplicate “/api” segments, ensuring correct links across environments.
- Refactor
  - Streamlined API URL construction to produce consistent, reliable links for downloads and related endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->