### PR TITLE
Do not delete groups

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
@@ -1004,13 +1004,10 @@ class AuthorizationService:
         added_permissions: AddedPermissionDict,
         initial_permission_assignments: list[PermissionAssignmentModel],
         initial_user_to_group_assignments: list[UserGroupAssignmentModel],
-        initial_waiting_group_assignments: list[UserGroupAssignmentWaitingModel],
         group_permissions_only: bool = False,
     ) -> None:
         added_permission_assignments = added_permissions["permission_assignments"]
-        added_group_identifiers = added_permissions["group_identifiers"]
         added_user_to_group_identifiers = added_permissions["user_to_group_identifiers"]
-        added_waiting_group_assignments = added_permissions["waiting_user_group_assignments"]
 
         for ipa in initial_permission_assignments:
             if ipa not in added_permission_assignments:
@@ -1029,18 +1026,6 @@ class AuthorizationService:
                     }
                     if current_user_dict not in added_user_to_group_identifiers:
                         db.session.delete(iutga)
-
-        # do not remove the default user group
-        added_group_identifiers.add(current_app.config["SPIFFWORKFLOW_BACKEND_DEFAULT_USER_GROUP"])
-        added_group_identifiers.add(SPIFF_GUEST_GROUP)
-        groups_to_delete = GroupModel.query.filter(GroupModel.identifier.not_in(added_group_identifiers)).all()  # type: ignore
-        for gtd in groups_to_delete:
-            if not gtd.source_is_open_id:
-                db.session.delete(gtd)
-
-        for wugam in initial_waiting_group_assignments:
-            if wugam not in added_waiting_group_assignments:
-                db.session.delete(wugam)
 
         db.session.commit()
 
@@ -1109,7 +1094,6 @@ class AuthorizationService:
                 added_permissions,
                 initial_permission_assignments,
                 initial_user_to_group_assignments,
-                initial_waiting_group_assignments,
                 group_permissions_only=group_permissions_only,
             )
             current_app.logger.debug("AUTH SERVICE - REFRESH PERMISSIONS - COMPLETED successfully")

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
@@ -1004,10 +1004,12 @@ class AuthorizationService:
         added_permissions: AddedPermissionDict,
         initial_permission_assignments: list[PermissionAssignmentModel],
         initial_user_to_group_assignments: list[UserGroupAssignmentModel],
+        initial_waiting_group_assignments: list[UserGroupAssignmentWaitingModel],
         group_permissions_only: bool = False,
     ) -> None:
         added_permission_assignments = added_permissions["permission_assignments"]
         added_user_to_group_identifiers = added_permissions["user_to_group_identifiers"]
+        added_waiting_group_assignments = added_permissions["waiting_user_group_assignments"]
 
         for ipa in initial_permission_assignments:
             if ipa not in added_permission_assignments:
@@ -1026,6 +1028,10 @@ class AuthorizationService:
                     }
                     if current_user_dict not in added_user_to_group_identifiers:
                         db.session.delete(iutga)
+
+        for wugam in initial_waiting_group_assignments:
+            if wugam not in added_waiting_group_assignments:
+                db.session.delete(wugam)
 
         db.session.commit()
 
@@ -1094,6 +1100,7 @@ class AuthorizationService:
                 added_permissions,
                 initial_permission_assignments,
                 initial_user_to_group_assignments,
+                initial_waiting_group_assignments,
                 group_permissions_only=group_permissions_only,
             )
             current_app.logger.debug("AUTH SERVICE - REFRESH PERMISSIONS - COMPLETED successfully")

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_authorization_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_authorization_service.py
@@ -441,7 +441,8 @@ class TestAuthorizationService(BaseTest):
             },
         ]
         AuthorizationService.refresh_permissions(group_info)
-        assert GroupModel.query.filter_by(identifier="group_two").first() is None
+        # we decided there is no reason to delete groups and it can cause db foreign key constraint issues
+        assert GroupModel.query.filter_by(identifier="group_two").first() is not None
         assert GroupModel.query.filter_by(identifier="group_one").first() is not None
         self.assert_user_has_permission(admin_user, "create", "/v1.0/process-groups/whatever")
         self.assert_user_has_permission(user, "read", "/v1.0/process-groups/hey")


### PR DESCRIPTION
Deleting groups was causing foreign key constraint issues between the group table and other tables like human_task. Since we could not think of a good reason to delete groups we are instead, not deleting groups.