### PR TITLE
Let db type default based on URI

### DIFF
--- a/spiffworkflow-backend/conftest.py
+++ b/spiffworkflow-backend/conftest.py
@@ -2,7 +2,6 @@
 import os
 import shutil
 from collections.abc import Generator
-from tempfile import TemporaryDirectory
 from typing import Any
 
 import flask
@@ -37,16 +36,14 @@ def _set_unit_testing_env_variables() -> None:
 @pytest.fixture(scope="session")
 def connexion_app() -> Generator[FlaskApp, Any, Any]:  # noqa
     _set_unit_testing_env_variables()
-    with TemporaryDirectory() as temp_dir:
-        os.environ["SPIFFWORKFLOW_BACKEND_BPMN_SPEC_ABSOLUTE_DIR"] = temp_dir
-        connexion_app = create_app()
-        with connexion_app.app.app_context():
-            # to screw with this, poet add nplusone --group dev
-            # from nplusone.ext.flask_sqlalchemy import NPlusOne
-            # connexion_app.config["NPLUSONE_RAISE"] = True
-            # NPlusOne(connexion_app)
+    connexion_app = create_app()
+    with connexion_app.app.app_context():
+        # to screw with this, poet add nplusone --group dev
+        # from nplusone.ext.flask_sqlalchemy import NPlusOne
+        # connexion_app.config["NPLUSONE_RAISE"] = True
+        # NPlusOne(connexion_app)
 
-            yield connexion_app
+        yield connexion_app
 
 
 @pytest.fixture(scope="session")

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/__init__.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/__init__.py
@@ -28,6 +28,22 @@ class NoOpCipher:
         return value
 
 
+# given the database uri from the env, returns string (mysql, postgres, sqlite) or None
+def detect_database_type_from_uri(database_uri: str | None) -> str | None:
+    if not database_uri:
+        return None
+
+    parsed = urlparse(database_uri)
+    database_type_from_uri = parsed.scheme
+
+    if "+" in database_type_from_uri:
+        database_type_from_uri = database_type_from_uri.split("+")[0]
+    if database_type_from_uri == "postgresql":
+        database_type_from_uri = "postgres"
+
+    return database_type_from_uri
+
+
 def setup_database_configs(app: Flask) -> None:
     worker_id = os.environ.get("PYTEST_XDIST_WORKER")
     parallel_test_suffix = ""
@@ -36,12 +52,9 @@ def setup_database_configs(app: Flask) -> None:
 
     database_uri = app.config.get("SPIFFWORKFLOW_BACKEND_DATABASE_URI")
     if database_uri:
-        database_type_from_uri = urlparse(database_uri).scheme
-        if "+" in database_type_from_uri:
-            database_type_from_uri = database_type_from_uri.split("+")[0]
-        if database_type_from_uri == "postgresql":
-            database_type_from_uri = "postgres"
-        app.config["SPIFFWORKFLOW_BACKEND_DATABASE_TYPE"] = database_type_from_uri
+        database_type_from_uri = detect_database_type_from_uri(database_uri)
+        if database_type_from_uri:
+            app.config["SPIFFWORKFLOW_BACKEND_DATABASE_TYPE"] = database_type_from_uri
 
     # Validate database type
     database_type = app.config.get("SPIFFWORKFLOW_BACKEND_DATABASE_TYPE")

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_config.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_config.py
@@ -1,45 +1,31 @@
-import importlib
-import os
 import unittest
-from unittest.mock import patch
 
-import spiffworkflow_backend.config.default as default_config
-from spiffworkflow_backend import create_app
+from spiffworkflow_backend.config import detect_database_type_from_uri
 
 
 class TestConfig(unittest.TestCase):
     def test_mysql_database_type_is_inferred_from_uri(self) -> None:
-        with patch.dict(
-            os.environ,
-            {
-                "SPIFFWORKFLOW_BACKEND_DATABASE_TYPE": "",
-                "SPIFFWORKFLOW_BACKEND_DATABASE_URI": "mysql+mysqldb://root:pwd@127.0.0.1/spiffworkflow_backend_unit_testing",
-            },
-        ):
-            importlib.reload(default_config)
-            app = create_app()
-            self.assertEqual(app.app.config["SPIFFWORKFLOW_BACKEND_DATABASE_TYPE"], "mysql")
+        database_uri = "mysql+mysqldb://root:pwd@127.0.0.1/spiffworkflow_backend_unit_testing"
+        database_type = detect_database_type_from_uri(database_uri)
+        self.assertEqual(database_type, "mysql")
 
     def test_postgres_database_type_is_inferred_from_uri(self) -> None:
-        with patch.dict(
-            os.environ,
-            {
-                "SPIFFWORKFLOW_BACKEND_DATABASE_TYPE": "",
-                "SPIFFWORKFLOW_BACKEND_DATABASE_URI": "postgresql://spiffworkflow_backend:spiffworkflow_backend@localhost:5432/spiffworkflow_backend_unit_testing",
-            },
-        ):
-            importlib.reload(default_config)
-            app = create_app()
-            self.assertEqual(app.app.config["SPIFFWORKFLOW_BACKEND_DATABASE_TYPE"], "postgres")
+        database_uri = (
+            "postgresql://spiffworkflow_backend:spiffworkflow_backend@localhost:5432/spiffworkflow_backend_unit_testing"
+        )
+        database_type = detect_database_type_from_uri(database_uri)
+        self.assertEqual(database_type, "postgres")
 
     def test_sqlite_database_type_is_inferred_from_uri(self) -> None:
-        with patch.dict(
-            os.environ,
-            {
-                "SPIFFWORKFLOW_BACKEND_DATABASE_TYPE": "",
-                "SPIFFWORKFLOW_BACKEND_DATABASE_URI": "sqlite:///db_unit_testing.sqlite3",
-            },
-        ):
-            importlib.reload(default_config)
-            app = create_app()
-            self.assertEqual(app.app.config["SPIFFWORKFLOW_BACKEND_DATABASE_TYPE"], "sqlite")
+        database_uri = "sqlite:///db_unit_testing.sqlite3"
+        database_type = detect_database_type_from_uri(database_uri)
+        self.assertEqual(database_type, "sqlite")
+
+    def test_empty_database_uri_returns_none(self) -> None:
+        self.assertIsNone(detect_database_type_from_uri(""))
+        self.assertIsNone(detect_database_type_from_uri(None))
+
+    def test_postgresql_scheme_is_normalized_to_postgres(self) -> None:
+        database_uri = "postgresql+psycopg2://user:pass@localhost/db"
+        database_type = detect_database_type_from_uri(database_uri)
+        self.assertEqual(database_type, "postgres")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database type is now automatically detected from the database connection URI, eliminating the need for separate manual configuration. Supports MySQL, PostgreSQL, and SQLite with automatic scheme normalization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->