### PR TITLE
Launch external form editor if url is configured

### DIFF
--- a/spiffworkflow-frontend/dev.docker-compose.yml
+++ b/spiffworkflow-frontend/dev.docker-compose.yml
@@ -9,6 +9,6 @@ services:
       HOST: "0.0.0.0"
       PORT: "${SPIFFWORKFLOW_FRONTEND_PORT:-8001}"
       XDG_CACHE_HOME: "/app/.cache"
-      VITE_SPIFFWORKFLOW_FRONTEND_LAUNCH_EDITOR_URL: "http://localhost:9999"
+      #VITE_SPIFFWORKFLOW_FRONTEND_LAUNCH_EDITOR_URL: "http://localhost:9999"
     volumes:
       - ./spiffworkflow-frontend:/app

--- a/spiffworkflow-frontend/dev.docker-compose.yml
+++ b/spiffworkflow-frontend/dev.docker-compose.yml
@@ -9,5 +9,6 @@ services:
       HOST: "0.0.0.0"
       PORT: "${SPIFFWORKFLOW_FRONTEND_PORT:-8001}"
       XDG_CACHE_HOME: "/app/.cache"
+      VITE_SPIFFWORKFLOW_FRONTEND_LAUNCH_EDITOR_URL: "http://localhost:9999"
     volumes:
       - ./spiffworkflow-frontend:/app

--- a/spiffworkflow-frontend/dev.docker-compose.yml
+++ b/spiffworkflow-frontend/dev.docker-compose.yml
@@ -9,6 +9,5 @@ services:
       HOST: "0.0.0.0"
       PORT: "${SPIFFWORKFLOW_FRONTEND_PORT:-8001}"
       XDG_CACHE_HOME: "/app/.cache"
-      #VITE_SPIFFWORKFLOW_FRONTEND_LAUNCH_EDITOR_URL: "http://localhost:9999"
     volumes:
       - ./spiffworkflow-frontend:/app

--- a/spiffworkflow-frontend/src/views/ProcessModelEditDiagram.tsx
+++ b/spiffworkflow-frontend/src/views/ProcessModelEditDiagram.tsx
@@ -1284,7 +1284,7 @@ export default function ProcessModelEditDiagram() {
     (_element: any, fileName: string, eventBus: any) => {
       const url = import.meta.env.VITE_SPIFFWORKFLOW_FRONTEND_LAUNCH_EDITOR_URL;
       if (url) {
-      	window.open(url, '_blank');
+      	window.open(`${url}?processModelId=${params.process_model_id || ''}&fileName=${fileName || ''}`, '_blank');
       	return;
       }
       

--- a/spiffworkflow-frontend/src/views/ProcessModelEditDiagram.tsx
+++ b/spiffworkflow-frontend/src/views/ProcessModelEditDiagram.tsx
@@ -1282,6 +1282,12 @@ export default function ProcessModelEditDiagram() {
 
   const onLaunchJsonSchemaEditor = useCallback(
     (_element: any, fileName: string, eventBus: any) => {
+      const url = import.meta.env.VITE_SPIFFWORKFLOW_FRONTEND_LAUNCH_EDITOR_URL;
+      if (url) {
+      	window.open(url, '_blank');
+      	return;
+      }
+      
       setFileEventBus(eventBus);
       setJsonSchemaFileName(fileName);
       setShowJsonSchemaEditor(true);

--- a/spiffworkflow-frontend/src/views/ProcessModelEditDiagram.tsx
+++ b/spiffworkflow-frontend/src/views/ProcessModelEditDiagram.tsx
@@ -1284,15 +1284,18 @@ export default function ProcessModelEditDiagram() {
     (_element: any, fileName: string, eventBus: any) => {
       const url = import.meta.env.VITE_SPIFFWORKFLOW_FRONTEND_LAUNCH_EDITOR_URL;
       if (url) {
-      	window.open(`${url}?processModelId=${params.process_model_id || ''}&fileName=${fileName || ''}`, '_blank');
-      	return;
+        window.open(
+          `${url}?processModelId=${params.process_model_id || ''}&fileName=${fileName || ''}`,
+          '_blank',
+        );
+        return;
       }
-      
+
       setFileEventBus(eventBus);
       setJsonSchemaFileName(fileName);
       setShowJsonSchemaEditor(true);
     },
-    [],
+    [params.process_model_id],
   );
 
   const addNewFileIfNotExist = () => {


### PR DESCRIPTION
For custom frontends that maybe use something else for form building.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Option to launch the JSON Schema Editor in an external tool. When configured, the editor opens in a new tab and automatically includes the current process model and file name.
* **Bug Fixes**
  * Ensures the JSON Schema Editor action reflects the currently selected process model when navigating between models, preventing stale references and opening the correct context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->