### PR TITLE
Bootstrap

### DIFF
--- a/spiffworkflow-backend/bin/bootstrap.py
+++ b/spiffworkflow-backend/bin/bootstrap.py
@@ -4,66 +4,78 @@ from spiffworkflow_backend import create_app
 from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.models.service_account import ServiceAccountModel
 from spiffworkflow_backend.models.user import UserModel
+from spiffworkflow_backend.routes.process_api_blueprint import _get_process_model_for_instantiation
+from spiffworkflow_backend.services.authorization_service import AuthorizationService
+from spiffworkflow_backend.services.process_instance_service import ProcessInstanceService
 from spiffworkflow_backend.services.secret_service import SecretService
 
-api_key_name = "SPIFFWORKFLOW_API_KEY"
-api_key_username = "adminX"
 
-def _tmp() -> None:
-    svc = ServiceAccountModel.query.filter(ServiceAccountModel.name == api_key_username).first()
-    if svc:
-        db.session.delete(svc)
-        
-    usr = UserModel.query.filter(UserModel.username == api_key_username).first()
-    if usr:
-        db.session.delete(usr)
-    
+def _bootstrap_users() -> None:
+    permissions = AuthorizationService.load_permissions_yaml()
+    usernames_to_bootstrap = [k for k, v in permissions["users"].items() if v["service"] == "bootstrap"]
+
+    for username in usernames_to_bootstrap:
+        user = AuthorizationService.create_user_from_sign_in(
+            {
+                "iss": "bootstrap",
+                "sub": username,
+            }
+        )
+
+        db.session.add(user)
+
+        if ServiceAccountModel.query.filter(ServiceAccountModel.user_id == user.id).first():
+            continue
+
+        api_key = ServiceAccountModel.generate_api_key()
+        api_key_hash = ServiceAccountModel.hash_api_key(api_key)
+
+        service_account = ServiceAccountModel(
+            name=user.username,
+            created_by_user_id=user.id,
+            user=user,
+            api_key_hash=api_key_hash,
+        )
+
+        db.session.add(service_account)
+
+        api_key_name = f"SPIFFWORKFLOW_API_KEY_{username}"
+        SecretService.add_secret(api_key_name, api_key, user.id)
+
+        print(f"Bootstrapped user {username} with api key: {api_key}")
+
     db.session.commit()
 
-    try:
-        SecretService.delete_secret(api_key_name, 1)
-    except:
-        pass
 
-def _bootstrap() -> None:
-    admin_user = UserModel.query.filter(UserModel.username == api_key_username).first()
-    if not admin_user:
-        admin_user = UserModel(
-            username=api_key_username,
-            service="http://localhost:8000/openid",
-            service_id=api_key_username,
-        )
-        db.session.add(admin_user)
-        db.session.commit()
-
-    if ServiceAccountModel.query.filter(ServiceAccountModel.user_id == admin_user.id).first():
+def _run_bootstrap_process_model() -> None:
+    process_model_name = os.environ.get("SPIFFWORKFLOW_BACKEND_BOOTSTRAP_PROCESS_MODEL")
+    if not process_model_name:
         return
 
-    api_key = ServiceAccountModel.generate_api_key()
-    api_key_hash = ServiceAccountModel.hash_api_key(api_key)
-    
-    service_account = ServiceAccountModel(
-        name=api_key_username,
-        created_by_user_id=admin_user.id,
-        user=admin_user,
-        api_key_hash=api_key_hash,
+    username = os.environ.get("SPIFFWORKFLOW_BACKEND_BOOTSTRAP_USERNAME")
+    if not username:
+        raise Exception("Bootstrap user not specified.")
+
+    user = UserModel.query.filter(UserModel.username == username).first()
+    if not user:
+        raise Exception(f"Bootstrap user '{username}' not found.")
+
+    print(f"Running bootstrap process model {process_model_name} as {user.username}")
+
+    process_model = _get_process_model_for_instantiation(process_model_name)
+    ProcessInstanceService.create_and_run_process_instance(
+        process_model=process_model,
+        persistence_level="full",
+        user=user,
     )
 
-    db.session.add(service_account)
     db.session.commit()
 
-    SecretService.add_secret(api_key_name, api_key, admin_user.id)
-    
-    print(api_key)
 
 def main() -> None:
-    bootstrap_process_model = os.environ.get("SPIFFWORKFLOW_BACKEND_BOOTSTRAP_PROCESS_MODEL")
-    #if not bootstrap_process_model:
-    #    return
-    app = create_app()
-    with app.app.app_context():
-        _tmp()
-        _bootstrap()
+    with create_app().app.app_context():
+        _bootstrap_users()
+        _run_bootstrap_process_model()
 
 
 if __name__ == "__main__":

--- a/spiffworkflow-backend/bin/run_server_locally
+++ b/spiffworkflow-backend/bin/run_server_locally
@@ -30,6 +30,8 @@ else
       UVICORN_LOG_LEVEL=debug
     fi
 
+    uv run python "${script_dir}/bootstrap.py"
+
     # this line blocks
     exec uv run uvicorn spiff_web_server:connexion_app \
       --reload \

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/example.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/example.yml
@@ -4,6 +4,8 @@ users:
     email: admin@example.com
     password: admin
     preferred_username: admin
+  adminX:
+    service: bootstrap
   nelson:
     service: local_open_id
     email: nelson@example.com
@@ -22,7 +24,7 @@ users:
 
 groups:
   admin:
-    users: [admin@example.com, nelson@example.com]
+    users: [admin@example.com, adminX@bootstrap, nelson@example.com]
   approvers:
     users: [malala@example.com, oskar@example.com]
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
@@ -827,7 +827,7 @@ class AuthorizationService:
         return actions
 
     @classmethod
-    def parse_permissions_yaml_into_group_info(cls) -> list[GroupPermissionsDict]:
+    def load_permissions_yaml(cls) -> Any:
         if current_app.config["SPIFFWORKFLOW_BACKEND_PERMISSIONS_FILE_ABSOLUTE_PATH"] is None:
             raise (
                 PermissionsFileNotSetError(
@@ -835,9 +835,12 @@ class AuthorizationService:
                 )
             )
 
-        permission_configs = None
         with open(current_app.config["SPIFFWORKFLOW_BACKEND_PERMISSIONS_FILE_ABSOLUTE_PATH"]) as file:
-            permission_configs = yaml.safe_load(file)
+            return yaml.safe_load(file)
+
+    @classmethod
+    def parse_permissions_yaml_into_group_info(cls) -> list[GroupPermissionsDict]:
+        permission_configs = cls.load_permissions_yaml()
 
         group_permissions_by_group: dict[str, GroupPermissionsDict] = {}
         if current_app.config["SPIFFWORKFLOW_BACKEND_DEFAULT_USER_GROUP"]:


### PR DESCRIPTION
This adds two hooks into the boot sequence, one for provisioning service accounts and one for running a process model as a user. This is only wired up in `bin/run_server_locally` atm.

The service accounts are declared in a permissions yaml file with the service `bootstrap`. They are not able to login but do have api keys generated for them. Permissions can be set up in the yaml like ordinary users. In the backend logs on boot you'll see something like this the first time a new service account is encountered:

```
Bootstrapped user adminX with api key: XXX
```

A secret named `SPIFFWORKFLOW_API_KEY_adminX` is also created.

If a bootstrap process model is defined it will be run as the backend is being brought up. If it should only run once that needs to be handled in the model itself. Currently service task calls back into the same backend instance are not working from `bin/run_server_locally`.

New env vars:
* SPIFFWORKFLOW_BACKEND_BOOTSTRAP_USERNAME
* SPIFFWORKFLOW_BACKEND_BOOTSTRAP_PROCESS_MODEL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated bootstrap utility to initialize users, permissions, and API keys.
  * Optional automatic execution of an initial bootstrap process model to instantiate starter workflows.

* **Chores**
  * Local development startup now runs the bootstrap step before launching the server.
  * Example permissions config updated to include a bootstrap user.
  * Permission-loading behavior improved for configuration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->