### PR TITLE
Add `run_test_cases` to common tester.py

### DIFF
--- a/spiff-arena-common/pyproject.toml
+++ b/spiff-arena-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spiff-arena-common"
-version = "0.1.9"
+version = "0.1.10"
 description = "Shared Python utilities for Spiff Arena frontend and backend components"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/spiff-arena-common/src/spiff_arena_common/tester.py
+++ b/spiff-arena-common/src/spiff_arena_common/tester.py
@@ -109,3 +109,15 @@ def run_tests_in_dir(dir):
         assert not err
         parsed.append((file, specs))
     return run_tests(parsed)
+
+def run_test_cases(tests):
+    suite = unittest.TestSuite()
+    suite.addTests(tests)
+    stream = io.StringIO()
+    result = unittest.TextTestRunner(stream=stream).run(suite)
+
+    return {
+        "testsRun": result.testsRun,
+        "wasSuccessful": result.wasSuccessful(),
+        "output": stream.getvalue(),
+    }

--- a/spiff-arena-common/tests/spiff_arena_common/test_tester.py
+++ b/spiff-arena-common/tests/spiff_arena_common/test_tester.py
@@ -69,29 +69,17 @@ ut_test = ("ut_test.bpmn", """
     <bpmn:scriptTask id="Activity_0f6vlzg" name="Test Result">
       <bpmn:incoming>Flow2_1770132558798</bpmn:incoming>
       <bpmn:outgoing>Flow_1a46c5r</bpmn:outgoing>
-      <bpmn:script>def runTests(tests):
-  import io
-  import unittest
-
-  suite = unittest.TestSuite()
-  suite.addTests(tests)
-  stream = io.StringIO()
-  result = unittest.TextTestRunner(stream=stream).run(suite)
-  
-  return {
-    "testsRun": result.testsRun,
-    "wasSuccessful": result.wasSuccessful(),
-    "output": stream.getvalue(),
-  }
-
+      <bpmn:script>
 def test():
   import unittest
+  
+  from spiff_arena_common.tester import run_test_cases
 
   class TestTaskData(unittest.TestCase):
     def runTest(self):
       self.assertEqual(some_field, spiff_testFixture["expected"]["some_field"])
       
-  return runTests([TestTaskData()])
+  return run_test_cases([TestTaskData()])
   
 spiff_testResult = test()</bpmn:script>
     </bpmn:scriptTask>

--- a/uv.lock
+++ b/uv.lock
@@ -433,7 +433,7 @@ wheels = [
 
 [[package]]
 name = "spiff-arena-common"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "spiff-arena-common" }
 
 [[package]]


### PR DESCRIPTION
This was present in various script tasks across multiple `_test.bpmn` files. Structure seems to have stabilized enough now that we can move it into common. This is used by ed/ci to run test cases via a script task and have their output collected to produce the overall test result for some set of `_test.bpmn` files.