### PR TITLE
rename pi event notifier to just event notifier

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/__init__.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/__init__.py
@@ -1,4 +1,6 @@
 CELERY_TASK_PROCESS_INSTANCE_RUN = (
     "spiffworkflow_backend.background_processing.celery_tasks.process_instance_task.celery_task_process_instance_run"
 )
-CELERY_TASK_PROCESS_INSTANCE_EVENT_NOTIFIER = "spiffworkflow_backend.background_processing.celery_tasks.process_instance_task.celery_task_process_instance_event_notifier_run"  # noqa: E501
+CELERY_TASK_EVENT_NOTIFIER = (
+    "spiffworkflow_backend.background_processing.celery_tasks.process_instance_task.celery_task_event_notifier_run"  # noqa: E501
+)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/celery_tasks/process_instance_task.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/celery_tasks/process_instance_task.py
@@ -28,18 +28,18 @@ class SpiffCeleryWorkerError(Exception):
 
 
 @shared_task(ignore_result=False, time_limit=TEN_MINUTES, bind=True)
-def celery_task_process_instance_event_notifier_run(
+def celery_task_event_notifier_run(
     self: Any,
     updated_process_instance_id: int,
     process_model_identifier: str,
     event_type: str,
 ) -> dict:
     celery_task_id = self.request.id
-    logger_prefix = f"celery_task_process_instance_event_notifier_run[{celery_task_id}]"
+    logger_prefix = f"celery_task_event_notifier_run[{celery_task_id}]"
     worker_intro_log_message = f"{logger_prefix}: updated_process_instance_id: {updated_process_instance_id}"
     current_app.logger.info(worker_intro_log_message)
 
-    process_model = _get_process_model(current_app.config["SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_EVENT_NOTIFIER_PROCESS_MODEL"])
+    process_model = _get_process_model(current_app.config["SPIFFWORKFLOW_BACKEND_EVENT_NOTIFIER_PROCESS_MODEL"])
     data = {
         "post_body": {
             "event_type": event_type,

--- a/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/celery_tasks/process_instance_task_producer.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/background_processing/celery_tasks/process_instance_task_producer.py
@@ -3,7 +3,7 @@ import time
 import celery
 from flask import current_app
 
-from spiffworkflow_backend.background_processing import CELERY_TASK_PROCESS_INSTANCE_EVENT_NOTIFIER
+from spiffworkflow_backend.background_processing import CELERY_TASK_EVENT_NOTIFIER
 from spiffworkflow_backend.background_processing import CELERY_TASK_PROCESS_INSTANCE_RUN
 from spiffworkflow_backend.exceptions.api_error import ApiError
 from spiffworkflow_backend.helpers.spiff_enum import ProcessInstanceExecutionMode
@@ -86,15 +86,15 @@ def queue_process_instance_if_appropriate(
     return False
 
 
-def queue_process_instance_event_notifier_if_appropriate(updated_process_instance: ProcessInstanceModel, event_type: str) -> bool:
+def queue_event_notifier_if_appropriate(updated_process_instance: ProcessInstanceModel, event_type: str) -> bool:
     if (
         queue_enabled_for_process_model()
-        and current_app.config["SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_EVENT_NOTIFIER_PROCESS_MODEL"]
-        and current_app.config["SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_EVENT_NOTIFIER_PROCESS_MODEL"]
+        and current_app.config["SPIFFWORKFLOW_BACKEND_EVENT_NOTIFIER_PROCESS_MODEL"]
+        and current_app.config["SPIFFWORKFLOW_BACKEND_EVENT_NOTIFIER_PROCESS_MODEL"]
         != updated_process_instance.process_model_identifier
     ):
         async_result = celery.current_app.send_task(
-            CELERY_TASK_PROCESS_INSTANCE_EVENT_NOTIFIER,
+            CELERY_TASK_EVENT_NOTIFIER,
             (updated_process_instance.id, updated_process_instance.process_model_identifier, event_type),
         )
         current_app.logger.info(f"Queueing process instance ({updated_process_instance.id}) for celery ({async_result.task_id})")

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/__init__.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/__init__.py
@@ -312,6 +312,6 @@ def setup_config(app: Flask) -> None:
     _check_for_incompatible_frontend_and_backend_urls(app)
     _check_extension_api_configs(app)
     _check_configs_dependent_on_celery(app, "SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_METADATA_BACKFILL_ENABLED")
-    _check_configs_dependent_on_celery(app, "SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_EVENT_NOTIFIER_PROCESS_MODEL")
+    _check_configs_dependent_on_celery(app, "SPIFFWORKFLOW_BACKEND_EVENT_NOTIFIER_PROCESS_MODEL")
     _setup_cipher(app)
     _set_up_open_id_scopes(app)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
@@ -254,7 +254,7 @@ config_from_env(
 )
 # process model to run when a process instance has been updated.
 # currently only supported when running with celery.
-config_from_env("SPIFFWORKFLOW_BACKEND_PROCESS_INSTANCE_EVENT_NOTIFIER_PROCESS_MODEL")
+config_from_env("SPIFFWORKFLOW_BACKEND_EVENT_NOTIFIER_PROCESS_MODEL")
 # check all tasks listed as child tasks are saved to the database
 config_from_env("SPIFFWORKFLOW_BACKEND_DEBUG_TASK_CONSISTENCY", default=False)
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -53,7 +53,7 @@ from sqlalchemy import and_
 from sqlalchemy import or_
 
 from spiffworkflow_backend.background_processing.celery_tasks.process_instance_task_producer import (
-    queue_process_instance_event_notifier_if_appropriate,
+    queue_event_notifier_if_appropriate,
 )
 from spiffworkflow_backend.constants import SPIFFWORKFLOW_BACKEND_SERIALIZER_VERSION
 from spiffworkflow_backend.data_stores.json import JSONDataStore
@@ -1199,7 +1199,7 @@ class ProcessInstanceProcessor:
                     "metadata": metadata,
                 }
                 LoggingService.log_event(ProcessInstanceEventType.process_instance_completed.value, log_extras)
-                queue_process_instance_event_notifier_if_appropriate(self.process_instance_model, "process_instance_complete")
+                queue_event_notifier_if_appropriate(self.process_instance_model, "process_instance_complete")
 
         db.session.add(self.process_instance_model)
 
@@ -1268,7 +1268,7 @@ class ProcessInstanceProcessor:
                         db.session.add(human_task_user)
 
         if len(new_humna_tasks) > 0:
-            queue_process_instance_event_notifier_if_appropriate(self.process_instance_model, "human_task_available")
+            queue_event_notifier_if_appropriate(self.process_instance_model, "human_task_available")
 
         if len(initial_human_tasks) > 0:
             for at in initial_human_tasks:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Refactor
  * Standardized “Event Notifier” naming across background processing tasks and services for clearer, consistent terminology. No behavioral changes.
* Configuration
  * Renamed the configuration setting for the Event Notifier process model. Please update your environment/configuration to use the new name.
* Tests
  * Updated test suite to reflect the new Event Notifier naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->