### PR TITLE
Add get_current_task_data to common runner

### DIFF
--- a/spiff-arena-common/pyproject.toml
+++ b/spiff-arena-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spiff-arena-common"
-version = "0.1.27"
+version = "0.1.28"
 description = "Shared Python utilities for Spiff Arena frontend and backend components"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/spiff-arena-common/src/spiff_arena_common/runner.py
+++ b/spiff-arena-common/src/spiff_arena_common/runner.py
@@ -6,6 +6,7 @@ import json
 import logging
 import time
 import uuid
+from types import ModuleType
 
 import jsonschema
 
@@ -39,6 +40,7 @@ def spiff_json_object_hook(dct):
 from spiff_arena_common.data_stores import JSONFileDataStore
 
 from SpiffWorkflow.bpmn.exceptions import WorkflowTaskException
+from SpiffWorkflow.bpmn.serializer import DefaultRegistry
 from SpiffWorkflow.bpmn.specs.mixins.multiinstance_task import LoopTask
 from SpiffWorkflow.bpmn.parser.util import full_tag
 from SpiffWorkflow.bpmn.script_engine import PythonScriptEngine, TaskDataEnvironment
@@ -53,6 +55,8 @@ from SpiffWorkflow.spiff.specs.defaults import CallActivity, ManualTask, NoneTas
 from SpiffWorkflow.util.task import TaskFilter, TaskState
 
 logging.basicConfig(level=logging.ERROR)
+
+_INTERNAL_KEYS = {"__builtins__", "__annotations__"}
 
 class CustomManualTask(ManualTask):
     def _run(self, task):
@@ -168,6 +172,12 @@ class CustomEnvironment(TaskDataEnvironment):
             "group_member_2@example.com",
             "group_member_3@example.com"
         ]
+        hidden_keys = _INTERNAL_KEYS | set(self.globals.keys()) | set(external_context.keys())
+        external_context["get_current_task_data"] = lambda: {
+            k: v
+            for k, v in DefaultRegistry().convert(context).items()
+            if k not in hidden_keys and not callable(v) and not isinstance(v, ModuleType)
+        }
 
         return super().execute(script or "", context, external_context)
 

--- a/spiff-arena-common/tests/spiff_arena_common/test_runner.py
+++ b/spiff-arena-common/tests/spiff_arena_common/test_runner.py
@@ -54,3 +54,19 @@ def test_advance_workflow_falls_back_to_root_ready_lookup_without_refresh(monkey
     assert root_ready_task.run_calls == 1
     assert next_task_calls == [task, None, root_ready_task, None]
     assert result == {"status": "ok", "error": None, "lazy_loads": []}
+
+
+def test_custom_environment_get_current_task_data_filters_internal_keys():
+    context = {
+        "visible": 1,
+        "__builtins__": {"len": len},
+        "__annotations__": {"visible": int},
+    }
+
+    result = runner.CustomEnvironment().execute(
+        "result = get_current_task_data()",
+        context,
+    )
+
+    assert result is True
+    assert context["result"] == {"visible": 1}

--- a/uv.lock
+++ b/uv.lock
@@ -433,7 +433,7 @@ wheels = [
 
 [[package]]
 name = "spiff-arena-common"
-version = "0.1.27"
+version = "0.1.28"
 source = { editable = "spiff-arena-common" }
 
 [[package]]


### PR DESCRIPTION
Will be used to validate task data against a schema in _test.bpmn files. Forgot to mention, this is a copy of the current script that the backend supports.