### PR TITLE
Skip real http requests for local calls

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/connectors/http_connector.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/connectors/http_connector.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import requests
+from flask import current_app
 
 from spiffworkflow_backend.config import CONNECTOR_PROXY_COMMAND_TIMEOUT
 
@@ -11,12 +12,22 @@ def does(id: str) -> bool:
 
 def do(id: str, params: dict[str, Any]) -> Any:
     handler = _config[id]["handler"]
+    url = params["url"]
     headers = params.get("headers")
     auth = _auth(params)
     data = params.get("data")
 
-    return handler(  # type: ignore
-        params["url"],
+    if url.startswith("http://local/"):
+        with current_app.test_client() as client:
+            return getattr(client, handler)(  # type: ignore
+                url,
+                query_string=params.get("params"),
+                headers=headers,
+                json=data,
+            )
+
+    return getattr(requests, handler)(  # type: ignore
+        url,
         params.get("params"),
         headers=headers,
         auth=auth,
@@ -55,12 +66,12 @@ _rw_params = [
 ]
 
 _config = {
-    "http/DeleteRequest": {"params": _rw_params, "handler": requests.delete},
-    "http/GetRequest": {"params": _ro_params, "handler": requests.get},
-    "http/HeadRequest": {"params": _ro_params, "handler": requests.head},
-    "http/PatchRequest": {"params": _rw_params, "handler": requests.patch},
-    "http/PostRequest": {"params": _rw_params, "handler": requests.post},
-    "http/PutRequest": {"params": _rw_params, "handler": requests.put},
+    "http/DeleteRequest": {"params": _rw_params, "handler": "delete"},
+    "http/GetRequest": {"params": _ro_params, "handler": "get"},
+    "http/HeadRequest": {"params": _ro_params, "handler": "head"},
+    "http/PatchRequest": {"params": _rw_params, "handler": "patch"},
+    "http/PostRequest": {"params": _rw_params, "handler": "post"},
+    "http/PutRequest": {"params": _rw_params, "handler": "put"},
 }
 
 commands = [{"id": k, "parameters": v["params"]} for k, v in _config.items()]


### PR DESCRIPTION
Adds support for `http://local/` in service tasks which will skip making an http request back into the same backend instance and just route the call through the test client. While useful this still doesn't work before the server is booted so any bootstrappy things that require calls back into the backend will have to be fired externally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added timeout support for remote HTTP requests.
  * Local HTTP calls can now be routed through the application test client to improve testing and request simulation.
  * Unified parameter handling so local and remote request flows behave consistently.

* **Refactor**
  * Simplified HTTP connector configuration for more reliable and consistent request processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->