### PR TITLE
Adds clear and delete buttons to data store list UI

### DIFF
--- a/spiff-arena-common/src/spiff_arena_common/runner.py
+++ b/spiff-arena-common/src/spiff_arena_common/runner.py
@@ -2,11 +2,9 @@ import calendar
 import datetime
 import json
 import logging
-import os
 import time
 import uuid
 
-from SpiffWorkflow.bpmn.exceptions import WorkflowTaskException
 from SpiffWorkflow.bpmn.parser.util import full_tag
 from SpiffWorkflow.bpmn.script_engine import PythonScriptEngine, TaskDataEnvironment
 from SpiffWorkflow.bpmn.serializer.workflow import BpmnWorkflowSerializer
@@ -16,8 +14,6 @@ from SpiffWorkflow.spiff.parser.task_spec import ServiceTaskParser, SpiffTaskPar
 from SpiffWorkflow.spiff.serializer.config import SPIFF_CONFIG
 from SpiffWorkflow.spiff.serializer.task_spec import ServiceTaskConverter, SpiffBpmnTaskConverter
 from SpiffWorkflow.spiff.specs.defaults import CallActivity, ManualTask, NoneTask, ServiceTask, UserTask
-from SpiffWorkflow.spiff.specs.spiff_task import SpiffBpmnTask
-from SpiffWorkflow.task import Task
 from SpiffWorkflow.util.task import TaskFilter, TaskState
 
 logging.basicConfig(level=logging.INFO)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
@@ -3646,6 +3646,14 @@ paths:
         - Data Stores
       responses:
         "200":
+          description: The requested data store.
+    delete:
+      operationId: spiffworkflow_backend.routes.data_store_controller.data_store_clear
+      summary: Clears all items of a data store.
+      tags:
+        - Data Stores
+      responses:
+        "200":
           description: A list of the data stored in the requested data store.
   /data-stores/{data_store_type}/{identifier}:
     parameters:
@@ -3670,6 +3678,14 @@ paths:
     get:
       operationId: spiffworkflow_backend.routes.data_store_controller.data_store_show
       summary: Returns a description of the data store.
+      tags:
+        - Data Stores
+      responses:
+        "200":
+          description: The requested data store.
+    delete:
+      operationId: spiffworkflow_backend.routes.data_store_controller.data_store_delete
+      summary: Deletes the data store.
       tags:
         - Data Stores
       responses:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/crud.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/crud.py
@@ -26,6 +26,14 @@ class DataStoreCRUD:
     def existing_instance(identifier: str, location: str) -> Any:
         raise Exception("must implement")
 
+    @classmethod
+    def clear(cls, identifier: str, location: str | None) -> None:
+        raise Exception("must implement")
+
+    @classmethod
+    def delete(cls, identifier: str, location: str | None) -> None:
+        raise Exception("must implement")
+
     @staticmethod
     def existing_data_stores(process_group_identifiers: list[str] | None = None) -> list[dict[str, Any]]:
         raise Exception("must implement")

--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/kkv.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/kkv.py
@@ -177,6 +177,33 @@ class KKVDataStore(BpmnDataStoreSpecification, DataStoreCRUD):  # type: ignore
     def register_data_store_class(data_store_classes: dict[str, Any]) -> None:
         data_store_classes["KKVDataStore"] = KKVDataStore
 
+    @classmethod
+    def clear(cls, identifier: str, location: str | None) -> None:
+        if not location:
+            return
+
+        store_model = db.session.query(KKVDataStoreModel).filter_by(identifier=identifier, location=location).first()
+
+        if store_model is None:
+            raise DataStoreWriteError(f"Unable to locate kkv data store '{identifier}'.")
+
+        models = db.session.query(KKVDataStoreEntryModel).filter_by(kkv_data_store_id=store_model.id).all()
+
+        for model_to_delete in models:
+            db.session.delete(model_to_delete)
+
+        db.session.commit()
+
+    @classmethod
+    def delete(cls, identifier: str, location: str | None) -> None:
+        if not location:
+            return
+
+        store_model = db.session.query(KKVDataStoreModel).filter_by(identifier=identifier, location=location).first()
+        if store_model:
+            db.session.delete(store_model)
+            db.session.commit()
+
 
 class KKVDataStoreConverter(BpmnConverter):  # type: ignore
     def to_dict(self, spec: Any) -> dict[str, Any]:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/typeahead.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/data_stores/typeahead.py
@@ -67,6 +67,19 @@ class TypeaheadDataStore(BpmnDataStoreSpecification, DataStoreCRUD):  # type: ig
     def register_data_store_class(data_store_classes: dict[str, Any]) -> None:
         data_store_classes["TypeaheadDataStore"] = TypeaheadDataStore
 
+    @classmethod
+    def clear(cls, identifier: str, location: str | None) -> None:
+        models = db.session.query(TypeaheadModel).filter_by(category=identifier).all()
+
+        for model_to_delete in models:
+            db.session.delete(model_to_delete)
+
+        db.session.commit()
+
+    @classmethod
+    def delete(cls, identifier: str, location: str | None) -> None:
+        cls.clear(identifier, location)
+
 
 class TypeaheadDataStoreConverter(BpmnConverter):  # type: ignore
     """TypeaheadDataStoreConverter."""

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
@@ -88,6 +88,35 @@ def data_store_item_list(
     return _build_response(data_store_class, identifier, location, page, per_page)
 
 
+def data_store_clear(
+    data_store_type: str, identifier: str, location: str | None = None, page: int = 1, per_page: int = 100
+) -> flask.wrappers.Response:
+    """Clears the items in a data store."""
+
+    if data_store_type not in DATA_STORES:
+        raise ApiError("unknown_data_store", f"Unknown data store type: {data_store_type}", status_code=400)
+
+    data_store_class, _ = DATA_STORES[data_store_type]
+    data_store_class.clear(identifier, location)
+    return _build_response(data_store_class, identifier, location, page, per_page)
+
+
+def data_store_delete(data_store_type: str, identifier: str, process_group_identifier: str) -> flask.wrappers.Response:
+    """Deletes a data store."""
+
+    if data_store_type not in DATA_STORES:
+        raise ApiError("unknown_data_store", f"Unknown data store type: {data_store_type}", status_code=400)
+
+    data_store_class, _ = DATA_STORES[data_store_type]
+    data_store_class.delete(identifier, process_group_identifier)
+
+    response = {
+        "ok": True,
+    }
+
+    return make_response(jsonify(response), 200)
+
+
 def data_store_create(body: dict) -> flask.wrappers.Response:
     return _data_store_upsert(body, True)
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/file_system_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/file_system_service.py
@@ -175,6 +175,11 @@ class FileSystemService:
     def write_to_json_file_at_relative_path(cls, relative_path: str, file_name: str, contents: Any) -> None:
         cls.write_to_file_at_relative_path(relative_path, file_name, json.dumps(contents, indent=4, sort_keys=True))
 
+    @classmethod
+    def delete_file_at_relative_path(cls, relative_path: str, file_name: str) -> None:
+        full_path = cls.full_path_from_relative_path(cls.path_join(relative_path, file_name))
+        os.remove(full_path)
+
     @staticmethod
     def process_model_relative_path(process_model: ProcessModelInfo) -> str:
         """Get the file path to a process model relative to SPIFFWORKFLOW_BACKEND_BPMN_SPEC_ABSOLUTE_DIR.

--- a/spiffworkflow-frontend/src/components/DataStoreButtons.tsx
+++ b/spiffworkflow-frontend/src/components/DataStoreButtons.tsx
@@ -1,0 +1,47 @@
+import { useTranslation } from 'react-i18next';
+import ButtonWithConfirmation from '../components/ButtonWithConfirmation';
+import HttpService from '../services/HttpService';
+import { DataStore } from '../interfaces';
+import { useNavigate } from 'react-router-dom';
+
+export default function DataStoreButtons({
+  dataStore,
+}: {
+  dataStore: DataStore;
+}) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const navigateToDataStores = (_result: any) => {
+    navigate(`/data-stores`);
+  };
+
+  const clearDataStore = () => {
+    HttpService.makeCallToBackend({
+      path: `/data-stores/${dataStore.type}/${dataStore.id}/items?location=${dataStore.location}`,
+      httpMethod: 'DELETE',
+      successCallback: navigateToDataStores,
+    });
+  };
+
+  const deleteDataStore = () => {
+    HttpService.makeCallToBackend({
+      path: `/data-stores/${dataStore.type}/${dataStore.id}?process_group_identifier=${dataStore.location}`,
+      httpMethod: 'DELETE',
+      successCallback: navigateToDataStores,
+    });
+  };
+
+  return (
+    <>
+      <ButtonWithConfirmation
+        buttonLabel={t('clear')}
+        onConfirmation={clearDataStore}
+      />{' '}
+      <ButtonWithConfirmation
+        buttonLabel={t('delete')}
+        onConfirmation={deleteDataStore}
+      />
+    </>
+  );
+}

--- a/spiffworkflow-frontend/src/components/DataStoreListTable.tsx
+++ b/spiffworkflow-frontend/src/components/DataStoreListTable.tsx
@@ -18,6 +18,7 @@ import HttpService from '../services/HttpService';
 import { DataStore, DataStoreRecords, PaginationObject } from '../interfaces';
 import PaginationForTable from './PaginationForTable';
 import { getPageInfoFromSearchParams } from '../helpers';
+import DataStoreButtons from './DataStoreButtons';
 
 export default function DataStoreListTable() {
   const [dataStores, setDataStores] = useState<DataStore[]>([]);
@@ -173,6 +174,7 @@ export default function DataStoreListTable() {
         tableToDisplay={getTable()}
         paginationQueryParamPrefix="datastore"
       />
+      {dataStore && <DataStoreButtons dataStore={dataStore} />}
     </>
   );
 }


### PR DESCRIPTION
Allows either clearing all data from a data store, or deleting the data store.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added Clear and Delete buttons in the Data Stores UI with confirmation and automatic return to the Data Stores list.
- API
  - Added DELETE endpoints to clear items in a data store and to delete a data store; updated related GET endpoint metadata for consistency.
- Chores
  - Removed unused imports.
  - Added backend support for clear/delete operations across JSON, KKV, and Typeahead data stores and a utility to delete files by relative path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->