### PR TITLE
Limit number of steps in history

### DIFF
--- a/spiff-arena-common/pyproject.toml
+++ b/spiff-arena-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spiff-arena-common"
-version = "0.1.23"
+version = "0.1.24"
 description = "Shared Python utilities for Spiff Arena frontend and backend components"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/spiff-arena-common/src/spiff_arena_common/runner.py
+++ b/spiff-arena-common/src/spiff_arena_common/runner.py
@@ -594,6 +594,13 @@ def build_response(workflow, e, compress_response=False, lazy_loads_result=None,
         full_state = get_state(workflow, compress=False)
         _step_history_cache[session_id].append(full_state)
 
+        # Cap step history at 64 steps - replace oldest entries with {} to reduce memory
+        STEP_HISTORY_CAP = 64
+        steps = _step_history_cache[session_id]
+        if len(steps) > STEP_HISTORY_CAP:
+            # On step 64, step 0 becomes {} (keeping array size intact for jump indices)
+            steps[len(steps) - STEP_HISTORY_CAP - 1] = {}
+
         # Return step index instead of full state
         response["step_idx"] = len(_step_history_cache[session_id]) - 1
     

--- a/spiff-arena-common/src/spiff_arena_common/runner.py
+++ b/spiff-arena-common/src/spiff_arena_common/runner.py
@@ -594,12 +594,12 @@ def build_response(workflow, e, compress_response=False, lazy_loads_result=None,
         full_state = get_state(workflow, compress=False)
         _step_history_cache[session_id].append(full_state)
 
-        # Cap step history at 64 steps - replace oldest entries with {} to reduce memory
+        # Cap step history at 64 steps - replace oldest entries with None to reduce memory
         STEP_HISTORY_CAP = 64
         steps = _step_history_cache[session_id]
         if len(steps) > STEP_HISTORY_CAP:
-            # On step 64, step 0 becomes {} (keeping array size intact for jump indices)
-            steps[len(steps) - STEP_HISTORY_CAP - 1] = {}
+            # On step 64, step 0 becomes None (keeping array size intact for jump indices)
+            steps[len(steps) - STEP_HISTORY_CAP - 1] = None
 
         # Return step index instead of full state
         response["step_idx"] = len(_step_history_cache[session_id]) - 1

--- a/uv.lock
+++ b/uv.lock
@@ -433,7 +433,7 @@ wheels = [
 
 [[package]]
 name = "spiff-arena-common"
-version = "0.1.23"
+version = "0.1.24"
 source = { editable = "spiff-arena-common" }
 
 [[package]]


### PR DESCRIPTION
Part of ongoing performance work for ed, this is mostly noticeable during single stepping large workflows. The max steps are hardcoded to 64 now, I'll likely make this configurable at some point, but we are starting to get a lot of named parameters on advance_workflow, so will want to deal with configuration better overall at some point. 64 ought to be enough for anybody...