### PR TITLE
support using a subdir of the bpmn repo

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/default.py
@@ -215,6 +215,8 @@ config_from_env("SPIFFWORKFLOW_BACKEND_GIT_USERNAME")
 config_from_env("SPIFFWORKFLOW_BACKEND_GIT_USER_EMAIL")
 config_from_env("SPIFFWORKFLOW_BACKEND_GITHUB_WEBHOOK_SECRET")
 config_from_env("SPIFFWORKFLOW_BACKEND_GIT_SSH_PRIVATE_KEY_PATH")
+# If the BPMN spec directory is a subdirectory within a git repo, rather than the entire git repo, this is the path to that subdirectory.
+config_from_env("SPIFFWORKFLOW_BACKEND_BPMN_SPEC_SUBDIR_WITHIN_REPO")
 
 ### webhook
 # configs for handling incoming webhooks from other systems

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/git_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/git_service.py
@@ -54,9 +54,13 @@ class GitService:
     ) -> str:
         bpmn_spec_absolute_dir = current_app.config["SPIFFWORKFLOW_BACKEND_BPMN_SPEC_ABSOLUTE_DIR"]
         process_model_relative_path = FileSystemService.process_model_relative_path(process_model)
+        path_in_repo = f"{process_model_relative_path}/{file_name}"
+        subdir = current_app.config.get("SPIFFWORKFLOW_BACKEND_BPMN_SPEC_SUBDIR_WITHIN_REPO")
+        if subdir:
+            path_in_repo = f"{subdir}/{path_in_repo}"
         shell_command = [
             "show",
-            f"{revision}:{process_model_relative_path}/{file_name}",
+            f"{revision}:{path_in_repo}",
         ]
         return cls.run_shell_command_to_get_stdout(shell_command, context_directory=bpmn_spec_absolute_dir)
 


### PR DESCRIPTION
if your git repo has top level directories like content and src, and content is your bpmn process models, you probably want to set your `SPIFFWORKFLOW_BACKEND_BPMN_SPEC_ABSOLUTE_DIR=/path/to/content`.

but we need to know that content itself isn't the git repo, but just a subdir, so we now allow specifying this subdir as a config option so that we can look back in time at the contents of files from past git revisions.