### PR TITLE
Pi status webhook

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,12 @@ jobs:
               upload_coverage: true,
             }
           - {
+              python: "3.13.7",
+              os: "ubuntu-latest",
+              session: "tests",
+              database: "mysql",
+            }
+          - {
               python: "3.11",
               os: "ubuntu-latest",
               session: "tests",
@@ -364,7 +370,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 24.x
       - run: npm install
       - run: npm run lint
       - run: npm test

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-python 3.12.1
+python 3.13.7

--- a/connector-proxy-demo/Dockerfile
+++ b/connector-proxy-demo/Dockerfile
@@ -22,7 +22,7 @@ FROM base AS deployment
 # vim ftw
 RUN apt-get update \
   && apt-get clean -y \
-  && apt-get install -y -q git-core curl procps gunicorn3 default-mysql-client vim-tiny libkrb5support0 libexpat1 \
+  && apt-get install -y -q git-core curl procps gunicorn3 default-mysql-client vim-tiny libkrb5support0 libexpat1 3.40.1-2+deb12u2 \
   && rm -rf /var/lib/apt/lists/*
 
 RUN pip install poetry==1.6.1

--- a/connector-proxy-demo/Dockerfile
+++ b/connector-proxy-demo/Dockerfile
@@ -20,9 +20,10 @@ FROM base AS deployment
 # gunicorn3 for web server
 # default-mysql-client for convenience accessing mysql docker container
 # vim ftw
+# libsqlite3-0=3.40.1-2+deb12u2 is to fix https://avd.aquasec.com/nvd/2025/cve-2025-6965/
 RUN apt-get update \
   && apt-get clean -y \
-  && apt-get install -y -q git-core curl procps gunicorn3 default-mysql-client vim-tiny libkrb5support0 libexpat1 3.40.1-2+deb12u2 \
+  && apt-get install -y -q git-core curl procps gunicorn3 default-mysql-client vim-tiny libkrb5support0 libexpat1 libsqlite3-0=3.40.1-2+deb12u2 \
   && rm -rf /var/lib/apt/lists/*
 
 RUN pip install poetry==1.6.1
@@ -42,7 +43,7 @@ RUN pip install poetry==1.6.1
 RUN useradd _gunicorn --no-create-home --user-group
 
 RUN apt-get update \
-  && apt-get install -y -q gcc libssl-dev pkg-config
+  && apt-get install -y -q gcc libssl-dev pkg-config libsqlite3-0=3.40.1-2+deb12u2
 
 # poetry install takes a long time and can be cached if dependencies don't change,
 # so that's why we tolerate running it twice.

--- a/spiffworkflow-backend/Dockerfile
+++ b/spiffworkflow-backend/Dockerfile
@@ -1,5 +1,5 @@
 # Base image to share ENV vars that activate VENV.
-FROM python:3.12.1-slim-bookworm AS base
+FROM python:3.13.7-slim-trixie AS base
 
 ENV UV_NO_SYNC=true
 ENV VIRTUAL_ENV=/app/venv

--- a/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/__init__.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/__init__.py
@@ -1,4 +1,4 @@
 CELERY_TASK_PROCESS_INSTANCE_RUN = (
     "spiffworkflow_backend.background_processing.celery_tasks.process_instance_task.celery_task_process_instance_run"
 )
-CELERY_TASK_PROCESS_INSTANCE_UPDATE_NOTIFIER = "spiffworkflow_backend.background_processing.celery_tasks.process_instance_task.celery_task_process_instance_update_notifier_run"  # noqa: E501
+CELERY_TASK_PROCESS_INSTANCE_EVENT_NOTIFIER = "spiffworkflow_backend.background_processing.celery_tasks.process_instance_task.celery_task_process_instance_event_notifier_run"  # noqa: E501

--- a/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/__init__.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/__init__.py
@@ -1,3 +1,4 @@
 CELERY_TASK_PROCESS_INSTANCE_RUN = (
     "spiffworkflow_backend.background_processing.celery_tasks.process_instance_task.celery_task_process_instance_run"
 )
+CELERY_TASK_PROCESS_INSTANCE_UPDATE_NOTIFIER = "spiffworkflow_backend.background_processing.celery_tasks.process_instance_task.celery_task_process_instance_update_notifier_run"  # noqa: E501

--- a/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/celery_tasks/process_instance_task.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/celery_tasks/process_instance_task.py
@@ -28,20 +28,20 @@ class SpiffCeleryWorkerError(Exception):
 
 
 @shared_task(ignore_result=False, time_limit=TEN_MINUTES, bind=True)
-def celery_task_process_instance_update_notifier_run(
+def celery_task_process_instance_event_notifier_run(
     self: Any,
     updated_process_instance_id: int,
     process_model_identifier: str,
-    update_type: str,
+    event_type: str,
 ) -> dict:
     celery_task_id = self.request.id
-    logger_prefix = f"celery_task_process_instance_update_notifier_run[{celery_task_id}]"
+    logger_prefix = f"celery_task_process_instance_event_notifier_run[{celery_task_id}]"
     worker_intro_log_message = f"{logger_prefix}: updated_process_instance_id: {updated_process_instance_id}"
     current_app.logger.info(worker_intro_log_message)
 
-    process_model = _get_process_model(current_app.config["SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_UPDATE_NOTIFIER_PROCESS_MODEL"])
+    process_model = _get_process_model(current_app.config["SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_EVENT_NOTIFIER_PROCESS_MODEL"])
     data = {
-        "update_type": update_type,
+        "event_type": event_type,
         "updated_process_instance_id": updated_process_instance_id,
         "process_model_identifier": process_model_identifier,
     }

--- a/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/celery_tasks/process_instance_task.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/celery_tasks/process_instance_task.py
@@ -39,7 +39,7 @@ def celery_task_process_instance_update_notifier_run(
     worker_intro_log_message = f"{logger_prefix}: updated_process_instance_id: {updated_process_instance_id}"
     current_app.logger.info(worker_intro_log_message)
 
-    process_model = _get_process_model(current_app.config["SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_UPDATE_PROCESS_MODEL"])
+    process_model = _get_process_model(current_app.config["SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_UPDATE_NOTIFIER_PROCESS_MODEL"])
     data = {
         "update_type": update_type,
         "updated_process_instance_id": updated_process_instance_id,

--- a/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/celery_tasks/process_instance_task_producer.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/celery_tasks/process_instance_task_producer.py
@@ -90,6 +90,8 @@ def queue_process_instance_event_notifier_if_appropriate(updated_process_instanc
     if (
         queue_enabled_for_process_model()
         and current_app.config["SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_EVENT_NOTIFIER_PROCESS_MODEL"]
+        and current_app.config["SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_EVENT_NOTIFIER_PROCESS_MODEL"]
+        != updated_process_instance.process_model_identifier
     ):
         async_result = celery.current_app.send_task(
             CELERY_TASK_PROCESS_INSTANCE_EVENT_NOTIFIER,

--- a/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/celery_tasks/process_instance_task_producer.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/celery_tasks/process_instance_task_producer.py
@@ -89,7 +89,7 @@ def queue_process_instance_if_appropriate(
 def queue_process_instance_update_notifier_if_appropriate(
     updated_process_instance: ProcessInstanceModel, update_type: str
 ) -> bool:
-    if queue_enabled_for_process_model() and current_app.config["SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_UPDATE_PROCESS_MODEL"]:
+    if queue_enabled_for_process_model() and current_app.config["SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_UPDATE_NOTIFIER_PROCESS_MODEL"]:
         async_result = celery.current_app.send_task(
             CELERY_TASK_PROCESS_INSTANCE_UPDATE_NOTIFIER,
             (updated_process_instance.id, updated_process_instance.process_model_identifier, update_type),

--- a/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/celery_tasks/process_instance_task_producer.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/celery_tasks/process_instance_task_producer.py
@@ -4,17 +4,18 @@ import celery
 from flask import current_app
 
 from spiffworkflow_backend.background_processing import CELERY_TASK_PROCESS_INSTANCE_RUN
+from spiffworkflow_backend.background_processing import CELERY_TASK_PROCESS_INSTANCE_UPDATE_NOTIFIER
 from spiffworkflow_backend.exceptions.api_error import ApiError
 from spiffworkflow_backend.helpers.spiff_enum import ProcessInstanceExecutionMode
 from spiffworkflow_backend.models.process_instance import ProcessInstanceModel
 
 
-def queue_enabled_for_process_model(process_instance: ProcessInstanceModel) -> bool:
+def queue_enabled_for_process_model() -> bool:
     # TODO: check based on the process model itself as well
     return current_app.config["SPIFFWORKFLOW_BACKEND_CELERY_ENABLED"] is True
 
 
-def should_queue_process_instance(process_instance: ProcessInstanceModel, execution_mode: str | None = None) -> bool:
+def should_queue_process_instance(execution_mode: str | None = None) -> bool:
     # check if the enum value is valid
     if execution_mode:
         ProcessInstanceExecutionMode(execution_mode)
@@ -22,7 +23,7 @@ def should_queue_process_instance(process_instance: ProcessInstanceModel, execut
     if execution_mode == ProcessInstanceExecutionMode.synchronous.value:
         return False
 
-    queue_enabled = queue_enabled_for_process_model(process_instance)
+    queue_enabled = queue_enabled_for_process_model()
     if execution_mode == ProcessInstanceExecutionMode.asynchronous.value and not queue_enabled:
         raise ApiError(
             error_code="async_mode_called_without_celery",
@@ -38,7 +39,7 @@ def should_queue_process_instance(process_instance: ProcessInstanceModel, execut
 def queue_future_task_if_appropriate(
     process_instance: ProcessInstanceModel, eta_in_seconds: float, task_guid: str | None = None
 ) -> bool:
-    if queue_enabled_for_process_model(process_instance):
+    if queue_enabled_for_process_model():
         buffer = 1
         countdown = eta_in_seconds - time.time() + buffer
         args_to_celery = {
@@ -78,8 +79,21 @@ def queue_process_instance_if_appropriate(
     #         " can lead to further locking issues."
     #     )
 
-    if should_queue_process_instance(process_instance, execution_mode):
+    if should_queue_process_instance(execution_mode):
         async_result = celery.current_app.send_task(CELERY_TASK_PROCESS_INSTANCE_RUN, (process_instance.id, task_guid))
         current_app.logger.info(f"Queueing process instance ({process_instance.id}) for celery ({async_result.task_id})")
+        return True
+    return False
+
+
+def queue_process_instance_update_notifier_if_appropriate(
+    updated_process_instance: ProcessInstanceModel, update_type: str
+) -> bool:
+    if queue_enabled_for_process_model() and current_app.config["SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_UPDATE_PROCESS_MODEL"]:
+        async_result = celery.current_app.send_task(
+            CELERY_TASK_PROCESS_INSTANCE_UPDATE_NOTIFIER,
+            (updated_process_instance.id, updated_process_instance.process_model_identifier, update_type),
+        )
+        current_app.logger.info(f"Queueing process instance ({updated_process_instance.id}) for celery ({async_result.task_id})")
         return True
     return False

--- a/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/celery_tasks/process_instance_task_producer.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/celery_tasks/process_instance_task_producer.py
@@ -89,7 +89,10 @@ def queue_process_instance_if_appropriate(
 def queue_process_instance_update_notifier_if_appropriate(
     updated_process_instance: ProcessInstanceModel, update_type: str
 ) -> bool:
-    if queue_enabled_for_process_model() and current_app.config["SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_UPDATE_NOTIFIER_PROCESS_MODEL"]:
+    if (
+        queue_enabled_for_process_model()
+        and current_app.config["SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_UPDATE_NOTIFIER_PROCESS_MODEL"]
+    ):
         async_result = celery.current_app.send_task(
             CELERY_TASK_PROCESS_INSTANCE_UPDATE_NOTIFIER,
             (updated_process_instance.id, updated_process_instance.process_model_identifier, update_type),

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/__init__.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/__init__.py
@@ -108,19 +108,16 @@ def _check_extension_api_configs(app: Flask) -> None:
         )
 
 
-def _check_metadata_backfill_requirements(app: Flask) -> None:
-    """Check that Celery is enabled if metadata backfill is enabled.
+def _check_configs_dependent_on_celery(app: Flask, config: str) -> None:
+    """Check that Celery is enabled for certain configs.
 
-    The process instance metadata backfill feature requires Celery to be enabled
-    since it runs as a background task to avoid impacting application performance.
+    This generally means the features that use the configs require celery background processing to function.
     """
-    if app.config.get("SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_METADATA_BACKFILL_ENABLED") and not app.config.get(
-        "SPIFFWORKFLOW_BACKEND_CELERY_ENABLED"
-    ):
+    if app.config.get(config) and not app.config.get("SPIFFWORKFLOW_BACKEND_CELERY_ENABLED"):
         raise ConfigurationError(
-            "SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_METADATA_BACKFILL_ENABLED is set to true but "
+            f"{config} is set to true but "
             "SPIFFWORKFLOW_BACKEND_CELERY_ENABLED is set to false. "
-            "The metadata backfill feature requires Celery to be enabled."
+            "This feature requires Celery to be enabled."
         )
 
 
@@ -314,6 +311,7 @@ def setup_config(app: Flask) -> None:
     _set_up_tenant_specific_fields_as_list_of_strings(app)
     _check_for_incompatible_frontend_and_backend_urls(app)
     _check_extension_api_configs(app)
-    _check_metadata_backfill_requirements(app)
+    _check_configs_dependent_on_celery(app, "SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_METADATA_BACKFILL_ENABLED")
+    _check_configs_dependent_on_celery(app, "SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_UPDATE_NOTIFIER_PROCESS_MODEL")
     _setup_cipher(app)
     _set_up_open_id_scopes(app)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/__init__.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/__init__.py
@@ -312,6 +312,6 @@ def setup_config(app: Flask) -> None:
     _check_for_incompatible_frontend_and_backend_urls(app)
     _check_extension_api_configs(app)
     _check_configs_dependent_on_celery(app, "SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_METADATA_BACKFILL_ENABLED")
-    _check_configs_dependent_on_celery(app, "SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_UPDATE_NOTIFIER_PROCESS_MODEL")
+    _check_configs_dependent_on_celery(app, "SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_EVENT_NOTIFIER_PROCESS_MODEL")
     _setup_cipher(app)
     _set_up_open_id_scopes(app)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
@@ -249,8 +249,8 @@ config_from_env("SPIFFWORKFLOW_BACKEND_MAX_INSTANCE_LOCK_DURATION_IN_SECONDS", d
 
 ### other
 config_from_env(
-    "SPIFFWORKFLOW_BACKEND_SYSTEM_NOTIFICATION_PROCESS_MODEL_MESSAGE_ID",
-    default="Message_SystemMessageNotification",
+    "SPIFFWORKFLOW_BACKEND_SYSTEM_NOTIFICATION_MESSAGE_NAME",
+    default="SystemErrorMessage",
 )
 # check all tasks listed as child tasks are saved to the database
 config_from_env("SPIFFWORKFLOW_BACKEND_DEBUG_TASK_CONSISTENCY", default=False)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
@@ -254,7 +254,7 @@ config_from_env(
 )
 # process model to run when a process instance has been updated.
 # currently only supported when running with celery.
-config_from_env("SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_UPDATE_PROCESS_MODEL")
+config_from_env("SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_UPDATE_NOTIFIER_PROCESS_MODEL")
 # check all tasks listed as child tasks are saved to the database
 config_from_env("SPIFFWORKFLOW_BACKEND_DEBUG_TASK_CONSISTENCY", default=False)
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
@@ -254,7 +254,7 @@ config_from_env(
 )
 # process model to run when a process instance has been updated.
 # currently only supported when running with celery.
-config_from_env("SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_UPDATE_NOTIFIER_PROCESS_MODEL")
+config_from_env("SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_EVENT_NOTIFIER_PROCESS_MODEL")
 # check all tasks listed as child tasks are saved to the database
 config_from_env("SPIFFWORKFLOW_BACKEND_DEBUG_TASK_CONSISTENCY", default=False)
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
@@ -252,6 +252,9 @@ config_from_env(
     "SPIFFWORKFLOW_BACKEND_SYSTEM_NOTIFICATION_MESSAGE_NAME",
     default="SystemErrorMessage",
 )
+# process model to run when a process instance has been updated.
+# currently only supported when running with celery.
+config_from_env("SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_UPDATE_PROCESS_MODEL")
 # check all tasks listed as child tasks are saved to the database
 config_from_env("SPIFFWORKFLOW_BACKEND_DEBUG_TASK_CONSISTENCY", default=False)
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
@@ -576,7 +576,7 @@ def _task_submit_shared(
 
     if processor.next_task():
         task = ProcessInstanceService.spiff_task_to_api_task(processor, processor.next_task())
-        task.process_model_uses_queued_execution = queue_enabled_for_process_model(process_instance)
+        task.process_model_uses_queued_execution = queue_enabled_for_process_model()
         return {"next_task": task}
 
     # next_task always returns something, even if the instance is complete, so we never get here

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_instances_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_instances_controller.py
@@ -89,7 +89,7 @@ def process_instance_run(
 
     process_instance_api = ProcessInstanceService.processor_to_process_instance_api(process_instance)
     process_instance_api_dict = process_instance_api.to_dict()
-    process_instance_api_dict["process_model_uses_queued_execution"] = queue_enabled_for_process_model(process_instance)
+    process_instance_api_dict["process_model_uses_queued_execution"] = queue_enabled_for_process_model()
     return make_response(jsonify(process_instance_api_dict), 200)
 
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/error_handling_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/error_handling_service.py
@@ -11,8 +11,6 @@ from spiffworkflow_backend.services.process_model_service import ProcessModelSer
 
 
 class ErrorHandlingService:
-    MESSAGE_NAME = "SystemErrorMessage"
-
     @classmethod
     def handle_error(cls, process_instance: ProcessInstanceModel, error: Exception) -> None:
         """On unhandled exceptions, set instance.status based on model.fault_or_suspend_on_exception."""
@@ -89,7 +87,7 @@ class ErrorHandlingService:
 
         message_instance = MessageInstanceModel(
             message_type="send",
-            name=ErrorHandlingService.MESSAGE_NAME,
+            name=str(current_app.config.get("SPIFFWORKFLOW_BACKEND_SYSTEM_NOTIFICATION_MESSAGE_NAME")),
             payload=message_payload,
             user_id=user_id,
         )

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/message_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/message_service.py
@@ -134,7 +134,7 @@ class MessageService:
                         processor_receive.save()
                     else:
                         db.session.commit()
-                if should_queue_process_instance(receiving_process_instance, execution_mode=execution_mode):
+                if should_queue_process_instance(execution_mode=execution_mode):
                     queue_process_instance_if_appropriate(receiving_process_instance, execution_mode=execution_mode)
                 return message_instance_receive
 
@@ -259,7 +259,7 @@ class MessageService:
         processor_receive_to_use.bpmn_process_instance.send_event(bpmn_event)
         execution_strategy_name = None
 
-        if should_queue_process_instance(receiving_process_instance, execution_mode=execution_mode):
+        if should_queue_process_instance(execution_mode=execution_mode):
             # even if we are queueing, we ran a "send_event" call up above, and it updated some tasks.
             # we need to serialize these task updates to the db. do_engine_steps with save does that.
             processor_receive_to_use.do_engine_steps(

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -1197,6 +1197,7 @@ class ProcessInstanceProcessor:
                     "metadata": metadata,
                 }
                 LoggingService.log_event(ProcessInstanceEventType.process_instance_completed.value, log_extras)
+                queue_process_instance_event_notifier_if_appropriate(self.process_instance_model, "process_instance_complete")
 
         db.session.add(self.process_instance_model)
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -51,6 +51,9 @@ from SpiffWorkflow.util.task import TaskState
 from sqlalchemy import and_
 from sqlalchemy import or_
 
+from spiffworkflow_backend.background_processing.celery_tasks.process_instance_task_producer import (
+    queue_process_instance_update_notifier_if_appropriate,
+)
 from spiffworkflow_backend.constants import SPIFFWORKFLOW_BACKEND_SERIALIZER_VERSION
 from spiffworkflow_backend.data_stores.json import JSONDataStore
 from spiffworkflow_backend.data_stores.json import JSONDataStoreConverter
@@ -1261,6 +1264,7 @@ class ProcessInstanceProcessor:
             for at in human_tasks:
                 at.completed = True
                 db.session.add(at)
+            queue_process_instance_update_notifier_if_appropriate(self.process_instance_model, "human_task_available")
         db.session.commit()
 
     def serialize_task_spec(self, task_spec: SpiffTask) -> dict:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -52,7 +52,7 @@ from sqlalchemy import and_
 from sqlalchemy import or_
 
 from spiffworkflow_backend.background_processing.celery_tasks.process_instance_task_producer import (
-    queue_process_instance_update_notifier_if_appropriate,
+    queue_process_instance_event_notifier_if_appropriate,
 )
 from spiffworkflow_backend.constants import SPIFFWORKFLOW_BACKEND_SERIALIZER_VERSION
 from spiffworkflow_backend.data_stores.json import JSONDataStore
@@ -1200,7 +1200,10 @@ class ProcessInstanceProcessor:
 
         db.session.add(self.process_instance_model)
 
-        human_tasks = HumanTaskModel.query.filter_by(process_instance_id=self.process_instance_model.id, completed=False).all()
+        new_humna_tasks = []
+        initial_human_tasks = HumanTaskModel.query.filter_by(
+            process_instance_id=self.process_instance_model.id, completed=False
+        ).all()
         ready_or_waiting_tasks = self.get_all_ready_or_waiting_tasks()
 
         self.store_metadata(metadata)
@@ -1227,10 +1230,10 @@ class ProcessInstanceProcessor:
                         ui_form_file_name = properties["formUiSchemaFilename"]
 
                 human_task = None
-                for at in human_tasks:
+                for at in initial_human_tasks:
                     if at.task_id == str(ready_or_waiting_task.id):
                         human_task = at
-                        human_tasks.remove(at)
+                        initial_human_tasks.remove(at)
 
                 if human_task is None:
                     task_guid = str(ready_or_waiting_task.id)
@@ -1253,6 +1256,7 @@ class ProcessInstanceProcessor:
                         lane_assignment_id=potential_owner_hash["lane_assignment_id"],
                     )
                     db.session.add(human_task)
+                    new_humna_tasks.append(human_task)
 
                     for potential_owner in potential_owner_hash["potential_owners"]:
                         human_task_user = HumanTaskUserModel(
@@ -1260,11 +1264,13 @@ class ProcessInstanceProcessor:
                         )
                         db.session.add(human_task_user)
 
-        if len(human_tasks) > 0:
-            for at in human_tasks:
+        if len(new_humna_tasks) > 0:
+            queue_process_instance_event_notifier_if_appropriate(self.process_instance_model, "human_task_available")
+
+        if len(initial_human_tasks) > 0:
+            for at in initial_human_tasks:
                 at.completed = True
                 db.session.add(at)
-            queue_process_instance_update_notifier_if_appropriate(self.process_instance_model, "human_task_available")
         db.session.commit()
 
     def serialize_task_spec(self, task_spec: SpiffTask) -> dict:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
@@ -777,7 +777,7 @@ class ProcessInstanceService:
         processor.complete_task(spiff_task, human_task, user=user)
 
         # the caller needs to handle the actual queueing of the process instance for better dequeueing ability
-        if should_queue_process_instance(processor.process_instance_model, execution_mode):
+        if should_queue_process_instance(execution_mode):
             processor.bpmn_process_instance.refresh_waiting_tasks()
             tasks = processor.bpmn_process_instance.get_tasks(state=TaskState.WAITING | TaskState.READY)
             JinjaService.add_instruction_for_end_user_if_appropriate(tasks, processor.process_instance_model.id, set())

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_background_processing_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_background_processing_service.py
@@ -3,6 +3,7 @@ import time
 from flask import Flask
 from pytest_mock.plugin import MockerFixture
 
+from spiffworkflow_backend.background_processing import CELERY_TASK_PROCESS_INSTANCE_EVENT_NOTIFIER
 from spiffworkflow_backend.background_processing.background_processing_service import BackgroundProcessingService
 from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.models.future_task import FutureTaskModel
@@ -158,6 +159,36 @@ class TestBackgroundProcessingService(BaseTest):
                 process_instance = self.create_process_instance_from_process_model(process_model=process_model)
                 processor = ProcessInstanceProcessor(process_instance)
                 processor.do_engine_steps(save=True)
+                mock.assert_called_with(
+                    CELERY_TASK_PROCESS_INSTANCE_EVENT_NOTIFIER,
+                    (process_instance.id, process_instance.process_model_identifier, "human_task_available"),
+                )
+                assert mock.call_count == 1
+
+    def test_queues_process_instance_event_notifier_when_complete(
+        self,
+        app: Flask,
+        mocker: MockerFixture,
+        with_db_and_bpmn_file_cleanup: None,
+    ) -> None:
+        with self.app_config_mock(app, "SPIFFWORKFLOW_BACKEND_CELERY_ENABLED", True):
+            with self.app_config_mock(
+                app, "SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_EVENT_NOTIFIER_PROCESS_MODEL", "SOME PROCESS MODEL"
+            ):
+                mock = mocker.patch("celery.current_app.send_task")
+                process_model = load_test_spec(
+                    "test_group/sample",
+                    process_model_source_directory="sample",
+                )
+                process_instance = self.create_process_instance_from_process_model(
+                    process_model=process_model, save_start_and_end_times=False
+                )
+                processor = ProcessInstanceProcessor(process_instance)
+                processor.do_engine_steps(save=True)
+                mock.assert_called_with(
+                    CELERY_TASK_PROCESS_INSTANCE_EVENT_NOTIFIER,
+                    (process_instance.id, process_instance.process_model_identifier, "process_instance_complete"),
+                )
                 assert mock.call_count == 1
 
     def _load_up_a_future_task_and_return_instance(

--- a/spiffworkflow-frontend/.tool-versions
+++ b/spiffworkflow-frontend/.tool-versions
@@ -1,1 +1,1 @@
-nodejs 22.3.0
+nodejs 24.7.0

--- a/spiffworkflow-frontend/Dockerfile
+++ b/spiffworkflow-frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Base image to share ENV vars that activate VENV.
-FROM node:22.3.0-bookworm-slim AS base
+FROM node:24.7.0-trixie-slim AS base
 
 RUN mkdir /app
 
@@ -19,7 +19,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # this matches total memory on spiffworkflow-demo
-ENV NODE_OPTIONS=--max_old_space_size=2048
+ENV NODE_OPTIONS=--max_old_space_size=4096
 
 
 ######################## - SETUP
@@ -41,17 +41,8 @@ RUN ./bin/build
 ######################## - FINAL
 
 # Use nginx as the base image
-FROM nginx:1.27.5-bookworm
-
-# 3.40.1-2+deb12u2 is to fix https://avd.aquasec.com/nvd/2025/cve-2025-6965/
-RUN apt-get update \
-  && apt-get clean -y \
-  && apt-get install -y -q \
-  libkrb5support0 \
-  libexpat1 \
-  libaom3 \
-  3.40.1-2+deb12u2 \
-  && rm -rf /var/lib/apt/lists/*
+# FROM nginx:1.29.1-bookworm
+FROM nginx:1.29.1-alpine-slim
 
 # Remove default nginx configuration
 RUN rm -rf /etc/nginx/conf.d/*

--- a/spiffworkflow-frontend/Dockerfile
+++ b/spiffworkflow-frontend/Dockerfile
@@ -43,12 +43,14 @@ RUN ./bin/build
 # Use nginx as the base image
 FROM nginx:1.27.5-bookworm
 
+# 3.40.1-2+deb12u2 is to fix https://avd.aquasec.com/nvd/2025/cve-2025-6965/
 RUN apt-get update \
   && apt-get clean -y \
   && apt-get install -y -q \
   libkrb5support0 \
   libexpat1 \
   libaom3 \
+  3.40.1-2+deb12u2 \
   && rm -rf /var/lib/apt/lists/*
 
 # Remove default nginx configuration

--- a/spiffworkflow-frontend/package-lock.json
+++ b/spiffworkflow-frontend/package-lock.json
@@ -2264,17 +2264,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.3.tgz",
-      "integrity": "sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
@@ -2725,302 +2714,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@parcel/watcher": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
-      "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
-      "hasInstallScript": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "detect-libc": "^1.0.3",
-        "is-glob": "^4.0.3",
-        "micromatch": "^4.0.5",
-        "node-addon-api": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "@parcel/watcher-android-arm64": "2.5.1",
-        "@parcel/watcher-darwin-arm64": "2.5.1",
-        "@parcel/watcher-darwin-x64": "2.5.1",
-        "@parcel/watcher-freebsd-x64": "2.5.1",
-        "@parcel/watcher-linux-arm-glibc": "2.5.1",
-        "@parcel/watcher-linux-arm-musl": "2.5.1",
-        "@parcel/watcher-linux-arm64-glibc": "2.5.1",
-        "@parcel/watcher-linux-arm64-musl": "2.5.1",
-        "@parcel/watcher-linux-x64-glibc": "2.5.1",
-        "@parcel/watcher-linux-x64-musl": "2.5.1",
-        "@parcel/watcher-win32-arm64": "2.5.1",
-        "@parcel/watcher-win32-ia32": "2.5.1",
-        "@parcel/watcher-win32-x64": "2.5.1"
-      }
-    },
-    "node_modules/@parcel/watcher-android-arm64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
-      "integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-darwin-arm64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
-      "integrity": "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-darwin-x64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
-      "integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-freebsd-x64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
-      "integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm-glibc": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
-      "integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm-musl": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
-      "integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm64-glibc": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
-      "integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm64-musl": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
-      "integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-x64-glibc": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
-      "integrity": "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-x64-musl": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz",
-      "integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-arm64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
-      "integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-ia32": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
-      "integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-x64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
-      "integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -4828,7 +4521,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -5655,13 +5348,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "optional": true,
-      "peer": true
     },
     "node_modules/builtin-modules": {
       "version": "3.3.0",
@@ -6767,19 +6453,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "detect-libc": "bin/detect-libc.js"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/devlop": {
@@ -9908,7 +9581,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9961,7 +9634,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -12518,13 +12191,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/node-html-parser": {
       "version": "6.1.13",
       "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.13.tgz",
@@ -14496,27 +14162,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/source-map-support/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/space-separated-tokens": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
@@ -14970,32 +14615,6 @@
       "dependencies": {
         "dom-iterator": "^1.0.2"
       }
-    },
-    "node_modules/terser": {
-      "version": "5.16.9",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.9.tgz",
-      "integrity": "sha512-HPa/FdTB9XGI2H1/keLFZHxl6WNvAI4YalHGtDQTlMnJcoqSab1UwL4l1hGEhs6/GmLHBZIg/YgB++jcbzoOEg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.2",
-        "acorn": "^8.5.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "optional": true,
-      "peer": true
     },
     "node_modules/test-exclude": {
       "version": "7.0.1",
@@ -16408,19 +16027,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
-    },
-    "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      }
     },
     "node_modules/yauzl": {
       "version": "2.10.0",
@@ -17886,17 +17492,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A=="
     },
-    "@jridgewell/source-map": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.3.tgz",
-      "integrity": "sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      }
-    },
     "@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
@@ -18132,123 +17727,6 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
-    },
-    "@parcel/watcher": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
-      "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@parcel/watcher-android-arm64": "2.5.1",
-        "@parcel/watcher-darwin-arm64": "2.5.1",
-        "@parcel/watcher-darwin-x64": "2.5.1",
-        "@parcel/watcher-freebsd-x64": "2.5.1",
-        "@parcel/watcher-linux-arm-glibc": "2.5.1",
-        "@parcel/watcher-linux-arm-musl": "2.5.1",
-        "@parcel/watcher-linux-arm64-glibc": "2.5.1",
-        "@parcel/watcher-linux-arm64-musl": "2.5.1",
-        "@parcel/watcher-linux-x64-glibc": "2.5.1",
-        "@parcel/watcher-linux-x64-musl": "2.5.1",
-        "@parcel/watcher-win32-arm64": "2.5.1",
-        "@parcel/watcher-win32-ia32": "2.5.1",
-        "@parcel/watcher-win32-x64": "2.5.1",
-        "detect-libc": "^1.0.3",
-        "is-glob": "^4.0.3",
-        "micromatch": "^4.0.5",
-        "node-addon-api": "^7.0.0"
-      }
-    },
-    "@parcel/watcher-android-arm64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
-      "integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==",
-      "optional": true,
-      "peer": true
-    },
-    "@parcel/watcher-darwin-arm64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
-      "integrity": "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==",
-      "optional": true,
-      "peer": true
-    },
-    "@parcel/watcher-darwin-x64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
-      "integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==",
-      "optional": true,
-      "peer": true
-    },
-    "@parcel/watcher-freebsd-x64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
-      "integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==",
-      "optional": true,
-      "peer": true
-    },
-    "@parcel/watcher-linux-arm-glibc": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
-      "integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==",
-      "optional": true,
-      "peer": true
-    },
-    "@parcel/watcher-linux-arm-musl": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
-      "integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
-      "optional": true,
-      "peer": true
-    },
-    "@parcel/watcher-linux-arm64-glibc": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
-      "integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==",
-      "optional": true,
-      "peer": true
-    },
-    "@parcel/watcher-linux-arm64-musl": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
-      "integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
-      "optional": true,
-      "peer": true
-    },
-    "@parcel/watcher-linux-x64-glibc": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
-      "integrity": "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==",
-      "optional": true,
-      "peer": true
-    },
-    "@parcel/watcher-linux-x64-musl": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz",
-      "integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==",
-      "optional": true,
-      "peer": true
-    },
-    "@parcel/watcher-win32-arm64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
-      "integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==",
-      "optional": true,
-      "peer": true
-    },
-    "@parcel/watcher-win32-ia32": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
-      "integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==",
-      "optional": true,
-      "peer": true
-    },
-    "@parcel/watcher-win32-x64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
-      "integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
-      "optional": true,
-      "peer": true
     },
     "@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -19414,7 +18892,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "devOptional": true
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -19984,13 +19462,6 @@
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "dev": true
-    },
-    "buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "optional": true,
-      "peer": true
     },
     "builtin-modules": {
       "version": "3.3.0",
@@ -20756,13 +20227,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
-    },
-    "detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-      "optional": true,
-      "peer": true
     },
     "devlop": {
       "version": "1.1.0",
@@ -23048,7 +22512,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "devOptional": true
+      "dev": true
     },
     "is-finalizationregistry": {
       "version": "1.1.1",
@@ -23081,7 +22545,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -24797,13 +24261,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "optional": true,
-      "peer": true
-    },
     "node-html-parser": {
       "version": "6.1.13",
       "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.13.tgz",
@@ -26166,26 +25623,6 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="
     },
-    "source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "optional": true,
-          "peer": true
-        }
-      }
-    },
     "space-separated-tokens": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
@@ -26522,28 +25959,6 @@
           "requires": {
             "dom-iterator": "^1.0.2"
           }
-        }
-      }
-    },
-    "terser": {
-      "version": "5.16.9",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.9.tgz",
-      "integrity": "sha512-HPa/FdTB9XGI2H1/keLFZHxl6WNvAI4YalHGtDQTlMnJcoqSab1UwL4l1hGEhs6/GmLHBZIg/YgB++jcbzoOEg==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@jridgewell/source-map": "^0.3.2",
-        "acorn": "^8.5.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "optional": true,
-          "peer": true
         }
       }
     },
@@ -27457,13 +26872,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
-    },
-    "yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-      "optional": true,
-      "peer": true
     },
     "yauzl": {
       "version": "2.10.0",

--- a/uv.lock
+++ b/uv.lock
@@ -182,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "spiff-arena-common"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "spiff-arena-common" }
 
 [[package]]


### PR DESCRIPTION
This adds support for a process model to be used as an event notifier at key times. Right now it only gets called on:

* `human_task_available` - whenever a new human task is completed
* `process_instance_complete` - whenever a process instances is marked as completed.

Usage:
* set env var `SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_EVENT_NOTIFIER_PROCESS_MODEL` to process model identifier
* payload arena gives the model: 
    ```
    data = {
        "event_type": event_type,
        "updated_process_instance_id": updated_process_instance_id,
        "process_model_identifier": process_model_identifier,
    }
    ```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Background event notifications for process completion and new human-task availability (requires Celery and configured notifier model).

- **Chores**
  - New config to specify the notifier process model; startup now validates Celery-dependent settings and will error when misconfigured.
  - Asynchronous execution now explicitly requires Celery.
  - System notification message env var renamed; default now “SystemErrorMessage”.

- **Tests**
  - Added unit tests verifying notifier queuing.

- **Chores (infra)**
  - Updated base images and added package to address CVE-2025-6965; Node/Python tool versions bumped; CI matrix extended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->