### PR TITLE
Custom Script File Support and ability to serlialize datetimes.  

### DIFF
--- a/spiff-arena-common/pyproject.toml
+++ b/spiff-arena-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spiff-arena-common"
-version = "0.1.21"
+version = "0.1.24"
 description = "Shared Python utilities for Spiff Arena frontend and backend components"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/spiff-arena-common/pyproject.toml
+++ b/spiff-arena-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spiff-arena-common"
-version = "0.1.24"
+version = "0.1.22"
 description = "Shared Python utilities for Spiff Arena frontend and backend components"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/spiff-arena-common/src/spiff_arena_common/runner.py
+++ b/spiff-arena-common/src/spiff_arena_common/runner.py
@@ -463,10 +463,7 @@ def advance_workflow(specs, state, completed_task, strategy_name, start_params, 
         try:
             return build_response(workflow, e, compress_state=compress_state, session_id=session_id)
         except Exception as e2:
-            import traceback
-            tb = traceback.format_exc()
-            print(tb, flush=True)
-            return json.dumps({ "status": "error", "message": f"{e2}\n{tb}" }, cls=SpiffJsonEncoder)
+            return json.dumps({"status": "error", "message": f"{e}"})
 
 def get_tasks(workflow, task_filter):
     tasks = workflow.get_tasks(task_filter=task_filter)

--- a/spiff-arena-common/src/spiff_arena_common/runner.py
+++ b/spiff-arena-common/src/spiff_arena_common/runner.py
@@ -154,12 +154,20 @@ class CustomEnvironment(TaskDataEnvironment):
         if external_context is None:
             external_context = {}
 
-        # ToDo: Provide placeholders for all of Arena's built in scripts..
         external_context["get_task_data_value"] = lambda k, d=None: context.get(k, d)
         external_context["get_top_level_process_info"] = lambda: {
             "process_instance_id": 0,
             "process_model_identifier": "local",
         }
+        external_context["get_current_user"] = lambda: {
+            "email": "current_user@example.com",
+            "display_name": "Mr. Current User",
+        }
+        external_context["get_group_members"] = lambda group_name: [
+            "group_member_1@example.com",
+            "group_member_2@example.com",
+            "group_member_3@example.com"
+        ]
 
         return super().execute(script or "", context, external_context)
 

--- a/spiff-arena-common/src/spiff_arena_common/runner.py
+++ b/spiff-arena-common/src/spiff_arena_common/runner.py
@@ -10,13 +10,31 @@ import uuid
 import jsonschema
 
 
-class EdEncoder(json.JSONEncoder):
+# This encoder/decoder replicates the type conversion behavior of
+# SpiffWorkflow's DefaultRegistry (bpmn.serializer.helpers.registry)
+# for UUID, datetime, and timedelta, but uses a JSONEncoder subclass
+# and json.loads object_hook for single-pass performance on large payloads.
+class SpiffJsonEncoder(json.JSONEncoder):
     def default(self, obj):
+        if isinstance(obj, uuid.UUID):
+            return { 'typename': 'UUID', 'value': str(obj) }
         if isinstance(obj, (datetime.datetime, datetime.date)):
-            return obj.isoformat()
+            return { 'typename': 'datetime', 'value': obj.isoformat() }
         if isinstance(obj, datetime.timedelta):
-            return obj.total_seconds()
+            return { 'typename': 'timedelta', 'days': obj.days, 'seconds': obj.seconds }
         return super().default(obj)
+
+
+def spiff_json_object_hook(dct):
+    typename = dct.get('typename')
+    if typename == 'UUID':
+        return uuid.UUID(dct['value'])
+    if typename == 'datetime':
+        return datetime.datetime.fromisoformat(dct['value'])
+    if typename == 'timedelta':
+        return datetime.timedelta(days=dct['days'], seconds=dct['seconds'])
+    return dct
+
 
 from spiff_arena_common.data_stores import JSONFileDataStore
 
@@ -131,29 +149,11 @@ class CustomEnvironment(TaskDataEnvironment):
             "time": time,
             "timedelta": datetime.timedelta,
         })
-        self.custom_scripts = {}
-
-    def load_custom_scripts(self, path):
-        self.custom_scripts = {}
-        try:
-            with open(path) as f:
-                source = f.read()
-            namespace = {}
-            exec(source, namespace)
-            self.custom_scripts = {
-                k: v for k, v in namespace.items()
-                if callable(v) and not k.startswith('_')
-            }
-        except FileNotFoundError:
-            pass
-        except Exception as e:
-            logging.warning(f"Failed to load custom scripts from {path}: {e}")
 
     def execute(self, script, context, external_context=None):
         if external_context is None:
             external_context = {}
 
-        external_context.update(self.custom_scripts)
         # ToDo: Provide placeholders for all of Arena's built in scripts..
         external_context["get_task_data_value"] = lambda k, d=None: context.get(k, d)
         external_context["get_top_level_process_info"] = lambda: {
@@ -187,12 +187,11 @@ class CustomScriptEngine(PythonScriptEngine):
             "operation_name": operation_name,
             "operation_params": operation_params,
             "task_data": task_data,
-        }, cls=EdEncoder)
+        }, cls=SpiffJsonEncoder)
 
 
 registry = BpmnWorkflowSerializer.configure(SPIFF_CONFIG)
 serializer = BpmnWorkflowSerializer(registry=registry)
-
 # Global workflow cache by session_id to avoid repeated (de)serialization
 _workflow_cache = {}
 
@@ -226,7 +225,7 @@ def specs_from_xml(files):
         "subprocess_specs": workflow_dct["subprocess_specs"],
     }
 
-    return json.dumps(workflow_specs_dct, cls=EdEncoder), None
+    return json.dumps(workflow_specs_dct, cls=SpiffJsonEncoder), None
 
 def hydrate_workflow(specs, state, session_id=None):
     """Hydrate workflow from specs and state, using cache when available.
@@ -251,7 +250,7 @@ def hydrate_workflow(specs, state, session_id=None):
         if isinstance(state, str) and not state.startswith('{'):
             compressed = base64.b64decode(state)
             decompressed = gzip.decompress(compressed)
-            state = json.loads(decompressed.decode('utf-8'))
+            state = json.loads(decompressed.decode('utf-8'), object_hook=spiff_json_object_hook)
 
         # Update cached workflow with new state (in-place mutation)
         # Only update the mutable parts - tasks, data, etc.
@@ -290,7 +289,7 @@ def hydrate_workflow(specs, state, session_id=None):
             # Decode base64 then decompress
             compressed = base64.b64decode(state)
             decompressed = gzip.decompress(compressed)
-            state = json.loads(decompressed.decode('utf-8'))
+            state = json.loads(decompressed.decode('utf-8'), object_hook=spiff_json_object_hook)
 
         state["spec"] = process
         state["subprocess_specs"] = subprocesses
@@ -430,15 +429,12 @@ def _advance_workflow(workflow, task, strategy_name, compress_state=False, sessi
                     task.data.update(expected["data"])
     return build_response(workflow, None, compress_state=compress_state, lazy_loads_result=lazy_loads_list, session_id=session_id)
 
-def advance_workflow(specs, state, completed_task, strategy_name, start_params, compress_state=False, session_id=None, jump_to_step_idx=None, scripts_path=None):
+def advance_workflow(specs, state, completed_task, strategy_name, start_params, compress_state=False, session_id=None, jump_to_step_idx=None):
     # If jumping to a specific step, restore state from step history cache
     if jump_to_step_idx is not None and session_id and session_id in _step_history_cache:
         steps = _step_history_cache[session_id]
         if 0 <= jump_to_step_idx < len(steps):
             state = steps[jump_to_step_idx]
-
-    if scripts_path:
-        custom_environment.load_custom_scripts(scripts_path)
 
     workflow = hydrate_workflow(specs, state, session_id=session_id)
     if state == {} and start_params:
@@ -462,7 +458,7 @@ def advance_workflow(specs, state, completed_task, strategy_name, start_params, 
             import traceback
             tb = traceback.format_exc()
             print(tb, flush=True)
-            return json.dumps({ "status": "error", "message": f"{e2}\n{tb}" }, cls=EdEncoder)
+            return json.dumps({ "status": "error", "message": f"{e2}\n{tb}" }, cls=SpiffJsonEncoder)
 
 def get_tasks(workflow, task_filter):
     tasks = workflow.get_tasks(task_filter=task_filter)
@@ -498,7 +494,7 @@ def get_state(workflow, compress=False):
     state.pop("subprocess_specs")
 
     if compress:
-        json_str = json.dumps(state, cls=EdEncoder)
+        json_str = json.dumps(state, cls=SpiffJsonEncoder)
         compressed = gzip.compress(json_str.encode('utf-8'))
         # Base64 encode for JSON serialization
         return base64.b64encode(compressed).decode('ascii')
@@ -595,7 +591,7 @@ def build_response(workflow, e, compress_state=False, lazy_loads_result=None, se
 
         # Return step index instead of full state
         response["step_idx"] = len(_step_history_cache[session_id]) - 1
-    return json.dumps(response, cls=EdEncoder)
+    return json.dumps(response, cls=SpiffJsonEncoder)
 
 def truncate_step_history(session_id, step_idx):
     """Truncate step history cache to a specific step index.

--- a/spiff-arena-common/src/spiff_arena_common/runner.py
+++ b/spiff-arena-common/src/spiff_arena_common/runner.py
@@ -9,6 +9,15 @@ import uuid
 
 import jsonschema
 
+
+class EdEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, (datetime.datetime, datetime.date)):
+            return obj.isoformat()
+        if isinstance(obj, datetime.timedelta):
+            return obj.total_seconds()
+        return super().default(obj)
+
 from spiff_arena_common.data_stores import JSONFileDataStore
 
 from SpiffWorkflow.bpmn.exceptions import WorkflowTaskException
@@ -122,18 +131,36 @@ class CustomEnvironment(TaskDataEnvironment):
             "time": time,
             "timedelta": datetime.timedelta,
         })
+        self.custom_scripts = {}
+
+    def load_custom_scripts(self, path):
+        self.custom_scripts = {}
+        try:
+            with open(path) as f:
+                source = f.read()
+            namespace = {}
+            exec(source, namespace)
+            self.custom_scripts = {
+                k: v for k, v in namespace.items()
+                if callable(v) and not k.startswith('_')
+            }
+        except FileNotFoundError:
+            pass
+        except Exception as e:
+            logging.warning(f"Failed to load custom scripts from {path}: {e}")
 
     def execute(self, script, context, external_context=None):
         if external_context is None:
             external_context = {}
-        
-        # TODO: would be nice to get these from the client so we don't have to code change for globals
+
+        external_context.update(self.custom_scripts)
+        # ToDo: Provide placeholders for all of Arena's built in scripts..
         external_context["get_task_data_value"] = lambda k, d=None: context.get(k, d)
         external_context["get_top_level_process_info"] = lambda: {
             "process_instance_id": 0,
             "process_model_identifier": "local",
         }
-        
+
         return super().execute(script or "", context, external_context)
 
 
@@ -160,7 +187,7 @@ class CustomScriptEngine(PythonScriptEngine):
             "operation_name": operation_name,
             "operation_params": operation_params,
             "task_data": task_data,
-        })
+        }, cls=EdEncoder)
 
 
 registry = BpmnWorkflowSerializer.configure(SPIFF_CONFIG)
@@ -199,7 +226,7 @@ def specs_from_xml(files):
         "subprocess_specs": workflow_dct["subprocess_specs"],
     }
 
-    return json.dumps(workflow_specs_dct), None
+    return json.dumps(workflow_specs_dct, cls=EdEncoder), None
 
 def hydrate_workflow(specs, state, session_id=None):
     """Hydrate workflow from specs and state, using cache when available.
@@ -403,12 +430,15 @@ def _advance_workflow(workflow, task, strategy_name, compress_state=False, sessi
                     task.data.update(expected["data"])
     return build_response(workflow, None, compress_state=compress_state, lazy_loads_result=lazy_loads_list, session_id=session_id)
 
-def advance_workflow(specs, state, completed_task, strategy_name, start_params, compress_state=False, session_id=None, jump_to_step_idx=None):
+def advance_workflow(specs, state, completed_task, strategy_name, start_params, compress_state=False, session_id=None, jump_to_step_idx=None, scripts_path=None):
     # If jumping to a specific step, restore state from step history cache
     if jump_to_step_idx is not None and session_id and session_id in _step_history_cache:
         steps = _step_history_cache[session_id]
         if 0 <= jump_to_step_idx < len(steps):
             state = steps[jump_to_step_idx]
+
+    if scripts_path:
+        custom_environment.load_custom_scripts(scripts_path)
 
     workflow = hydrate_workflow(specs, state, session_id=session_id)
     if state == {} and start_params:
@@ -429,7 +459,10 @@ def advance_workflow(specs, state, completed_task, strategy_name, start_params, 
         try:
             return build_response(workflow, e, compress_state=compress_state, session_id=session_id)
         except Exception as e2:
-            return json.dumps({ "status": "error", "message": f"{e}" })
+            import traceback
+            tb = traceback.format_exc()
+            print(tb, flush=True)
+            return json.dumps({ "status": "error", "message": f"{e2}\n{tb}" }, cls=EdEncoder)
 
 def get_tasks(workflow, task_filter):
     tasks = workflow.get_tasks(task_filter=task_filter)
@@ -465,7 +498,7 @@ def get_state(workflow, compress=False):
     state.pop("subprocess_specs")
 
     if compress:
-        json_str = json.dumps(state)
+        json_str = json.dumps(state, cls=EdEncoder)
         compressed = gzip.compress(json_str.encode('utf-8'))
         # Base64 encode for JSON serialization
         return base64.b64encode(compressed).decode('ascii')
@@ -562,8 +595,7 @@ def build_response(workflow, e, compress_state=False, lazy_loads_result=None, se
 
         # Return step index instead of full state
         response["step_idx"] = len(_step_history_cache[session_id]) - 1
-
-    return json.dumps(response)
+    return json.dumps(response, cls=EdEncoder)
 
 def truncate_step_history(session_id, step_idx):
     """Truncate step history cache to a specific step index.

--- a/spiff-arena-common/src/spiff_arena_common/tester.py
+++ b/spiff-arena-common/src/spiff_arena_common/tester.py
@@ -5,7 +5,7 @@ import unittest
 
 from collections import namedtuple
 
-from spiff_arena_common.runner import advance_workflow, specs_from_xml
+from spiff_arena_common.runner import advance_workflow, SpiffJsonEncoder, spiff_json_object_hook, specs_from_xml
 
 Test = namedtuple("Test", ["file", "specs"])
 TestCtx = namedtuple("TestCtx", ["files", "specs", "tests", "test_cases"])
@@ -23,20 +23,20 @@ class BpmnTestCase(unittest.TestCase):
         super().__init__()
 
     def lazy_load(self, ids):
-        self.specs = json.loads(self.specs)
+        self.specs = json.loads(self.specs, object_hook=spiff_json_object_hook)
         for id in ids:
-            specs = json.loads(self.specs_by_id[id])
+            specs = json.loads(self.specs_by_id[id], object_hook=spiff_json_object_hook)
             subprocess_specs = self.specs["subprocess_specs"]
             subprocess_specs[id] = specs["spec"]
             subprocess_specs.update(specs["subprocess_specs"])
-        self.specs = json.dumps(self.specs)
+        self.specs = json.dumps(self.specs, cls=SpiffJsonEncoder)
 
     def runTest(self):
         iters = 0
         r = None
         while iters < 100:
             iters = iters + 1
-            r = json.loads(advance_workflow(self.specs, self.state, None, "unittest", None))
+            r = json.loads(advance_workflow(self.specs, self.state, None, "unittest", None), object_hook=spiff_json_object_hook)
             self.state = r["state"]
 
             # Check for errors after each advance

--- a/uv.lock
+++ b/uv.lock
@@ -433,7 +433,7 @@ wheels = [
 
 [[package]]
 name = "spiff-arena-common"
-version = "0.1.21"
+version = "0.1.24"
 source = { editable = "spiff-arena-common" }
 
 [[package]]


### PR DESCRIPTION
SpiffWorkflow has a custom encoder that allows serializing datetime objects, adding that ability to Ed as well.

Added the ability to load custom script files.  Given a python file, it will make all the functions defined in that file available to the execution engine.

The custom script files are just working in Ed, but have a todo to make this work correctly in SpiffArena as well.   Just anxious not to take on too much at once.  