### PR TITLE
remember collapsed state

### DIFF
--- a/spiffworkflow-frontend/src/ContainerForExtensions.tsx
+++ b/spiffworkflow-frontend/src/ContainerForExtensions.tsx
@@ -73,7 +73,10 @@ export default function ContainerForExtensions() {
   const [additionalNavElement, setAdditionalNavElement] =
     useState<ReactElement | null>(null);
 
-  const [isNavCollapsed, setIsNavCollapsed] = useState<boolean>(false);
+  const [isNavCollapsed, setIsNavCollapsed] = useState<boolean>(() => {
+    const stored = localStorage.getItem('isNavCollapsed');
+    return stored ? JSON.parse(stored) : false;
+  });
 
   const isMobile = useMediaQuery((theme: any) => theme.breakpoints.down('sm'));
   const [isSideNavVisible, setIsSideNavVisible] = useState<boolean>(!isMobile);
@@ -82,12 +85,16 @@ export default function ContainerForExtensions() {
     if (isMobile) {
       setIsSideNavVisible(!isSideNavVisible);
     } else {
-      setIsNavCollapsed(!isNavCollapsed);
+      const newCollapsedState = !isNavCollapsed;
+      setIsNavCollapsed(newCollapsedState);
+      localStorage.setItem('isNavCollapsed', JSON.stringify(newCollapsedState));
     }
     if (isMobile) {
       setIsSideNavVisible(!isSideNavVisible);
     } else {
-      setIsNavCollapsed(!isNavCollapsed);
+      const newCollapsedState = !isNavCollapsed;
+      setIsNavCollapsed(newCollapsedState);
+      localStorage.setItem('isNavCollapsed', JSON.stringify(newCollapsedState));
     }
   };
 
@@ -136,7 +143,6 @@ export default function ContainerForExtensions() {
       setIsSideNavVisible(false);
     } else {
       setIsSideNavVisible(true);
-      setIsNavCollapsed(false);
     }
   }, [isMobile]);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * The sidebar/navigation collapse state is now remembered between sessions and across viewport changes (desktop/tablet), preserving your preference.
* Bug Fixes
  * More reliable collapse/expand behavior on non-mobile devices, eliminating occasional double toggles and unexpected resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->