### PR TITLE
Only return form related task data for human tasks

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
@@ -753,6 +753,10 @@ def _get_task_model_for_request(
                 task_model.form_ui_schema = {}
             _munge_form_ui_schema_based_on_hidden_fields_in_task_data(task_model.form_ui_schema, task_model.data)
 
+            subset_var = extensions.get("variableName")
+            if subset_var:
+                task_model.data = {subset_var: task_model.data.get(subset_var, {})}
+
         # it should be safe to add instructions to the task spec here since we are never commiting it back to the db
         extensions["instructionsForEndUser"] = JinjaService.render_instructions_for_end_user(task_model, extensions)
 


### PR DESCRIPTION
If a user task is configured with a `variableName`, limit the task data in the api response to only contain that key. This piggybacks on the previous `variableName` work to not leak irrelevant task data.

I'm still auditing endpoints but this appears to be working and should be safe to merge since it is only in play if a `variableName` is configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced task data handling with support for variable name extensions in task configurations, enabling better organization and structure of task-related information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->