### PR TITLE
Use bpmn_id instead of name for recordings

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -18,4 +18,4 @@ RUN adduser --uid $USER_ID --gid $GROUP_ID $USER_NAME
 RUN git config --global --add safe.directory *
 
 RUN pip install --upgrade pip
-RUN pip install uv==0.6.16
+RUN pip install uv==0.10.0

--- a/spiff-arena-common/pyproject.toml
+++ b/spiff-arena-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spiff-arena-common"
-version = "0.1.25"
+version = "0.1.26"
 description = "Shared Python utilities for Spiff Arena frontend and backend components"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/spiff-arena-common/src/spiff_arena_common/runner.py
+++ b/spiff-arena-common/src/spiff_arena_common/runner.py
@@ -434,7 +434,7 @@ def _advance_workflow(workflow, task, strategy_name, compress_response=False, se
                         break
 
                     expected = stack[index]
-                    if task.task_spec.name != expected["id"]:
+                    if task.task_spec.bpmn_id != expected["id"]:
                         break
 
                     task.run()
@@ -446,7 +446,7 @@ def _advance_workflow(workflow, task, strategy_name, compress_response=False, se
                     if not stack:
                         break
                     expected = stack.pop()
-                    if task.task_spec.name != expected["id"]:
+                    if task.task_spec.bpmn_id != expected["id"]:
                         break
                     task.run()
                     task.data.update(expected["data"])

--- a/spiff-arena-common/tests/spiff_arena_common/test_runner.py
+++ b/spiff-arena-common/tests/spiff_arena_common/test_runner.py
@@ -1,0 +1,7 @@
+def test_bpmn_ids_match_by_exact_string_equality():
+    assert "any_task" == "any_task"
+
+
+def test_bpmn_ids_do_not_normalize_child_suffixes():
+    assert "any_task [child]" != "any_task"
+    assert "any_task" != "any_task [child]"

--- a/spiff-arena-common/tests/spiff_arena_common/test_runner.py
+++ b/spiff-arena-common/tests/spiff_arena_common/test_runner.py
@@ -1,7 +1,0 @@
-def test_bpmn_ids_match_by_exact_string_equality():
-    assert "any_task" == "any_task"
-
-
-def test_bpmn_ids_do_not_normalize_child_suffixes():
-    assert "any_task [child]" != "any_task"
-    assert "any_task" != "any_task [child]"

--- a/spiffworkflow-backend/dev.Dockerfile
+++ b/spiffworkflow-backend/dev.Dockerfile
@@ -10,6 +10,6 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 RUN pip install --upgrade pip
-RUN pip install uv==0.6.16 pytest-xdist==3.6.1
+RUN pip install uv==0.10.0 pytest-xdist==3.6.1
 
 CMD ["./bin/run_server_locally"]

--- a/uv.lock
+++ b/uv.lock
@@ -433,7 +433,7 @@ wheels = [
 
 [[package]]
 name = "spiff-arena-common"
-version = "0.1.25"
+version = "0.1.26"
 source = { editable = "spiff-arena-common" }
 
 [[package]]


### PR DESCRIPTION
Ran into an issue where some recordings that had multi-instance flows would end up with the task names as "Something [child]", which did not match the actual runtime task. Fix is to switch over to use bpmn_id, which will require old recordings to be patched or re-recorded.