### PR TITLE
only run git init if git status fails

### DIFF
--- a/spiffworkflow-backend/bin/boot_server_in_docker
+++ b/spiffworkflow-backend/bin/boot_server_in_docker
@@ -78,9 +78,11 @@ if [[ "${SPIFFWORKFLOW_BACKEND_GIT_CLONE_PROCESS_MODELS:-}" == "true" ]]; then
   ./bin/clone_process_models
 fi
 
-# ensure that the Process Models Directory is initialized as a git repo
-log_info "Running git init"
-git init "${SPIFFWORKFLOW_BACKEND_BPMN_SPEC_ABSOLUTE_DIR}"
+if ! git status >/dev/null 2>&1; then
+  # ensure that the Process Models Directory is initialized as a git repo
+  log_info "Running git init"
+  git init "${SPIFFWORKFLOW_BACKEND_BPMN_SPEC_ABSOLUTE_DIR}"
+fi
 
 # # VersionOneThree and the process_instance_file_data db => filesystem migration have run on all necessary environments,
 # so commenting out run_all.py.

--- a/spiffworkflow-backend/bin/boot_server_in_docker
+++ b/spiffworkflow-backend/bin/boot_server_in_docker
@@ -78,7 +78,7 @@ if [[ "${SPIFFWORKFLOW_BACKEND_GIT_CLONE_PROCESS_MODELS:-}" == "true" ]]; then
   ./bin/clone_process_models
 fi
 
-if ! git status >/dev/null 2>&1; then
+if ! git -C "$SPIFFWORKFLOW_BACKEND_BPMN_SPEC_ABSOLUTE_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   # ensure that the Process Models Directory is initialized as a git repo
   log_info "Running git init"
   git init "${SPIFFWORKFLOW_BACKEND_BPMN_SPEC_ABSOLUTE_DIR}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents unnecessary repository re-initialization during server startup by initializing only when needed.
  * Reduces startup log noise and avoids potential Git warnings in existing repositories.
  * Maintains existing startup behavior otherwise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->