### PR TITLE
use user task variable name if present

### DIFF
--- a/spiffworkflow-frontend/src/views/TaskShow/TaskShow.tsx
+++ b/spiffworkflow-frontend/src/views/TaskShow/TaskShow.tsx
@@ -108,7 +108,19 @@ export default function TaskShow() {
     const processTaskWithDataResult = (result: Task) => {
       setTaskWithTaskData(result);
 
-      const taskDataToUse = result.saved_form_data || result.data;
+      const variableName = result.extensions.variableName;
+      let taskDataToUse;
+      if (result.saved_form_data) {
+        taskDataToUse = result.saved_form_data;
+      } else if (
+        typeof variableName !== 'undefined' &&
+        variableName != null &&
+        typeof result.data[variableName] !== 'undefined'
+      ) {
+        taskDataToUse = result.data[variableName];
+      } else {
+        taskDataToUse = result.data;
+      }
       setTaskData(recursivelyChangeNullAndUndefined(taskDataToUse, undefined));
       setFormButtonsDisabled(false);
     };


### PR DESCRIPTION
This checks to see if the form data is stored in a single variable and if the variable is present in the task data, uses that variable to populate the form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task data retrieval logic to check additional data sources when saved form data is unavailable. The system now attempts to locate task data through an alternative source before falling back to the default option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->