### PR TITLE
Embed the http connectors

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/connectors/http_connector.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/connectors/http_connector.py
@@ -1,0 +1,66 @@
+from typing import Any
+
+import requests
+
+from spiffworkflow_backend.config import CONNECTOR_PROXY_COMMAND_TIMEOUT
+
+
+def does(id: str) -> bool:
+    return id in _config
+
+
+def do(id: str, params: dict[str, Any]) -> Any:
+    handler = _config[id]["handler"]
+    headers = params.get("headers")
+    auth = _auth(params)
+    data = params.get("data")
+
+    return handler(  # type: ignore
+        params["url"],
+        params.get("params"),
+        headers=headers,
+        auth=auth,
+        json=data,
+        timeout=CONNECTOR_PROXY_COMMAND_TIMEOUT,
+    )
+
+
+def _auth(params: dict[str, Any]) -> tuple[str, str] | None:
+    username = params.get("basic_auth_username")
+    password = params.get("basic_auth_password")
+
+    return (username, password) if username and password else None
+
+
+_base_params = [
+    {"id": "url", "type": "str", "required": True},
+    {"id": "headers", "type": "any", "required": False},
+]
+
+_basic_auth_params = [
+    {"id": "basic_auth_username", "type": "str", "required": False},
+    {"id": "basic_auth_password", "type": "str", "required": False},
+]
+
+_ro_params = [
+    *_base_params,
+    {"id": "params", "type": "any", "required": False},
+    *_basic_auth_params,
+]
+
+_rw_params = [
+    *_base_params,
+    {"id": "data", "type": "any", "required": False},
+    *_basic_auth_params,
+]
+
+_config = {
+    "http/DeleteRequest": {"params": _rw_params, "handler": requests.delete},
+    "http/GetRequest": {"params": _ro_params, "handler": requests.get},
+    "http/HeadRequest": {"params": _ro_params, "handler": requests.head},
+    "http/PatchRequest": {"params": _rw_params, "handler": requests.patch},
+    "http/PostRequest": {"params": _rw_params, "handler": requests.post},
+    "http/PutRequest": {"params": _rw_params, "handler": requests.put},
+}
+
+commands = [{"id": k, "parameters": v["params"]} for k, v in _config.items()]

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/service_task_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/service_task_service.py
@@ -20,6 +20,7 @@ from spiffworkflow_connector_command.command_interface import CommandErrorDict
 
 from spiffworkflow_backend.config import CONNECTOR_PROXY_COMMAND_TIMEOUT
 from spiffworkflow_backend.config import HTTP_REQUEST_TIMEOUT_SECONDS
+from spiffworkflow_backend.connectors import http_connector
 from spiffworkflow_backend.services.file_system_service import FileSystemService
 from spiffworkflow_backend.services.secret_service import SecretService
 from spiffworkflow_backend.services.user_service import UserService
@@ -200,8 +201,11 @@ class ServiceTaskDelegate:
                 status_code = 0
                 parsed_response: dict = {}
                 try:
-                    # this will raise on ConnectionError - like a bad url, and maybe limited other scenarios
-                    proxied_response = requests.post(call_url, json=params, timeout=CONNECTOR_PROXY_COMMAND_TIMEOUT)
+                    if http_connector.does(operator_identifier):
+                        proxied_response = http_connector.do(operator_identifier, params)
+                    else:
+                        # this will raise on ConnectionError - like a bad url, and maybe limited other scenarios
+                        proxied_response = requests.post(call_url, json=params, timeout=CONNECTOR_PROXY_COMMAND_TIMEOUT)
 
                     status_code = proxied_response.status_code
                     response_text = proxied_response.text


### PR DESCRIPTION
Embeds the http connectors in the backend and loosely sets up a pattern for delegating to other embedded connectors. There is still the need to push the embedded commands into the response that drives the drop down, will follow up with that after getting some of the bootstrap related branches merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced HTTP connector supporting standardized operations: GET, POST, PUT, PATCH, DELETE, and HEAD requests with configurable parameters and optional authentication support.

* **Improvements**
  * Service task HTTP operations now intelligently route through the new connector for optimized handling while maintaining backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->