### PR TITLE
Fix service task delegate error

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/connectors/http_connector.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/connectors/http_connector.py
@@ -1,4 +1,5 @@
 import json
+from dataclasses import dataclass
 from typing import Any
 from typing import cast
 from urllib.parse import urlparse
@@ -9,16 +10,18 @@ from flask import current_app
 from spiffworkflow_backend.config import CONNECTOR_PROXY_COMMAND_TIMEOUT
 
 
+@dataclass
 class HttpConnectorResponse:
-    text: str | None = None
-    status_code: int | None = None
+    text: str
+    status_code: int
+    headers: dict[str, Any]
 
 
 def does(id: str) -> bool:
     return id in _config
 
 
-def do(id: str, params: dict[str, Any]) -> Any:
+def do(id: str, params: dict[str, Any]) -> HttpConnectorResponse:
     handler = cast(str, _config[id]["handler"])
     url = params["url"]
     headers = params.get("headers")
@@ -109,11 +112,10 @@ def _connector_response(http_response: requests.Response) -> HttpConnectorRespon
         "spiff__logs": [],
     }
 
-    # create a blank object so we can mimic an actual http response object
-    obj = HttpConnectorResponse()
-    obj.text = json.dumps(return_dict)
-    obj.status_code = http_response.status_code
-    return obj
+    # return a mimicked version an actual http response object
+    return HttpConnectorResponse(
+        text=json.dumps(return_dict), status_code=http_response.status_code, headers=dict(http_response.headers)
+    )
 
 
 def _auth(params: dict[str, Any]) -> tuple[str, str] | None:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/service_task_delegate.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/service_task_delegate.py
@@ -271,6 +271,7 @@ class ServiceTaskDelegate:
                 response_text = ""
                 status_code = 0
                 parsed_response: dict = {}
+                proxied_response: http_connector.HttpConnectorResponse | requests.Response
                 try:
                     if http_connector.does(operator_identifier):
                         proxied_response = http_connector.do(operator_identifier, params)


### PR DESCRIPTION
In the `call_connector` method of `ServiceTaskDelegate`, [there is an attempt to log headers](https://github.com/sartography/spiff-arena/blob/1731038258e04bf020074d8d1d71d09084c3164c/spiffworkflow-backend/src/spiffworkflow_backend/services/service_task_delegate.py#L292) from an object that is either a `Response` or an `HttpConnectorResponse`. However, an object of type `HttpConnectorResponse` does not have the `headers` attribute, so this causes Service Connector calls in the `HttpConnectorResponse` execution branch to fail.

This PR fixes the issue by adding headers to the `HttpConnectorResponse` response object and using better typing hints so that such errors will be exposed in the future.