### PR TITLE
Add calendar to allowed backend imports

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -1,6 +1,7 @@
 # TODO: clean up this service for a clear distinction between it and the process_instance_service
 #   where this points to the pi service
 import _strptime  # type: ignore
+import calendar
 import copy
 import decimal
 import json
@@ -326,6 +327,7 @@ class CustomBpmnScriptEngine(PythonScriptEngine):  # type: ignore
         default_globals = {
             "_strptime": _strptime,
             "all": all,
+            "calendar": calendar,
             "dateparser": dateparser,
             "datetime": datetime,
             "decimal": decimal,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scripts executed by the workflow script engine now have built-in access to the standard calendar module, enabling richer date and scheduling logic (e.g., month ranges, weekday calculations, leap year checks) without custom utilities or extra configuration. This simplifies implementing complex date-based rules in process scripts and improves consistency for time-related operations across workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->