### PR TITLE
Patch update KKV data stores

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
@@ -3963,7 +3963,7 @@ paths:
     - name: per_page
       in: query
       required: false
-      description: Number of items per page. Defaults to 100. Set to 0 to return all results without pagination.
+      description: Number of items per page. Defaults to 100.
       schema:
         type: integer
     - name: top_level_key
@@ -3978,6 +3978,13 @@ paths:
       description: Filter KKV entries by secondary key (e.g. process model). Can be used alone or with top_level_key.
       schema:
         type: string
+    - name: paginate
+      in: query
+      required: false
+      description: Defaults to true. Pass false to return all entries unpaginated
+      schema:
+        type: boolean
+        default: true
     get:
       operationId: spiffworkflow_backend.routes.data_store_controller.data_store_item_list
       summary: Returns a paginated list of the contents of a data store.

--- a/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
@@ -3969,13 +3969,13 @@ paths:
     - name: top_level_key
       in: query
       required: false
-      description: Filter KKV entries by top-level key (e.g. process instance ID). Requires a seconday_key.
+      description: Filter KKV entries by top-level key (e.g. process instance ID). Can be used alone or with secondary_key.
       schema:
         type: string
     - name: secondary_key
       in: query
       required: false
-      description: Filter KKV entries by secondary key (e.g. process model). Requires top_level_key.
+      description: Filter KKV entries by secondary key (e.g. process model). Can be used alone or with top_level_key.
       schema:
         type: string
     get:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
@@ -5,7 +5,7 @@ info:
   license:
     name: LGPL
 servers:
-  - url: http://localhost:5000/v1.0
+- url: http://localhost:5000/v1.0
 # this is handled in flask now
 security: []
 
@@ -16,7 +16,7 @@ paths:
       description: Returns information about available authentication methods and configurations for this SpiffWorkflow instance
       operationId: spiffworkflow_backend.routes.authentication_controller.authentication_options
       tags:
-        - Authentication
+      - Authentication
       responses:
         "200":
           description: List of authentication providers
@@ -27,8 +27,8 @@ paths:
                 items:
                   type: object
                   required:
-                    - uri
-                    - identifier
+                  - uri
+                  - identifier
                   properties:
                     uri:
                       type: string
@@ -44,102 +44,102 @@ paths:
                       example: "default"
   /login:
     parameters:
-      - name: authentication_identifier
-        in: query
-        required: true
-        schema:
-          type: string
-      - name: redirect_url
-        in: query
-        required: false
-        schema:
-          type: string
-      - name: process_instance_id
-        in: query
-        required: false
-        schema:
-          type: integer
-      - name: task_guid
-        in: query
-        required: false
-        schema:
-          type: string
+    - name: authentication_identifier
+      in: query
+      required: true
+      schema:
+        type: string
+    - name: redirect_url
+      in: query
+      required: false
+      schema:
+        type: string
+    - name: process_instance_id
+      in: query
+      required: false
+      schema:
+        type: integer
+    - name: task_guid
+      in: query
+      required: false
+      schema:
+        type: string
     get:
       summary: Initiate login flow
       description: Redirects to the authentication server to begin the login process. After successful authentication, the user will be redirected back to the redirect_url or the login_return endpoint.
       operationId: spiffworkflow_backend.routes.authentication_controller.login
       tags:
-        - Authentication
+      - Authentication
       responses:
         "302":
           description: Redirects to authentication server for login
   /login_return:
     parameters:
-      - name: code
-        in: query
-        required: false
-        schema:
-          type: string
-      - name: state
-        in: query
-        required: true
-        schema:
-          type: string
-      - name: session_state
-        in: query
-        required: false
-        schema:
-          type: string
-      - name: error
-        in: query
-        required: false
-        schema:
-          type: string
-      - name: error_description
-        in: query
-        required: false
-        schema:
-          type: string
+    - name: code
+      in: query
+      required: false
+      schema:
+        type: string
+    - name: state
+      in: query
+      required: true
+      schema:
+        type: string
+    - name: session_state
+      in: query
+      required: false
+      schema:
+        type: string
+    - name: error
+      in: query
+      required: false
+      schema:
+        type: string
+    - name: error_description
+      in: query
+      required: false
+      schema:
+        type: string
     get:
       operationId: spiffworkflow_backend.routes.authentication_controller.login_return
       tags:
-        - Authentication
+      - Authentication
       responses:
         "200":
           description: Test Return Response
   /logout:
     parameters:
-      - name: id_token
-        in: query
-        required: true
-        description: The ID token to invalidate
-        schema:
-          type: string
-      - name: redirect_url
-        in: query
-        required: false
-        description: URL to redirect to after logout
-        schema:
-          type: string
-      - name: authentication_identifier
-        in: query
-        required: true
-        description: Identifier of the authentication method being used
-        schema:
-          type: string
-      - name: backend_only
-        in: query
-        required: false
-        description: If true, only logout from the backend without redirecting to the authentication server
-        schema:
-          type: boolean
-          default: false
+    - name: id_token
+      in: query
+      required: true
+      description: The ID token to invalidate
+      schema:
+        type: string
+    - name: redirect_url
+      in: query
+      required: false
+      description: URL to redirect to after logout
+      schema:
+        type: string
+    - name: authentication_identifier
+      in: query
+      required: true
+      description: Identifier of the authentication method being used
+      schema:
+        type: string
+    - name: backend_only
+      in: query
+      required: false
+      description: If true, only logout from the backend without redirecting to the authentication server
+      schema:
+        type: boolean
+        default: false
     get:
       operationId: spiffworkflow_backend.routes.authentication_controller.logout
       summary: Logout authenticated user
       description: Logs out the user and optionally redirects to the authentication server's logout endpoint
       tags:
-        - Authentication
+      - Authentication
       responses:
         "302":
           description: Redirects to authentication server logout or redirect_url
@@ -150,28 +150,28 @@ paths:
       operationId: spiffworkflow_backend.routes.authentication_controller.logout_return
       summary: Logout authenticated user
       tags:
-        - Authentication
+      - Authentication
       responses:
         "200":
           description: Logout Authenticated User
 
   /login_with_access_token:
     parameters:
-      - name: access_token
-        in: query
-        required: true
-        schema:
-          type: string
-      - name: authentication_identifier
-        in: query
-        required: true
-        schema:
-          type: string
+    - name: access_token
+      in: query
+      required: true
+      schema:
+        type: string
+    - name: authentication_identifier
+      in: query
+      required: true
+      schema:
+        type: string
     post:
       operationId: spiffworkflow_backend.routes.authentication_controller.login_with_access_token
       summary: Authenticate user for API access with an openid token already posessed.
       tags:
-        - Authentication
+      - Authentication
       responses:
         "200":
           description: "Returns ok: true if user successfully logged in."
@@ -185,7 +185,7 @@ paths:
       operationId: spiffworkflow_backend.routes.script_assist_controller.enabled
       summary: Returns value of SCRIPT_ASSIST_ENABLED
       tags:
-        - AI Tools
+      - AI Tools
       responses:
         "200":
           description: Returns if AI script should be enabled in UI
@@ -199,7 +199,7 @@ paths:
       operationId: spiffworkflow_backend.routes.script_assist_controller.process_message
       summary: Send natural language message in for processing by AI service
       tags:
-        - AI Tools
+      - AI Tools
       requestBody:
         required: true
         content:
@@ -223,8 +223,8 @@ paths:
       summary: Returns server status and frontend access permission
       description: Checks if the server is running and whether the current user (if authenticated) has permission to access the frontend
       tags:
-        - Liveness
-        - Status
+      - Liveness
+      - Status
       responses:
         "200":
           description: Server is running with status information
@@ -233,8 +233,8 @@ paths:
               schema:
                 type: object
                 required:
-                  - ok
-                  - can_access_frontend
+                - ok
+                - can_access_frontend
                 properties:
                   ok:
                     type: boolean
@@ -250,7 +250,7 @@ paths:
       operationId: spiffworkflow_backend.routes.debug_controller.test_raise_error
       summary: Returns an unhandled exception that should notify sentry, if sentry is configured
       tags:
-        - Status
+      - Status
       responses:
         "500":
           description: The server raises a test error as expected.
@@ -264,7 +264,7 @@ paths:
       operationId: spiffworkflow_backend.routes.debug_controller.url_info
       summary: Returns information about the url of the application
       tags:
-        - Status
+      - Status
       responses:
         "200":
           description: Returns url info
@@ -278,7 +278,7 @@ paths:
       operationId: spiffworkflow_backend.routes.debug_controller.version_info
       summary: Returns information about the version of the application
       tags:
-        - Status
+      - Status
       responses:
         "200":
           description: Returns version info if it exists.
@@ -292,7 +292,7 @@ paths:
       operationId: spiffworkflow_backend.routes.debug_controller.process_instance_with_most_tasks
       summary: Returns the process instance with the most tasks and the count
       tags:
-        - Status
+      - Status
       responses:
         "200":
           description: Returns process instance ID and task count.
@@ -303,21 +303,21 @@ paths:
 
   /debug/celery-backend-results/{process_instance_id}:
     parameters:
-      - name: process_instance_id
-        in: path
-        required: true
-        schema:
-          type: integer
-      - name: include_all_failures
-        in: query
-        required: false
-        schema:
-          type: boolean
+    - name: process_instance_id
+      in: path
+      required: true
+      schema:
+        type: integer
+    - name: include_all_failures
+      in: query
+      required: false
+      schema:
+        type: boolean
     get:
       operationId: spiffworkflow_backend.routes.debug_controller.celery_backend_results
       summary: Returns the results from the celery backend for a process instance
       tags:
-        - Status
+      - Status
       responses:
         "200":
           description: Returns results.
@@ -331,7 +331,7 @@ paths:
       operationId: spiffworkflow_backend.routes.onboarding_controller.get_onboarding
       summary: Returns information about the next onboarding to show
       tags:
-        - Status
+      - Status
       responses:
         "200":
           description: Returns info about the next onboarding to show if it exists.
@@ -342,15 +342,15 @@ paths:
 
   /active-users/updates/{last_visited_identifier}:
     parameters:
-      - name: last_visited_identifier
-        in: path
-        required: true
-        description: The identifier for the last visited page for the user.
-        schema:
-          type: string
+    - name: last_visited_identifier
+      in: path
+      required: true
+      description: The identifier for the last visited page for the user.
+      schema:
+        type: string
     post:
       tags:
-        - Active User
+      - Active User
       operationId: spiffworkflow_backend.routes.active_users_controller.active_user_updates
       summary: An SSE (Server Sent Events) endpoint that returns what users are also currently viewing the same page as you.
       responses:
@@ -365,15 +365,15 @@ paths:
 
   /active-users/unregister/{last_visited_identifier}:
     parameters:
-      - name: last_visited_identifier
-        in: path
-        required: true
-        description: The identifier for the last visited page for the user.
-        schema:
-          type: string
+    - name: last_visited_identifier
+      in: path
+      required: true
+      description: The identifier for the last visited page for the user.
+      schema:
+        type: string
     post:
       tags:
-        - Active User
+      - Active User
       operationId: spiffworkflow_backend.routes.active_users_controller.active_user_unregister
       summary: Unregisters a user from a page. To be used when the /active-users/updates endpoint is closed.
       responses:
@@ -386,35 +386,35 @@ paths:
 
   /process-groups:
     parameters:
-      - name: process_group_identifier
-        in: query
-        required: false
-        description: Optional parameter to filter by a single group
-        schema:
-          type: string
-      - name: filter_runnable_by_user
-        in: query
-        required: false
-        description: Get only the process models that the user can run
-        schema:
-          type: boolean
-      - name: page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
-      - name: per_page
-        in: query
-        required: false
-        description: The number of groups to show per page. Defaults to 10.
-        schema:
-          type: integer
+    - name: process_group_identifier
+      in: query
+      required: false
+      description: Optional parameter to filter by a single group
+      schema:
+        type: string
+    - name: filter_runnable_by_user
+      in: query
+      required: false
+      description: Get only the process models that the user can run
+      schema:
+        type: boolean
+    - name: page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
+    - name: per_page
+      in: query
+      required: false
+      description: The number of groups to show per page. Defaults to 10.
+      schema:
+        type: integer
     get:
       operationId: spiffworkflow_backend.routes.process_groups_controller.process_group_list
       summary: get list
       tags:
-        - Process Groups
+      - Process Groups
       responses:
         "200":
           description: An array of process groups
@@ -428,7 +428,7 @@ paths:
       operationId: spiffworkflow_backend.routes.process_groups_controller.process_group_create
       summary: Add process group
       tags:
-        - Process Groups
+      - Process Groups
       requestBody:
         required: true
         content:
@@ -445,18 +445,18 @@ paths:
 
   /process-groups/{modified_process_group_id}:
     parameters:
-      - name: modified_process_group_id
-        in: path
-        required: true
-        description: The unique id of an existing process group.
-        schema:
-          type: string
+    - name: modified_process_group_id
+      in: path
+      required: true
+      description: The unique id of an existing process group.
+      schema:
+        type: string
     # process_group_show
     get:
       operationId: spiffworkflow_backend.routes.process_groups_controller.process_group_show
       summary: Returns a single process group
       tags:
-        - Process Groups
+      - Process Groups
       responses:
         "200":
           description: Processs Group.
@@ -468,7 +468,7 @@ paths:
       operationId: spiffworkflow_backend.routes.process_groups_controller.process_group_delete
       summary: Deletes a single process group
       tags:
-        - Process Groups
+      - Process Groups
       responses:
         "200":
           description: The process group was deleted.
@@ -476,7 +476,7 @@ paths:
       operationId: spiffworkflow_backend.routes.process_groups_controller.process_group_update
       summary: Updates a single process group
       tags:
-        - Process Groups
+      - Process Groups
       requestBody:
         required: true
         content:
@@ -493,23 +493,23 @@ paths:
 
   /process-groups/{modified_process_group_identifier}/move:
     parameters:
-      - name: modified_process_group_identifier
-        in: path
-        required: true
-        description: The unique id of an existing process group.
-        schema:
-          type: string
-      - name: new_location
-        in: query
-        required: true
-        description: the new location, as an existing process group id
-        schema:
-          type: string
+    - name: modified_process_group_identifier
+      in: path
+      required: true
+      description: The unique id of an existing process group.
+      schema:
+        type: string
+    - name: new_location
+      in: query
+      required: true
+      description: the new location, as an existing process group id
+      schema:
+        type: string
     put:
       operationId: spiffworkflow_backend.routes.process_groups_controller.process_group_move
       summary: returns the new group
       tags:
-        - Process Groups
+      - Process Groups
       responses:
         "200":
           description: Process Group
@@ -520,17 +520,17 @@ paths:
 
   /upsearch-locations:
     parameters:
-      - name: location
-        in: query
-        required: false
-        description: The location to perform the upsearch
-        schema:
-          type: string
+    - name: location
+      in: query
+      required: false
+      description: The location to perform the upsearch
+      schema:
+        type: string
     get:
       operationId: spiffworkflow_backend.routes.upsearch_controller.upsearch_locations
       summary: Returns upsearch locations for the given location
       tags:
-        - Upsearch
+      - Upsearch
       responses:
         "200":
           description: Upsearch Locations.
@@ -541,53 +541,53 @@ paths:
 
   /process-models:
     parameters:
-      - name: process_group_identifier
-        in: query
-        required: false
-        description: The group containing the models we want to return
-        schema:
-          type: string
-      - name: recursive
-        in: query
-        required: false
-        description: Get all sub process models recursively if true
-        schema:
-          type: boolean
-      - name: filter_runnable_by_user
-        in: query
-        required: false
-        description: Get only the process models that the user can run
-        schema:
-          type: boolean
-      - name: include_parent_groups
-        in: query
-        required: false
-        description: Get the display names for the parent groups as well
-        schema:
-          type: boolean
-      - name: group_by_process_group
-        in: query
-        required: false
-        description: Returns a list of process_groups instead which include the process models. Useful alongside filter_runnable_by_user.
-        schema:
-          type: boolean
-      - name: page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
-      - name: per_page
-        in: query
-        required: false
-        description: The number of models to show per page. Defaults to 10.
-        schema:
-          type: integer
+    - name: process_group_identifier
+      in: query
+      required: false
+      description: The group containing the models we want to return
+      schema:
+        type: string
+    - name: recursive
+      in: query
+      required: false
+      description: Get all sub process models recursively if true
+      schema:
+        type: boolean
+    - name: filter_runnable_by_user
+      in: query
+      required: false
+      description: Get only the process models that the user can run
+      schema:
+        type: boolean
+    - name: include_parent_groups
+      in: query
+      required: false
+      description: Get the display names for the parent groups as well
+      schema:
+        type: boolean
+    - name: group_by_process_group
+      in: query
+      required: false
+      description: Returns a list of process_groups instead which include the process models. Useful alongside filter_runnable_by_user.
+      schema:
+        type: boolean
+    - name: page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
+    - name: per_page
+      in: query
+      required: false
+      description: The number of models to show per page. Defaults to 10.
+      schema:
+        type: integer
     get:
       operationId: spiffworkflow_backend.routes.process_models_controller.process_model_list
       summary: Return a list of process models for a given process group
       tags:
-        - Process Models
+      - Process Models
       responses:
         "200":
           description: Successfully return the requested models
@@ -600,17 +600,17 @@ paths:
 
   /process-models/{modified_process_group_id}:
     parameters:
-      - name: modified_process_group_id
-        in: path
-        required: true
-        description: modified id of an existing process group
-        schema:
-          type: string
+    - name: modified_process_group_id
+      in: path
+      required: true
+      description: modified id of an existing process group
+      schema:
+        type: string
     post:
       operationId: spiffworkflow_backend.routes.process_models_controller.process_model_create
       summary: Creates a new process model with the given parameters.
       tags:
-        - Process Models
+      - Process Models
       requestBody:
         required: true
         content:
@@ -627,17 +627,17 @@ paths:
 
   /process-models/{modified_process_model_identifier}/copy:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: the modified process model id
-        schema:
-          type: string
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: the modified process model id
+      schema:
+        type: string
     post:
       operationId: spiffworkflow_backend.routes.process_models_controller.process_model_copy
       summary: Creates a new process model with the given parameters.
       tags:
-        - Process Models
+      - Process Models
       requestBody:
         required: true
         content:
@@ -654,17 +654,17 @@ paths:
 
   /process-model-natural-language/{modified_process_group_id}:
     parameters:
-      - name: modified_process_group_id
-        in: path
-        required: true
-        description: modified id of an existing process group
-        schema:
-          type: string
+    - name: modified_process_group_id
+      in: path
+      required: true
+      description: modified id of an existing process group
+      schema:
+        type: string
     post:
       operationId: spiffworkflow_backend.routes.process_models_controller.process_model_create_with_natural_language
       summary: Creates a new process model with the given parameters.
       tags:
-        - Process Models
+      - Process Models
       requestBody:
         required: true
         content:
@@ -681,17 +681,17 @@ paths:
 
   /process-model-import/{modified_process_group_id}:
     parameters:
-      - name: modified_process_group_id
-        in: path
-        required: true
-        description: modified id of an existing process group
-        schema:
-          type: string
+    - name: modified_process_group_id
+      in: path
+      required: true
+      description: modified id of an existing process group
+      schema:
+        type: string
     post:
       operationId: spiffworkflow_backend.routes.process_model_import_controller.process_model_import
       summary: Import a process model from a GitHub URL
       tags:
-        - Process Models
+      - Process Models
       requestBody:
         required: true
         content:
@@ -699,7 +699,7 @@ paths:
             schema:
               type: object
               required:
-                - repository_url
+              - repository_url
               properties:
                 repository_url:
                   type: string
@@ -721,29 +721,29 @@ paths:
 
   /process-model-tests/run/{modified_process_model_identifier}:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The process_model_id, modified to replace slashes (/)
-        schema:
-          type: string
-      - name: test_case_file
-        in: query
-        required: false
-        description: The name of the test case file to run
-        schema:
-          type: string
-      - name: test_case_identifier
-        in: query
-        required: false
-        description: The name of the test case file to run
-        schema:
-          type: string
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The process_model_id, modified to replace slashes (/)
+      schema:
+        type: string
+    - name: test_case_file
+      in: query
+      required: false
+      description: The name of the test case file to run
+      schema:
+        type: string
+    - name: test_case_identifier
+      in: query
+      required: false
+      description: The name of the test case file to run
+      schema:
+        type: string
     post:
       operationId: spiffworkflow_backend.routes.process_models_controller.process_model_test_run
       summary: Run a test for a process model
       tags:
-        - Process Model Tests
+      - Process Model Tests
       responses:
         "200":
           description: Test results
@@ -754,23 +754,23 @@ paths:
 
   /process-model-tests/create/{modified_process_model_identifier}:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The process_model_id, modified to replace slashes (/)
-        schema:
-          type: string
-      - name: test_case_identifier
-        in: query
-        required: false
-        description: The name of the test case file to run
-        schema:
-          type: string
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The process_model_id, modified to replace slashes (/)
+      schema:
+        type: string
+    - name: test_case_identifier
+      in: query
+      required: false
+      description: The name of the test case file to run
+      schema:
+        type: string
     post:
       operationId: spiffworkflow_backend.routes.process_models_controller.process_model_test_generate
       summary: Create a bpmn unit test from a process instance
       tags:
-        - Process Model Tests
+      - Process Model Tests
       requestBody:
         required: true
         content:
@@ -796,17 +796,17 @@ paths:
 
   /process-models/{modified_process_model_identifier}/files:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The process_model_id, modified to replace slashes (/)
-        schema:
-          type: string
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The process_model_id, modified to replace slashes (/)
+      schema:
+        type: string
     post:
       operationId: spiffworkflow_backend.routes.process_models_controller.process_model_file_create
       summary: Add a new workflow spec file
       tags:
-        - Process Model Files
+      - Process Model Files
       requestBody:
         content:
           multipart/form-data:
@@ -826,23 +826,23 @@ paths:
 
   /process-models/{modified_process_model_identifier}:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: the modified process model id
-        schema:
-          type: string
-      - name: include_file_references
-        in: query
-        required: false
-        description: include all file references in the return
-        schema:
-          type: boolean
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: the modified process model id
+      schema:
+        type: string
+    - name: include_file_references
+      in: query
+      required: false
+      description: include all file references in the return
+      schema:
+        type: boolean
     get:
       operationId: spiffworkflow_backend.routes.process_models_controller.process_model_show
       summary: Returns a single process model
       tags:
-        - Process Models
+      - Process Models
       responses:
         "200":
           description: Workflow spec.
@@ -854,7 +854,7 @@ paths:
       operationId: spiffworkflow_backend.routes.process_models_controller.process_model_update
       summary: Modifies an existing process model with the given parameters.
       tags:
-        - Process Models
+      - Process Models
       requestBody:
         required: true
         content:
@@ -872,7 +872,7 @@ paths:
       operationId: spiffworkflow_backend.routes.process_models_controller.process_model_delete
       summary: Removes an existing process model
       tags:
-        - Process Models
+      - Process Models
       responses:
         "200":
           description: The process model has been removed.
@@ -883,23 +883,23 @@ paths:
 
   /process-models/{modified_process_model_identifier}/move:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: the modified process model id
-        schema:
-          type: string
-      - name: new_location
-        in: query
-        required: true
-        description: the new location for the process model, as a process group id
-        schema:
-          type: string
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: the modified process model id
+      schema:
+        type: string
+    - name: new_location
+      in: query
+      required: true
+      description: the new location for the process model, as a process group id
+      schema:
+        type: string
     put:
       operationId: spiffworkflow_backend.routes.process_models_controller.process_model_move
       summary: returns the new model
       tags:
-        - Process Models
+      - Process Models
       responses:
         "200":
           description: Process Model
@@ -910,23 +910,23 @@ paths:
 
   /process-model-publish/{modified_process_model_identifier}:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: the modified process model id
-        schema:
-          type: string
-      - name: branch_to_update
-        in: query
-        required: false
-        description: the name of the branch we want to merge into
-        schema:
-          type: string
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: the modified process model id
+      schema:
+        type: string
+    - name: branch_to_update
+      in: query
+      required: false
+      description: the name of the branch we want to merge into
+      schema:
+        type: string
     post:
       operationId: spiffworkflow_backend.routes.process_models_controller.process_model_publish
       summary: Merge changes from this model to another branch.
       tags:
-        - Process Models
+      - Process Models
       responses:
         "200":
           description: The process model was published.
@@ -937,20 +937,20 @@ paths:
 
   /processes/callers/{bpmn_process_identifiers}:
     parameters:
-      - name: bpmn_process_identifiers
-        in: path
-        required: true
-        description: the bpmn process identifiers/ids (not the names with spaces and not the process model identifiers)
-        schema:
-          type: array
-          items:
-            type: string
-          minItems: 1
+    - name: bpmn_process_identifiers
+      in: path
+      required: true
+      description: the bpmn process identifiers/ids (not the names with spaces and not the process model identifiers)
+      schema:
+        type: array
+        items:
+          type: string
+        minItems: 1
     get:
       operationId: spiffworkflow_backend.routes.process_api_blueprint.process_caller_list
       summary: Return a list of information about all processes that call the provided process id
       tags:
-        - Process Models
+      - Process Models
       responses:
         "200":
           description: Successfully return the requested calling processes
@@ -967,7 +967,7 @@ paths:
       summary: Return a list of all processes (not just primary process of a process model)
       description: Returns all BPMN process definitions from all process models. Useful for finding processes for call activities.
       tags:
-        - Process Models
+      - Process Models
       responses:
         "200":
           description: Array of BPMN process definitions
@@ -977,23 +977,23 @@ paths:
                 type: array
                 items:
                   allOf:
-                    - $ref: "#/components/schemas/Process"
-                    - type: object
+                  - $ref: "#/components/schemas/Process"
+                  - type: object
+                    properties:
+                      relative_location:
+                        type: string
+                        description: The process group location relative to root
+                        example: "misc/qa/bpmn-model-testing"
                       properties:
-                        relative_location:
-                          type: string
-                          description: The process group location relative to root
-                          example: "misc/qa/bpmn-model-testing"
+                        type: object
+                        description: Additional process properties
                         properties:
-                          type: object
-                          description: Additional process properties
-                          properties:
-                            has_lanes:
-                              type: boolean
-                            is_primary:
-                              type: boolean
-                            is_executable:
-                              type: boolean
+                          has_lanes:
+                            type: boolean
+                          is_primary:
+                            type: boolean
+                          is_executable:
+                            type: boolean
 
   /github-webhook-receive:
     post:
@@ -1006,7 +1006,7 @@ paths:
             schema:
               $ref: "#/components/schemas/AwesomeUnspecifiedPayload"
       tags:
-        - git
+      - git
       responses:
         "200":
           description: Success
@@ -1026,7 +1026,7 @@ paths:
             schema:
               $ref: "#/components/schemas/AwesomeUnspecifiedPayload"
       tags:
-        - git
+      - git
       responses:
         "200":
           description: Success
@@ -1037,29 +1037,29 @@ paths:
 
   /process-instances/for-me:
     parameters:
-      - name: process_model_identifier
-        in: query
-        required: false
-        description: The unique id of an existing process model.
-        schema:
-          type: string
-      - name: page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
-      - name: per_page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
+    - name: process_model_identifier
+      in: query
+      required: false
+      description: The unique id of an existing process model.
+      schema:
+        type: string
+    - name: page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
+    - name: per_page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
     post:
       operationId: spiffworkflow_backend.routes.process_instances_controller.process_instance_list_for_me
       summary: Returns a list of process instances that are associated with me.
       tags:
-        - Process Instances
+      - Process Instances
       requestBody:
         description: Report dictionary to use.
         required: true
@@ -1071,7 +1071,7 @@ paths:
                 report_metadata:
                   $ref: "#/components/schemas/ReportMetadata"
               required:
-                - report_metadata
+              - report_metadata
       responses:
         "200":
           description: Process instances matching the report criteria.
@@ -1094,29 +1094,29 @@ paths:
 
   /process-instances:
     parameters:
-      - name: process_model_identifier
-        in: query
-        required: false
-        description: The unique id of an existing process model.
-        schema:
-          type: string
-      - name: page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
-      - name: per_page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
+    - name: process_model_identifier
+      in: query
+      required: false
+      description: The unique id of an existing process model.
+      schema:
+        type: string
+    - name: page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
+    - name: per_page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
     post:
       operationId: spiffworkflow_backend.routes.process_instances_controller.process_instance_list
       summary: Returns a list of process instances.
       tags:
-        - Process Instances
+      - Process Instances
       requestBody:
         description: Report dictionary to use.
         required: true
@@ -1128,7 +1128,7 @@ paths:
                 report_metadata:
                   $ref: "#/components/schemas/ReportMetadata"
               required:
-                - report_metadata
+              - report_metadata
       responses:
         "200":
           description: Process instances matching the report criteria.
@@ -1155,7 +1155,7 @@ paths:
       summary: Returns the list of available extensions
       description: Gets all process models configured as extensions, including their files and UI schema definitions
       tags:
-        - Extensions
+      - Extensions
       responses:
         "200":
           description: Array of extension process models with file contents
@@ -1168,17 +1168,17 @@ paths:
 
   /extensions/{modified_process_model_identifier}:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The unique id of an existing process model.
-        schema:
-          type: string
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The unique id of an existing process model.
+      schema:
+        type: string
     get:
       operationId: spiffworkflow_backend.routes.extensions_controller.extension_show
       summary: Returns the metadata for a given extension
       tags:
-        - Extensions
+      - Extensions
       responses:
         "200":
           description: Resulting extension metadata
@@ -1190,7 +1190,7 @@ paths:
       operationId: spiffworkflow_backend.routes.extensions_controller.extension_run
       summary: Run an extension for a given process model
       tags:
-        - Extensions
+      - Extensions
       requestBody:
         required: false
         content:
@@ -1208,18 +1208,18 @@ paths:
 
   /extensions-get-data/{query_params}:
     parameters:
-      - name: query_params
-        in: path
-        required: true
-        description: The params required to run the extension. The first parameter must be the modified_process_model_identifier of the extension to run.
-        schema:
-          type: string
-          format: path
+    - name: query_params
+      in: path
+      required: true
+      description: The params required to run the extension. The first parameter must be the modified_process_model_identifier of the extension to run.
+      schema:
+        type: string
+        format: path
     get:
       operationId: spiffworkflow_backend.routes.extensions_controller.extension_get_data
       summary: Returns the metadata for a given extension
       tags:
-        - Extensions
+      - Extensions
       responses:
         "200":
           description: Resulting extension metadata
@@ -1230,24 +1230,24 @@ paths:
 
   /process-models/{modified_process_model_identifier}/script-unit-tests:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The unique id of an existing process model.
-        schema:
-          type: string
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The unique id of an existing process model.
+      schema:
+        type: string
     post:
       operationId: spiffworkflow_backend.routes.script_unit_tests_controller.script_unit_test_create
       summary: Create script unit test based on given criteria
       tags:
-        - Script Unit Test
+      - Script Unit Test
       requestBody:
         required: true
         content:
           application/json:
             schema:
               required:
-                - bpmn_task_identifier
+              - bpmn_task_identifier
               properties:
                 bpmn_task_identifier:
                   type: string
@@ -1279,17 +1279,17 @@ paths:
 
   /process-models/{modified_process_model_identifier}/script-unit-tests/run:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The unique id of an existing process model.
-        schema:
-          type: string
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The unique id of an existing process model.
+      schema:
+        type: string
     post:
       operationId: spiffworkflow_backend.routes.script_unit_tests_controller.script_unit_test_run
       summary: Run a given script unit test.
       tags:
-        - Script Unit Test
+      - Script Unit Test
       requestBody:
         required: true
         content:
@@ -1306,17 +1306,17 @@ paths:
 
   /process-instances/{modified_process_model_identifier}:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The unique id of an existing process model.
-        schema:
-          type: string
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The unique id of an existing process model.
+      schema:
+        type: string
     post:
       operationId: spiffworkflow_backend.routes.process_instances_controller.process_instance_create
       summary: Creates an process instance from a process model and returns the instance
       tags:
-        - Process Instances
+      - Process Instances
       requestBody:
         # this call does not actually need a body, but the lack of requestBody causes connexion
         # to mess up and not pass bodies through where it's supposed to, such as a POST to /process-instances/reports.
@@ -1327,7 +1327,7 @@ paths:
             schema:
               nullable: true
               allOf:
-                - $ref: "#/components/schemas/AwesomeUnspecifiedPayload"
+              - $ref: "#/components/schemas/AwesomeUnspecifiedPayload"
       responses:
         "201":
           description: Workflow generated successfully
@@ -1338,45 +1338,45 @@ paths:
 
   /process-instances/for-me/{modified_process_model_identifier}/{process_instance_id}/task-info:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The unique id of an existing process model
-        schema:
-          type: string
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of an existing process instance.
-        schema:
-          type: integer
-      - name: process_identifier
-        in: query
-        required: false
-        description: The identifier of the process to use for the diagram. Useful for displaying the diagram for a call activity.
-        schema:
-          type: string
-      - name: most_recent_tasks_only
-        in: query
-        required: false
-        description: If true, this wil return only the most recent tasks.
-        schema:
-          type: boolean
-      - name: bpmn_process_guid
-        in: query
-        required: false
-        description: The guid of the bpmn process to get the tasks for.
-        schema:
-          type: string
-      - name: to_task_guid
-        in: query
-        required: false
-        description: Get the tasks only up to the given guid.
-        schema:
-          type: string
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The unique id of an existing process model
+      schema:
+        type: string
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of an existing process instance.
+      schema:
+        type: integer
+    - name: process_identifier
+      in: query
+      required: false
+      description: The identifier of the process to use for the diagram. Useful for displaying the diagram for a call activity.
+      schema:
+        type: string
+    - name: most_recent_tasks_only
+      in: query
+      required: false
+      description: If true, this wil return only the most recent tasks.
+      schema:
+        type: boolean
+    - name: bpmn_process_guid
+      in: query
+      required: false
+      description: The guid of the bpmn process to get the tasks for.
+      schema:
+        type: string
+    - name: to_task_guid
+      in: query
+      required: false
+      description: Get the tasks only up to the given guid.
+      schema:
+        type: string
     get:
       tags:
-        - Process Instances
+      - Process Instances
       operationId: spiffworkflow_backend.routes.process_instances_controller.process_instance_task_list_without_task_data_for_me
       summary: returns the list of all user tasks associated with process instance without the task data
       responses:
@@ -1391,45 +1391,45 @@ paths:
 
   /process-instances/{modified_process_model_identifier}/{process_instance_id}/task-info:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The unique id of an existing process model
-        schema:
-          type: string
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of an existing process instance.
-        schema:
-          type: integer
-      - name: process_identifier
-        in: query
-        required: false
-        description: The identifier of the process to use for the diagram. Useful for displaying the diagram for a call activity.
-        schema:
-          type: string
-      - name: most_recent_tasks_only
-        in: query
-        required: false
-        description: If true, this wil return only the most recent tasks.
-        schema:
-          type: boolean
-      - name: bpmn_process_guid
-        in: query
-        required: false
-        description: The guid of the bpmn process to get the tasks for.
-        schema:
-          type: string
-      - name: to_task_guid
-        in: query
-        required: false
-        description: Get the tasks only up to the given guid.
-        schema:
-          type: string
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The unique id of an existing process model
+      schema:
+        type: string
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of an existing process instance.
+      schema:
+        type: integer
+    - name: process_identifier
+      in: query
+      required: false
+      description: The identifier of the process to use for the diagram. Useful for displaying the diagram for a call activity.
+      schema:
+        type: string
+    - name: most_recent_tasks_only
+      in: query
+      required: false
+      description: If true, this wil return only the most recent tasks.
+      schema:
+        type: boolean
+    - name: bpmn_process_guid
+      in: query
+      required: false
+      description: The guid of the bpmn process to get the tasks for.
+      schema:
+        type: string
+    - name: to_task_guid
+      in: query
+      required: false
+      description: Get the tasks only up to the given guid.
+      schema:
+        type: string
     get:
       tags:
-        - Process Instances
+      - Process Instances
       operationId: spiffworkflow_backend.routes.process_instances_controller.process_instance_task_list_without_task_data
       summary: returns the list of all user tasks associated with process instance without the task data
       responses:
@@ -1444,27 +1444,27 @@ paths:
 
   /process-instances/for-me/{modified_process_model_identifier}/{process_instance_id}:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The unique id of an existing process model
-        schema:
-          type: string
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of an existing process instance.
-        schema:
-          type: integer
-      - name: process_identifier
-        in: query
-        required: false
-        description: The identifier of the process to use for the diagram. Useful for displaying the diagram for a call activity.
-        schema:
-          type: string
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The unique id of an existing process model
+      schema:
+        type: string
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of an existing process instance.
+      schema:
+        type: integer
+    - name: process_identifier
+      in: query
+      required: false
+      description: The identifier of the process to use for the diagram. Useful for displaying the diagram for a call activity.
+      schema:
+        type: string
     get:
       tags:
-        - Process Instances
+      - Process Instances
       operationId: spiffworkflow_backend.routes.process_instances_controller.process_instance_show_for_me
       summary: Show information about a process instance that is associated with me
       responses:
@@ -1477,17 +1477,17 @@ paths:
 
   /process-instances/find-by-id/{process_instance_id}:
     parameters:
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of an existing process instance.
-        schema:
-          type: integer
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of an existing process instance.
+      schema:
+        type: integer
     get:
       operationId: spiffworkflow_backend.routes.process_instances_controller.process_instance_find_by_id
       summary: Find a process instance based on its id only
       tags:
-        - Process Instances
+      - Process Instances
       responses:
         "200":
           description: One Process Instance
@@ -1498,27 +1498,27 @@ paths:
 
   /process-instances/{modified_process_model_identifier}/{process_instance_id}:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The unique id of an existing process model
-        schema:
-          type: string
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of an existing process instance.
-        schema:
-          type: integer
-      - name: process_identifier
-        in: query
-        required: false
-        description: The identifier of the process to use for the diagram. Useful for displaying the diagram for a call activity.
-        schema:
-          type: string
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The unique id of an existing process model
+      schema:
+        type: string
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of an existing process instance.
+      schema:
+        type: integer
+    - name: process_identifier
+      in: query
+      required: false
+      description: The identifier of the process to use for the diagram. Useful for displaying the diagram for a call activity.
+      schema:
+        type: string
     get:
       tags:
-        - Process Instances
+      - Process Instances
       operationId: spiffworkflow_backend.routes.process_instances_controller.process_instance_show
       summary: Show information about a process instance
       responses:
@@ -1532,7 +1532,7 @@ paths:
       operationId: spiffworkflow_backend.routes.process_instances_controller.process_instance_delete
       summary: Deletes a single process instance
       tags:
-        - Process Instances
+      - Process Instances
       responses:
         "200":
           description: The process instance was deleted.
@@ -1543,27 +1543,27 @@ paths:
 
   /process-instances/{modified_process_model_identifier}/{process_instance_id}/check-can-migrate:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The unique id of an existing process model
-        schema:
-          type: string
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of an existing process instance.
-        schema:
-          type: integer
-      - name: target_bpmn_process_hash
-        in: query
-        required: false
-        description: The full bpmn process hash of the target version of the process model.
-        schema:
-          type: string
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The unique id of an existing process model
+      schema:
+        type: string
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of an existing process instance.
+      schema:
+        type: integer
+    - name: target_bpmn_process_hash
+      in: query
+      required: false
+      description: The full bpmn process hash of the target version of the process model.
+      schema:
+        type: string
     get:
       tags:
-        - Process Instances
+      - Process Instances
       operationId: spiffworkflow_backend.routes.process_instances_controller.process_instance_check_can_migrate
       summary: Checks if a given process instance can be migrated to the newest version of the process model.
       responses:
@@ -1581,39 +1581,39 @@ paths:
                     description: Process instance id
   /process-instances/{modified_process_model_identifier}/{process_instance_id}/run:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The modified process model identifyer
-        schema:
-          type: string
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of an existing process instance.
-        schema:
-          type: integer
-      - name: force_run
-        in: query
-        required: false
-        description: Force the process instance to run even if it has already been started.
-        schema:
-          type: boolean
-      - name: execution_mode
-        in: query
-        required: false
-        description: Either run in "synchronous" or "asynchronous" mode.
-        schema:
-          type: string
-          enum:
-            - synchronous
-            - asynchronous
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The modified process model identifyer
+      schema:
+        type: string
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of an existing process instance.
+      schema:
+        type: integer
+    - name: force_run
+      in: query
+      required: false
+      description: Force the process instance to run even if it has already been started.
+      schema:
+        type: boolean
+    - name: execution_mode
+      in: query
+      required: false
+      description: Either run in "synchronous" or "asynchronous" mode.
+      schema:
+        type: string
+        enum:
+        - synchronous
+        - asynchronous
     post:
       operationId: spiffworkflow_backend.routes.process_instances_controller.process_instance_run_deprecated
       summary: DEPRECATED Run a process instance. Use /process-instance-run
       deprecated: true
       tags:
-        - Process Instances
+      - Process Instances
       responses:
         "200":
           description: Returns details about the workflows state and current task
@@ -1624,38 +1624,38 @@ paths:
 
   /process-instance-run/{modified_process_model_identifier}/{process_instance_id}:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The modified process model identifyer
-        schema:
-          type: string
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of an existing process instance.
-        schema:
-          type: integer
-      - name: force_run
-        in: query
-        required: false
-        description: Force the process instance to run even if it has already been started.
-        schema:
-          type: boolean
-      - name: execution_mode
-        in: query
-        required: false
-        description: Either run in "synchronous" or "asynchronous" mode.
-        schema:
-          type: string
-          enum:
-            - synchronous
-            - asynchronous
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The modified process model identifyer
+      schema:
+        type: string
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of an existing process instance.
+      schema:
+        type: integer
+    - name: force_run
+      in: query
+      required: false
+      description: Force the process instance to run even if it has already been started.
+      schema:
+        type: boolean
+    - name: execution_mode
+      in: query
+      required: false
+      description: Either run in "synchronous" or "asynchronous" mode.
+      schema:
+        type: string
+        enum:
+        - synchronous
+        - asynchronous
     post:
       operationId: spiffworkflow_backend.routes.process_instances_controller.process_instance_run
       summary: Run a process instance
       tags:
-        - Process Instances
+      - Process Instances
       responses:
         "200":
           description: Returns details about the workflows state and current task
@@ -1666,23 +1666,23 @@ paths:
 
   /process-instance-terminate/{modified_process_model_identifier}/{process_instance_id}:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The modified process model id
-        schema:
-          type: string
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of an existing process instance.
-        schema:
-          type: integer
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The modified process model id
+      schema:
+        type: string
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of an existing process instance.
+      schema:
+        type: integer
     post:
       operationId: spiffworkflow_backend.routes.process_instances_controller.process_instance_terminate
       summary: Terminate a process instance
       tags:
-        - Process Instances
+      - Process Instances
       responses:
         "200":
           description: Empty ok true response on successful termination.
@@ -1693,23 +1693,23 @@ paths:
 
   /process-instance-suspend/{modified_process_model_identifier}/{process_instance_id}:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The modified process model id
-        schema:
-          type: string
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of an existing process instance.
-        schema:
-          type: integer
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The modified process model id
+      schema:
+        type: string
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of an existing process instance.
+      schema:
+        type: integer
     post:
       operationId: spiffworkflow_backend.routes.process_instances_controller.process_instance_suspend
       summary: Suspend a process instance
       tags:
-        - Process Instances
+      - Process Instances
       responses:
         "200":
           description: Empty ok true response on successful suspension.
@@ -1720,23 +1720,23 @@ paths:
 
   /process-instance-resume/{modified_process_model_identifier}/{process_instance_id}:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The modified process model id
-        schema:
-          type: string
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of an existing process instance.
-        schema:
-          type: integer
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The modified process model id
+      schema:
+        type: string
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of an existing process instance.
+      schema:
+        type: integer
     post:
       operationId: spiffworkflow_backend.routes.process_instances_controller.process_instance_resume
       summary: Resume a process instance
       tags:
-        - Process Instances
+      - Process Instances
       responses:
         "200":
           description: Empty ok true response on successful resume.
@@ -1747,29 +1747,29 @@ paths:
 
   /process-instance-reset/{modified_process_model_identifier}/{process_instance_id}/{to_task_guid}:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The modified process model id
-        schema:
-          type: string
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of an existing process instance.
-        schema:
-          type: integer
-      - name: to_task_guid
-        in: path
-        required: true
-        description: Get the tasks only up to the given guid.
-        schema:
-          type: string
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The modified process model id
+      schema:
+        type: string
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of an existing process instance.
+      schema:
+        type: integer
+    - name: to_task_guid
+      in: path
+      required: true
+      description: Get the tasks only up to the given guid.
+      schema:
+        type: string
     post:
       operationId: spiffworkflow_backend.routes.process_instances_controller.process_instance_reset
       summary: Reset a process instance to an earlier step
       tags:
-        - Process Instances
+      - Process Instances
       responses:
         "200":
           description: Empty ok true response on successful reset.
@@ -1780,29 +1780,29 @@ paths:
 
   /process-instance-migrate/{modified_process_model_identifier}/{process_instance_id}:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The modified process model id
-        schema:
-          type: string
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of an existing process instance.
-        schema:
-          type: integer
-      - name: target_bpmn_process_hash
-        in: query
-        required: false
-        description: The full bpmn process hash of the target version of the process model.
-        schema:
-          type: string
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The modified process model id
+      schema:
+        type: string
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of an existing process instance.
+      schema:
+        type: integer
+    - name: target_bpmn_process_hash
+      in: query
+      required: false
+      description: The full bpmn process hash of the target version of the process model.
+      schema:
+        type: string
     post:
       operationId: spiffworkflow_backend.routes.process_instances_controller.process_instance_migrate
       summary: Migrate a process instance to the new version of its process model.
       tags:
-        - Process Instances
+      - Process Instances
       responses:
         "200":
           description: Empty ok true response on successful reset.
@@ -1813,24 +1813,24 @@ paths:
 
   /process-instances/reports:
     parameters:
-      - name: page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
-      - name: per_page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
+    - name: page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
+    - name: per_page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
     get:
       operationId: spiffworkflow_backend.routes.process_instances_controller.process_instance_report_list
       summary: Returns all process instance reports for process model
       tags:
-        - Process Instances
-        - Process Instances Reports
+      - Process Instances
+      - Process Instances Reports
       responses:
         "200":
           description: Process Instance Report
@@ -1844,7 +1844,7 @@ paths:
       operationId: spiffworkflow_backend.routes.process_instances_controller.process_instance_report_create
       summary: Returns all process instance reports for process model
       tags:
-        - Process Instances
+      - Process Instances
       requestBody:
         required: true
         content:
@@ -1861,17 +1861,17 @@ paths:
 
   /process-instances/reports/columns:
     parameters:
-      - name: process_model_identifier
-        in: query
-        required: false
-        description: The process model identifier to filter by
-        schema:
-          type: string
+    - name: process_model_identifier
+      in: query
+      required: false
+      description: The process model identifier to filter by
+      schema:
+        type: string
     get:
       operationId: spiffworkflow_backend.routes.process_instances_controller.process_instance_report_column_list
       summary: Returns all available columns for a process instance report, including custom metadata
       tags:
-        - Process Instances
+      - Process Instances
       responses:
         "200":
           description: Available columns for process instance reports.
@@ -1884,29 +1884,29 @@ paths:
 
   /process-instances/report-metadata:
     parameters:
-      - name: report_hash
-        in: query
-        required: false
-        description: The hash of a query that has been searched before.
-        schema:
-          type: string
-      - name: report_id
-        in: query
-        required: false
-        description: The unique id of an existing report.
-        schema:
-          type: integer
-      - name: report_identifier
-        in: query
-        required: false
-        description: Specifies the identifier of a report to use, if any
-        schema:
-          type: string
+    - name: report_hash
+      in: query
+      required: false
+      description: The hash of a query that has been searched before.
+      schema:
+        type: string
+    - name: report_id
+      in: query
+      required: false
+      description: The unique id of an existing report.
+      schema:
+        type: integer
+    - name: report_identifier
+      in: query
+      required: false
+      description: Specifies the identifier of a report to use, if any
+      schema:
+        type: string
     get:
       operationId: spiffworkflow_backend.routes.process_instances_controller.process_instance_report_show
       summary: Returns the metadata associated with a given report key. This favors report_hash over report_id and report_identifier.
       tags:
-        - Process Instances
+      - Process Instances
       responses:
         "200":
           description: Returns the report metadata.
@@ -1917,29 +1917,29 @@ paths:
 
   /process-instances/reports/{report_id}:
     parameters:
-      - name: report_id
-        in: path
-        required: true
-        description: The unique id of an existing report
-        schema:
-          type: integer
-      - name: page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
-      - name: per_page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
+    - name: report_id
+      in: path
+      required: true
+      description: The unique id of an existing report
+      schema:
+        type: integer
+    - name: page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
+    - name: per_page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
     put:
       operationId: spiffworkflow_backend.routes.process_instances_controller.process_instance_report_update
       summary: Updates a process instance report
       tags:
-        - Process Instances
+      - Process Instances
       responses:
         "200":
           description: The process instance report was updated.
@@ -1951,7 +1951,7 @@ paths:
       operationId: spiffworkflow_backend.routes.process_instances_controller.process_instance_report_delete
       summary: Delete a process instance report
       tags:
-        - Process Instances
+      - Process Instances
       responses:
         "200":
           description: The process instance report was delete.
@@ -1965,7 +1965,7 @@ paths:
       operationId: spiffworkflow_backend.routes.process_instances_controller.unique_milestone_name_list
       summary: Returns a list of all unique milestone names.
       tags:
-        - Process Instances
+      - Process Instances
       responses:
         "200":
           description: List of unique milestone names.
@@ -1978,17 +1978,17 @@ paths:
 
   /process-models/{modified_process_model_identifier}/validate:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The modified process model id
-        schema:
-          type: string
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The modified process model id
+      schema:
+        type: string
     get:
       operationId: spiffworkflow_backend.routes.process_models_controller.process_model_validate
       summary: Validate a given process model
       tags:
-        - Process Models
+      - Process Models
       responses:
         "200":
           description: Returns ok true if the process model validated.
@@ -1999,17 +1999,17 @@ paths:
 
   /process-models/{modified_process_model_identifier}/milestones:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The modified process model id
-        schema:
-          type: string
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The modified process model id
+      schema:
+        type: string
     get:
       operationId: spiffworkflow_backend.routes.process_models_controller.process_model_milestone_list
       summary: Returns milestones for a process model
       tags:
-        - Process Models
+      - Process Models
       responses:
         "200":
           description: Returns the milestones for the process model.
@@ -2037,17 +2037,17 @@ paths:
 
   /process-models/{modified_process_model_identifier}/human-task-definitions:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The modified process model id
-        schema:
-          type: string
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The modified process model id
+      schema:
+        type: string
     get:
       operationId: spiffworkflow_backend.routes.process_models_controller.get_human_task_definitions
       summary: Returns human task definitions for a process model
       tags:
-        - Process Models
+      - Process Models
       responses:
         "200":
           description: Returns the human task definitions for the process model.
@@ -2060,30 +2060,30 @@ paths:
 
   /process-models/{modified_process_model_identifier}/files/{file_name}:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The modified process model id
-        schema:
-          type: string
-      - name: file_name
-        in: path
-        required: true
-        description: The id of the spec file
-        schema:
-          type: string
-      - name: file_contents_hash
-        in: query
-        required: false
-        description: Hash of the original file contents for optimistic locking. If provided, the update will only succeed if this hash matches the current file hash, preventing concurrent modification conflicts.
-        schema:
-          type: string
-          example: "0bd785d19b800380025d5a7819fee88833e145691683f1eabf33c24a8e2dbe97"
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The modified process model id
+      schema:
+        type: string
+    - name: file_name
+      in: path
+      required: true
+      description: The id of the spec file
+      schema:
+        type: string
+    - name: file_contents_hash
+      in: query
+      required: false
+      description: Hash of the original file contents for optimistic locking. If provided, the update will only succeed if this hash matches the current file hash, preventing concurrent modification conflicts.
+      schema:
+        type: string
+        example: "0bd785d19b800380025d5a7819fee88833e145691683f1eabf33c24a8e2dbe97"
     get:
       operationId: spiffworkflow_backend.routes.process_models_controller.process_model_file_show
       summary: Returns metadata about the file
       tags:
-        - Process Model Files
+      - Process Model Files
       responses:
         "200":
           description: Returns the file information requested.
@@ -2095,7 +2095,7 @@ paths:
       operationId: spiffworkflow_backend.routes.process_models_controller.process_model_file_update
       summary: save the contents to the given file
       tags:
-        - Process Model Files
+      - Process Model Files
       requestBody:
         description: Log Pagination Request
         required: false
@@ -2118,7 +2118,7 @@ paths:
       operationId: spiffworkflow_backend.routes.process_models_controller.process_model_file_delete
       summary: Removes an existing process model file
       tags:
-        - Process Model Files
+      - Process Model Files
       responses:
         "200":
           description: The process model has been removed.
@@ -2129,27 +2129,27 @@ paths:
 
   /tasks:
     parameters:
-      - name: process_instance_id
-        in: query
-        required: false
-        description: The process instance id to search by.
-        schema:
-          type: integer
-      - name: page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
-      - name: per_page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
+    - name: process_instance_id
+      in: query
+      required: false
+      description: The process instance id to search by.
+      schema:
+        type: integer
+    - name: page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
+    - name: per_page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
     get:
       tags:
-        - Tasks
+      - Tasks
       operationId: spiffworkflow_backend.routes.tasks_controller.task_list_my_tasks
       summary: returns the list of ready or waiting tasks for a user
       description: Gets all tasks assigned to or available to the current user, optionally filtered by process instance
@@ -2161,7 +2161,7 @@ paths:
               schema:
                 type: object
                 required:
-                  - results
+                - results
                 properties:
                   results:
                     type: array
@@ -2172,21 +2172,21 @@ paths:
 
   /tasks/for-my-open-processes:
     parameters:
-      - name: page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
-      - name: per_page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
+    - name: page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
+    - name: per_page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
     get:
       tags:
-        - Process Instances
+      - Process Instances
       operationId: spiffworkflow_backend.routes.tasks_controller.task_list_for_my_open_processes
       summary: returns the list of tasks for given user's open process instances
       responses:
@@ -2201,21 +2201,21 @@ paths:
 
   /tasks/service-tasks-awaiting-callback:
     parameters:
-      - name: page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
-      - name: per_page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
+    - name: page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
+    - name: per_page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
     get:
       tags:
-        - Process Instances
+      - Process Instances
       operationId: spiffworkflow_backend.routes.tasks_controller.service_task_list_awaiting_callback
       summary: returns the list of service tasks that are currently waiting for a callback.
       responses:
@@ -2235,21 +2235,21 @@ paths:
 
   /tasks/for-me:
     parameters:
-      - name: page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
-      - name: per_page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
+    - name: page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
+    - name: per_page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
     get:
       tags:
-        - Process Instances
+      - Process Instances
       operationId: spiffworkflow_backend.routes.tasks_controller.task_list_for_me
       summary: returns the list of tasks for given user's open process instances
       responses:
@@ -2264,27 +2264,27 @@ paths:
 
   /tasks/for-my-groups:
     parameters:
-      - name: user_group_identifier
-        in: query
-        required: false
-        description: The identifier of the group to get the tasks for
-        schema:
-          type: string
-      - name: page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
-      - name: per_page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
+    - name: user_group_identifier
+      in: query
+      required: false
+      description: The identifier of the group to get the tasks for
+      schema:
+        type: string
+    - name: page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
+    - name: per_page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
     get:
       tags:
-        - Process Instances
+      - Process Instances
       operationId: spiffworkflow_backend.routes.tasks_controller.task_list_for_my_groups
       summary: returns the list of tasks for given user's open process instances
       responses:
@@ -2299,27 +2299,27 @@ paths:
 
   /tasks/completed-by-me/{process_instance_id}:
     parameters:
-      - name: page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
-      - name: per_page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of an existing process instance.
-        schema:
-          type: integer
+    - name: page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
+    - name: per_page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of an existing process instance.
+      schema:
+        type: integer
     get:
       tags:
-        - Process Instances
+      - Process Instances
       operationId: spiffworkflow_backend.routes.tasks_controller.task_list_completed_by_me
       summary: returns the list of tasks for that the current user has completed
       responses:
@@ -2334,27 +2334,27 @@ paths:
 
   /tasks/completed/{process_instance_id}:
     parameters:
-      - name: page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
-      - name: per_page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of an existing process instance.
-        schema:
-          type: integer
+    - name: page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
+    - name: per_page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of an existing process instance.
+      schema:
+        type: integer
     get:
       tags:
-        - Process Instances
+      - Process Instances
       operationId: spiffworkflow_backend.routes.tasks_controller.task_list_completed
       summary: returns the list of human tasks that have been completed
       responses:
@@ -2369,15 +2369,15 @@ paths:
 
   /tasks/progress/{process_instance_id}:
     parameters:
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of an existing process instance.
-        schema:
-          type: integer
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of an existing process instance.
+      schema:
+        type: integer
     get:
       tags:
-        - Process Instances
+      - Process Instances
       operationId: spiffworkflow_backend.routes.tasks_controller.process_instance_progress
       summary: returns the list of instructions that have been queued for a process instance.
       responses:
@@ -2392,15 +2392,15 @@ paths:
 
   /users/search:
     parameters:
-      - name: username_prefix
-        in: query
-        required: true
-        description: The prefix of the user
-        schema:
-          type: string
+    - name: username_prefix
+      in: query
+      required: true
+      description: The prefix of the user
+      schema:
+        type: string
     get:
       tags:
-        - Users
+      - Users
       operationId: spiffworkflow_backend.routes.users_controller.user_search
       summary: Returns a list of users that the search param
       responses:
@@ -2416,7 +2416,7 @@ paths:
   /users/exists/by-username:
     post:
       tags:
-        - Users
+      - Users
       operationId: spiffworkflow_backend.routes.users_controller.user_exists_by_username
       summary: Returns a true if user exists by username.
       requestBody:
@@ -2436,7 +2436,7 @@ paths:
   /user-groups/for-current-user:
     get:
       tags:
-        - User Groups
+      - User Groups
       operationId: spiffworkflow_backend.routes.users_controller.user_group_list_for_current_user
       summary: Group identifiers for current logged in user
       responses:
@@ -2451,29 +2451,29 @@ paths:
 
   /task-data/{modified_process_model_identifier}/{process_instance_id}/{task_guid}:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The modified id of an existing process model
-        schema:
-          type: string
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of an existing process instance.
-        schema:
-          type: integer
-      - name: task_guid
-        in: path
-        required: true
-        description: The unique id of the task.
-        schema:
-          type: string
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The modified id of an existing process model
+      schema:
+        type: string
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of an existing process instance.
+      schema:
+        type: integer
+    - name: task_guid
+      in: path
+      required: true
+      description: The unique id of the task.
+      schema:
+        type: string
     get:
       operationId: spiffworkflow_backend.routes.tasks_controller.task_data_show
       summary: Get task data for a single task.
       tags:
-        - Process Instances
+      - Process Instances
       responses:
         "200":
           description: list of tasks
@@ -2485,7 +2485,7 @@ paths:
       operationId: spiffworkflow_backend.routes.tasks_controller.task_data_update
       summary: Update the task data for requested instance and task
       tags:
-        - Process Instances
+      - Process Instances
       requestBody:
         required: true
         content:
@@ -2502,29 +2502,29 @@ paths:
 
   /task-assign/{modified_process_model_identifier}/{process_instance_id}/{task_guid}:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The modified id of an existing process model
-        schema:
-          type: string
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of an existing process instance.
-        schema:
-          type: integer
-      - name: task_guid
-        in: path
-        required: true
-        description: The unique id of the task.
-        schema:
-          type: string
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The modified id of an existing process model
+      schema:
+        type: string
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of an existing process instance.
+      schema:
+        type: integer
+    - name: task_guid
+      in: path
+      required: true
+      description: The unique id of the task.
+      schema:
+        type: string
     post:
       operationId: spiffworkflow_backend.routes.tasks_controller.task_assign
       summary: Assign a given task to a list of additional users
       tags:
-        - Process Instances
+      - Process Instances
       requestBody:
         required: true
         content:
@@ -2541,47 +2541,47 @@ paths:
 
   /process-data/{category}/{modified_process_model_identifier}/{process_data_identifier}/{process_instance_id}:
     parameters:
-      - name: category
-        in: path
-        required: true
-        description: The category of the data object.
-        schema:
-          type: string
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The modified id of an existing process model
-        schema:
-          type: string
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of an existing process instance.
-        schema:
-          type: integer
-      - name: process_data_identifier
-        in: path
-        required: true
-        description: The identifier of the process data.
-        schema:
-          type: string
-      - name: process_identifier
-        in: query
-        required: false
-        description: "DEPRECATED - only the bpmn_process_guid is needed now: The identifier of the process the data object is in."
-        schema:
-          type: string
-      - name: bpmn_process_guid
-        in: query
-        required: false
-        description: The guid of the bpmn process to get the data object for.
-        schema:
-          type: string
+    - name: category
+      in: path
+      required: true
+      description: The category of the data object.
+      schema:
+        type: string
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The modified id of an existing process model
+      schema:
+        type: string
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of an existing process instance.
+      schema:
+        type: integer
+    - name: process_data_identifier
+      in: path
+      required: true
+      description: The identifier of the process data.
+      schema:
+        type: string
+    - name: process_identifier
+      in: query
+      required: false
+      description: "DEPRECATED - only the bpmn_process_guid is needed now: The identifier of the process the data object is in."
+      schema:
+        type: string
+    - name: bpmn_process_guid
+      in: query
+      required: false
+      description: The guid of the bpmn process to get the data object for.
+      schema:
+        type: string
     get:
       operationId: spiffworkflow_backend.routes.process_api_blueprint.process_data_show
       summary: Fetch the process data value.
       tags:
-        - Data Objects
+      - Data Objects
       responses:
         "200":
           description: Fetch succeeded.
@@ -2592,29 +2592,29 @@ paths:
 
   /process-data-file-download/{modified_process_model_identifier}/{process_instance_id}/{process_data_identifier}:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The modified id of an existing process model
-        schema:
-          type: string
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of an existing process instance.
-        schema:
-          type: integer
-      - name: process_data_identifier
-        in: path
-        required: true
-        description: The identifier of the process data.
-        schema:
-          type: string
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The modified id of an existing process model
+      schema:
+        type: string
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of an existing process instance.
+      schema:
+        type: integer
+    - name: process_data_identifier
+      in: path
+      required: true
+      description: The identifier of the process data.
+      schema:
+        type: string
     get:
       operationId: spiffworkflow_backend.routes.process_api_blueprint.process_data_file_download
       summary: Download the file referneced in the process data value.
       tags:
-        - Data Objects
+      - Data Objects
       responses:
         "200":
           description: Fetch succeeded.
@@ -2625,23 +2625,23 @@ paths:
 
   /send-event/{modified_process_model_identifier}/{process_instance_id}:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The modified id of an existing process model
-        schema:
-          type: string
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of the process instance
-        schema:
-          type: integer
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The modified id of an existing process model
+      schema:
+        type: string
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of the process instance
+      schema:
+        type: integer
     post:
       operationId: spiffworkflow_backend.routes.process_instances_controller.send_bpmn_event
       summary: Send a BPMN event to the process
       tags:
-        - Process Instances
+      - Process Instances
       requestBody:
         required: true
         content:
@@ -2658,29 +2658,29 @@ paths:
 
   /task-complete/{modified_process_model_identifier}/{process_instance_id}/{task_guid}:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The modified id of an existing process model
-        schema:
-          type: string
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of the process instance
-        schema:
-          type: integer
-      - name: task_guid
-        in: path
-        required: true
-        description: The unique id of the task.
-        schema:
-          type: string
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The modified id of an existing process model
+      schema:
+        type: string
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of the process instance
+      schema:
+        type: integer
+    - name: task_guid
+      in: path
+      required: true
+      description: The unique id of the task.
+      schema:
+        type: string
     post:
       operationId: spiffworkflow_backend.routes.tasks_controller.manual_complete_task
       summary: Mark a task complete without executing it
       tags:
-        - Process Instances
+      - Process Instances
       requestBody:
         required: true
         content:
@@ -2698,7 +2698,7 @@ paths:
   /service-tasks:
     get:
       tags:
-        - Service Tasks
+      - Service Tasks
       operationId: spiffworkflow_backend.routes.service_tasks_controller.service_task_list
       summary: Gets all available service task connectors
       responses:
@@ -2712,7 +2712,7 @@ paths:
   /authentications:
     get:
       tags:
-        - Authentications
+      - Authentications
       operationId: spiffworkflow_backend.routes.service_tasks_controller.authentication_list
       summary: Gets all available authentications from connector proxy
       responses:
@@ -2726,7 +2726,7 @@ paths:
   /authentication/configuration:
     get:
       tags:
-        - Authentications
+      - Authentications
       operationId: spiffworkflow_backend.routes.service_tasks_controller.authentication_configuration
       summary: Gets authentication configurations
       responses:
@@ -2740,7 +2740,7 @@ paths:
       operationId: spiffworkflow_backend.routes.service_tasks_controller.authentication_configuration_update
       summary: Save the authentication configuration
       tags:
-        - Authentication
+      - Authentication
       requestBody:
         required: true
         content:
@@ -2757,21 +2757,21 @@ paths:
 
   /authentication_begin/{service}/{auth_method}:
     parameters:
-      - name: service
-        in: path
-        required: true
-        description: The name of the service
-        schema:
-          type: string
-      - name: auth_method
-        in: path
-        required: true
-        description: The method
-        schema:
-          type: string
+    - name: service
+      in: path
+      required: true
+      description: The name of the service
+      schema:
+        type: string
+    - name: auth_method
+      in: path
+      required: true
+      description: The method
+      schema:
+        type: string
     get:
       tags:
-        - Authentications
+      - Authentications
       operationId: spiffworkflow_backend.routes.service_tasks_controller.authentication_begin
       summary: Begin an external authentication
       responses:
@@ -2784,57 +2784,57 @@ paths:
 
   /authentication_callback/{service}/{auth_method}:
     parameters:
-      - name: service
-        in: path
-        required: true
-        description: The name of the service
-        schema:
-          type: string
-      - name: auth_method
-        in: path
-        required: true
-        description: The method
-        schema:
-          type: string
-      - name: response
-        in: query
-        required: false
-        description: The response
-        schema:
-          type: string
-      - name: token
-        in: query
-        required: false
-        description: The response
-        schema:
-          type: string
-      - name: code
-        in: query
-        required: false
-        description: The response
-        schema:
-          type: string
-      - name: code_challenge
-        in: query
-        required: false
-        description: The response
-        schema:
-          type: string
-      - name: code_challenge_method
-        in: query
-        required: false
-        description: The response
-        schema:
-          type: string
-      - name: state
-        in: query
-        required: false
-        description: The response
-        schema:
-          type: string
+    - name: service
+      in: path
+      required: true
+      description: The name of the service
+      schema:
+        type: string
+    - name: auth_method
+      in: path
+      required: true
+      description: The method
+      schema:
+        type: string
+    - name: response
+      in: query
+      required: false
+      description: The response
+      schema:
+        type: string
+    - name: token
+      in: query
+      required: false
+      description: The response
+      schema:
+        type: string
+    - name: code
+      in: query
+      required: false
+      description: The response
+      schema:
+        type: string
+    - name: code_challenge
+      in: query
+      required: false
+      description: The response
+      schema:
+        type: string
+    - name: code_challenge_method
+      in: query
+      required: false
+      description: The response
+      schema:
+        type: string
+    - name: state
+      in: query
+      required: false
+      description: The response
+      schema:
+        type: string
     get:
       tags:
-        - Authentications
+      - Authentications
       operationId: spiffworkflow_backend.routes.service_tasks_controller.authentication_callback
       summary: Callback to backend
       responses:
@@ -2847,22 +2847,22 @@ paths:
 
   /tasks/{process_instance_id}:
     parameters:
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of an existing process instance.
-        schema:
-          type: integer
-      - name: execute_tasks
-        in: query
-        required: false
-        description: If true, execute ready tasks on the process instance automatically. This causes the process to run forward until it reaches a user task or completes.
-        schema:
-          type: boolean
-          default: false
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of an existing process instance.
+      schema:
+        type: integer
+    - name: execute_tasks
+      in: query
+      required: false
+      description: If true, execute ready tasks on the process instance automatically. This causes the process to run forward until it reaches a user task or completes.
+      schema:
+        type: boolean
+        default: false
     get:
       tags:
-        - Tasks
+      - Tasks
       operationId: spiffworkflow_backend.routes.tasks_controller.interstitial
       summary: Get currently active task for a process instance
       description: An SSE (Server Sent Events) endpoint that returns what tasks are currently active (running, waiting, or the final END event). Can optionally execute ready tasks automatically with execute_tasks=true.
@@ -2877,7 +2877,7 @@ paths:
   /tasks/prepare-form:
     post:
       tags:
-        - Tasks
+      - Tasks
       operationId: spiffworkflow_backend.routes.tasks_controller.prepare_form
       summary: Pre-processes a form schema, ui schema, and data, useful for previewing a form
       requestBody:
@@ -2896,15 +2896,15 @@ paths:
 
   /tasks/{process_instance_id}/instruction:
     parameters:
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of an existing process instance.
-        schema:
-          type: integer
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of an existing process instance.
+      schema:
+        type: integer
     get:
       tags:
-        - Tasks
+      - Tasks
       operationId: spiffworkflow_backend.routes.tasks_controller.task_with_instruction
       summary: Gets the next task and its instructions
       responses:
@@ -2917,21 +2917,21 @@ paths:
 
   /tasks/{process_instance_id}/{task_guid}/task-instances:
     parameters:
-      - name: task_guid
-        in: path
-        required: true
-        description: The unique id of an existing process group.
-        schema:
-          type: string
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of an existing process instance.
-        schema:
-          type: integer
+    - name: task_guid
+      in: path
+      required: true
+      description: The unique id of an existing process group.
+      schema:
+        type: string
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of an existing process instance.
+      schema:
+        type: integer
     get:
       tags:
-        - Tasks
+      - Tasks
       operationId: spiffworkflow_backend.routes.tasks_controller.task_instance_list
       summary: Gets all tasks that have the same bpmn identifier and are in the same bpmn process as the given task guid.
       responses:
@@ -2946,36 +2946,36 @@ paths:
 
   /tasks/{process_instance_id}/{task_guid}:
     parameters:
-      - name: task_guid
-        in: path
-        required: true
-        description: The unique id of an existing process group.
-        schema:
-          type: string
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of an existing process instance.
-        schema:
-          type: integer
-      - name: with_form_data
-        in: query
-        required: false
-        description: Include task data for forms
-        schema:
-          type: boolean
-      - name: execution_mode
-        in: query
-        required: false
-        description: Either run in "synchronous" or "asynchronous" mode.
-        schema:
-          type: string
-          enum:
-            - synchronous
-            - asynchronous
+    - name: task_guid
+      in: path
+      required: true
+      description: The unique id of an existing process group.
+      schema:
+        type: string
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of an existing process instance.
+      schema:
+        type: integer
+    - name: with_form_data
+      in: query
+      required: false
+      description: Include task data for forms
+      schema:
+        type: boolean
+    - name: execution_mode
+      in: query
+      required: false
+      description: Either run in "synchronous" or "asynchronous" mode.
+      schema:
+        type: string
+        enum:
+        - synchronous
+        - asynchronous
     get:
       tags:
-        - Tasks
+      - Tasks
       operationId: spiffworkflow_backend.routes.tasks_controller.task_show
       summary: Gets one task that a user wants to complete
       responses:
@@ -2987,7 +2987,7 @@ paths:
                 $ref: "#/components/schemas/Task"
     put:
       tags:
-        - Tasks
+      - Tasks
       operationId: spiffworkflow_backend.routes.tasks_controller.task_submit
       summary: Complete the task, submitting data as required.
       requestBody:
@@ -2997,7 +2997,7 @@ paths:
             schema:
               nullable: true
               allOf:
-                - $ref: "#/components/schemas/AwesomeUnspecifiedPayload"
+              - $ref: "#/components/schemas/AwesomeUnspecifiedPayload"
       responses:
         "200":
           description: One task
@@ -3014,21 +3014,21 @@ paths:
 
   /tasks/{process_instance_id}/{task_guid}/save-draft:
     parameters:
-      - name: task_guid
-        in: path
-        required: true
-        description: The unique id of an existing process group.
-        schema:
-          type: string
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of an existing process instance.
-        schema:
-          type: integer
+    - name: task_guid
+      in: path
+      required: true
+      description: The unique id of an existing process group.
+      schema:
+        type: string
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of an existing process instance.
+      schema:
+        type: integer
     post:
       tags:
-        - Tasks
+      - Tasks
       operationId: spiffworkflow_backend.routes.tasks_controller.task_save_draft
       summary: Update the draft form for this task
       requestBody:
@@ -3038,7 +3038,7 @@ paths:
             schema:
               nullable: true
               allOf:
-                - $ref: "#/components/schemas/AwesomeUnspecifiedPayload"
+              - $ref: "#/components/schemas/AwesomeUnspecifiedPayload"
       responses:
         "200":
           description: One task
@@ -3055,21 +3055,21 @@ paths:
 
   /tasks/{process_instance_id}/{task_guid}/callback:
     parameters:
-      - name: task_guid
-        in: path
-        required: true
-        description: The unique guid of a task.
-        schema:
-          type: string
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of an existing process instance.
-        schema:
-          type: integer
+    - name: task_guid
+      in: path
+      required: true
+      description: The unique guid of a task.
+      schema:
+        type: string
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of an existing process instance.
+      schema:
+        type: integer
     put:
       tags:
-        - Tasks
+      - Tasks
       operationId: spiffworkflow_backend.routes.tasks_controller.service_task_submit_callback
       summary: Complete a service task that was started and is awaiting completion through a callback.
       requestBody:
@@ -3079,7 +3079,7 @@ paths:
             schema:
               nullable: true
               allOf:
-                - $ref: "#/components/schemas/AwesomeUnspecifiedPayload"
+              - $ref: "#/components/schemas/AwesomeUnspecifiedPayload"
       responses:
         "200":
           description: Task completed
@@ -3090,21 +3090,21 @@ paths:
 
   /tasks/{process_instance_id}/{task_guid}/allows-guest:
     parameters:
-      - name: task_guid
-        in: path
-        required: true
-        description: The unique id of an existing process group.
-        schema:
-          type: string
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of an existing process instance.
-        schema:
-          type: integer
+    - name: task_guid
+      in: path
+      required: true
+      description: The unique id of an existing process group.
+      schema:
+        type: string
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of an existing process instance.
+      schema:
+        type: integer
     get:
       tags:
-        - Tasks
+      - Tasks
       operationId: spiffworkflow_backend.routes.tasks_controller.task_allows_guest
       summary: Gets checks if the given task allows guest login
       responses:
@@ -3118,17 +3118,17 @@ paths:
   # NOTE: this should probably be /process-instances instead
   /tasks/{process_instance_id}/send-user-signal-event:
     parameters:
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of the process instance
-        schema:
-          type: integer
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of the process instance
+      schema:
+        type: integer
     post:
       operationId: spiffworkflow_backend.routes.process_instances_controller.send_user_signal_event
       summary: Send a BPMN event to the process
       tags:
-        - Process Instances
+      - Process Instances
       requestBody:
         required: true
         content:
@@ -3146,7 +3146,7 @@ paths:
   /message-models:
     get:
       tags:
-        - Messages
+      - Messages
       operationId: spiffworkflow_backend.routes.messages_controller.message_model_list_from_root
       summary: Get a list of message models from the root location
       responses:
@@ -3160,7 +3160,7 @@ paths:
   /all-message-models:
     get:
       tags:
-        - Messages
+      - Messages
       operationId: spiffworkflow_backend.routes.messages_controller.message_model_list_all
       summary: Get a list of all message models
       responses:
@@ -3173,15 +3173,15 @@ paths:
 
   /message-models/{relative_location}:
     parameters:
-      - name: relative_location
-        in: path
-        required: true
-        description: The location of the message model relative to the root of the project, defaults to /
-        schema:
-          type: string
+    - name: relative_location
+      in: path
+      required: true
+      description: The location of the message model relative to the root of the project, defaults to /
+      schema:
+        type: string
     get:
       tags:
-        - Messages
+      - Messages
       operationId: spiffworkflow_backend.routes.messages_controller.message_model_list
       summary: Get a list of message models at the specified location
       responses:
@@ -3194,27 +3194,27 @@ paths:
 
   /messages:
     parameters:
-      - name: process_instance_id
-        in: query
-        required: false
-        description: the id of the process instance
-        schema:
-          type: integer
-      - name: page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
-      - name: per_page
-        in: query
-        required: false
-        description: The number of models to show per page. Defaults to 10.
-        schema:
-          type: integer
+    - name: process_instance_id
+      in: query
+      required: false
+      description: the id of the process instance
+      schema:
+        type: integer
+    - name: page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
+    - name: per_page
+      in: query
+      required: false
+      description: The number of models to show per page. Defaults to 10.
+      schema:
+        type: integer
     get:
       tags:
-        - Messages
+      - Messages
       operationId: spiffworkflow_backend.routes.messages_controller.message_instance_list
       summary: Get a list of message instances
       responses:
@@ -3229,7 +3229,7 @@ paths:
       operationId: spiffworkflow_backend.routes.messages_controller.message_instance_search
       summary: Returns a list of message instances matching the search criteria
       tags:
-        - Messages
+      - Messages
       requestBody:
         description: Filtering criteria for search
         required: true
@@ -3276,24 +3276,24 @@ paths:
 
   /messages/{modified_message_name}:
     parameters:
-      - name: modified_message_name
-        in: path
-        required: true
-        description: The message_name, modified to replace slashes (/) with colons
-        schema:
-          type: string
-      - name: execution_mode
-        in: query
-        required: false
-        description: Either run in "synchronous" or "asynchronous" mode.
-        schema:
-          type: string
-          enum:
-            - synchronous
-            - asynchronous
+    - name: modified_message_name
+      in: path
+      required: true
+      description: The message_name, modified to replace slashes (/) with colons
+      schema:
+        type: string
+    - name: execution_mode
+      in: query
+      required: false
+      description: Either run in "synchronous" or "asynchronous" mode.
+      schema:
+        type: string
+        enum:
+        - synchronous
+        - asynchronous
     post:
       tags:
-        - Messages
+      - Messages
       operationId: spiffworkflow_backend.routes.messages_controller.message_send
       summary: Instantiate and run a given process model with a message start event matching given name
       requestBody:
@@ -3316,17 +3316,17 @@ paths:
 
   /messages/{modified_message_name}/process-model:
     parameters:
-      - name: modified_message_name
-        in: path
-        required: true
-        description: The message_name, modified to replace slashes (/) with colons
-        schema:
-          type: string
+    - name: modified_message_name
+      in: path
+      required: true
+      description: The message_name, modified to replace slashes (/) with colons
+      schema:
+        type: string
     get:
       operationId: spiffworkflow_backend.routes.messages_controller.get_process_model_for_message
       summary: Returns the process model for a given message name
       tags:
-        - Messages
+      - Messages
       responses:
         "200":
           description: The process model associated with the message.
@@ -3342,15 +3342,15 @@ paths:
 
   /public/messages/form/{modified_message_name}:
     parameters:
-      - name: modified_message_name
-        in: path
-        required: true
-        description: The message_name, modified to replace slashes (/) with colons
-        schema:
-          type: string
+    - name: modified_message_name
+      in: path
+      required: true
+      description: The message_name, modified to replace slashes (/) with colons
+      schema:
+        type: string
     get:
       tags:
-        - Messages
+      - Messages
       operationId: spiffworkflow_backend.routes.public_controller.message_form_show
       summary: Gets the form associated with the given message name.
       responses:
@@ -3363,24 +3363,24 @@ paths:
 
   /public/messages/submit/{modified_message_name}:
     parameters:
-      - name: modified_message_name
-        in: path
-        required: true
-        description: The message_name, modified to replace slashes (/) with colons
-        schema:
-          type: string
-      - name: execution_mode
-        in: query
-        required: false
-        description: Either run in "synchronous" or "asynchronous" mode.
-        schema:
-          type: string
-          enum:
-            - synchronous
-            - asynchronous
+    - name: modified_message_name
+      in: path
+      required: true
+      description: The message_name, modified to replace slashes (/) with colons
+      schema:
+        type: string
+    - name: execution_mode
+      in: query
+      required: false
+      description: Either run in "synchronous" or "asynchronous" mode.
+      schema:
+        type: string
+        enum:
+        - synchronous
+        - asynchronous
     post:
       tags:
-        - Messages
+      - Messages
       operationId: spiffworkflow_backend.routes.public_controller.message_form_submit
       summary: Instantiate and run a given process model with a message start event matching given name
       requestBody:
@@ -3403,30 +3403,30 @@ paths:
 
   /public/tasks/{process_instance_id}/{task_guid}:
     parameters:
-      - name: task_guid
-        in: path
-        required: true
-        description: The unique id of an existing process group.
-        schema:
-          type: string
-      - name: process_instance_id
-        in: path
-        required: true
-        description: The unique id of an existing process instance.
-        schema:
-          type: integer
-      - name: execution_mode
-        in: query
-        required: false
-        description: Either run in "synchronous" or "asynchronous" mode.
-        schema:
-          type: string
-          enum:
-            - synchronous
-            - asynchronous
+    - name: task_guid
+      in: path
+      required: true
+      description: The unique id of an existing process group.
+      schema:
+        type: string
+    - name: process_instance_id
+      in: path
+      required: true
+      description: The unique id of an existing process instance.
+      schema:
+        type: integer
+    - name: execution_mode
+      in: query
+      required: false
+      description: Either run in "synchronous" or "asynchronous" mode.
+      schema:
+        type: string
+        enum:
+        - synchronous
+        - asynchronous
     get:
       tags:
-        - Tasks
+      - Tasks
       operationId: spiffworkflow_backend.routes.public_controller.form_show
       summary: Gets one task that a user wants to complete
       responses:
@@ -3438,7 +3438,7 @@ paths:
                 $ref: "#/components/schemas/Task"
     put:
       tags:
-        - Tasks
+      - Tasks
       operationId: spiffworkflow_backend.routes.public_controller.form_submit
       summary: Update the form data for a tasks
       requestBody:
@@ -3448,7 +3448,7 @@ paths:
             schema:
               nullable: true
               allOf:
-                - $ref: "#/components/schemas/AwesomeUnspecifiedPayload"
+              - $ref: "#/components/schemas/AwesomeUnspecifiedPayload"
       responses:
         "200":
           description: One task
@@ -3465,63 +3465,63 @@ paths:
 
   /logs/{modified_process_model_identifier}/{process_instance_id}:
     parameters:
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The modified process model id
-        schema:
-          type: string
-      - name: process_instance_id
-        in: path
-        required: true
-        description: the id of the process instance
-        schema:
-          type: integer
-      - name: page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
-      - name: per_page
-        in: query
-        required: false
-        description: The number of items to show per page. Defaults to 10.
-        schema:
-          type: integer
-      - name: events
-        in: query
-        required: false
-        description: Show the events view, which includes all log entries
-        schema:
-          type: boolean
-      - name: bpmn_name
-        in: query
-        required: false
-        description: The bpmn name of the task to search for.
-        schema:
-          type: string
-      - name: bpmn_identifier
-        in: query
-        required: false
-        description: The bpmn identifier of the task to search for.
-        schema:
-          type: string
-      - name: task_type
-        in: query
-        required: false
-        description: The task type of the task to search for.
-        schema:
-          type: string
-      - name: event_type
-        in: query
-        required: false
-        description: The type of the event to search for.
-        schema:
-          type: string
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The modified process model id
+      schema:
+        type: string
+    - name: process_instance_id
+      in: path
+      required: true
+      description: the id of the process instance
+      schema:
+        type: integer
+    - name: page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
+    - name: per_page
+      in: query
+      required: false
+      description: The number of items to show per page. Defaults to 10.
+      schema:
+        type: integer
+    - name: events
+      in: query
+      required: false
+      description: Show the events view, which includes all log entries
+      schema:
+        type: boolean
+    - name: bpmn_name
+      in: query
+      required: false
+      description: The bpmn name of the task to search for.
+      schema:
+        type: string
+    - name: bpmn_identifier
+      in: query
+      required: false
+      description: The bpmn identifier of the task to search for.
+      schema:
+        type: string
+    - name: task_type
+      in: query
+      required: false
+      description: The task type of the task to search for.
+      schema:
+        type: string
+    - name: event_type
+      in: query
+      required: false
+      description: The type of the event to search for.
+      schema:
+        type: string
     get:
       tags:
-        - Process Instance Events
+      - Process Instance Events
       operationId: spiffworkflow_backend.routes.process_instance_events_controller.log_list
       summary: returns a list of logs associated with the process instance
       responses:
@@ -3534,21 +3534,21 @@ paths:
 
   /process-instance-events/{modified_process_model_identifier}/{process_instance_id}/migration:
     parameters:
-      - name: process_instance_id
-        in: path
-        required: true
-        description: the id of the process instance
-        schema:
-          type: integer
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The process_model_id, modified to replace slashes (/)
-        schema:
-          type: string
+    - name: process_instance_id
+      in: path
+      required: true
+      description: the id of the process instance
+      schema:
+        type: integer
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The process_model_id, modified to replace slashes (/)
+      schema:
+        type: string
     get:
       tags:
-        - Process Instance Events
+      - Process Instance Events
       operationId: spiffworkflow_backend.routes.process_instance_events_controller.process_instance_migration_event_list
       summary: returns a list of migration events associated with the process instance
       responses:
@@ -3561,27 +3561,27 @@ paths:
 
   /logs/typeahead-filter-values/{modified_process_model_identifier}/{process_instance_id}:
     parameters:
-      - name: process_instance_id
-        in: path
-        required: true
-        description: the id of the process instance
-        schema:
-          type: integer
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The process_model_id, modified to replace slashes (/)
-        schema:
-          type: string
-      - name: task_type
-        in: query
-        required: false
-        description: The task type of the typehead filter values to get.
-        schema:
-          type: string
+    - name: process_instance_id
+      in: path
+      required: true
+      description: the id of the process instance
+      schema:
+        type: integer
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The process_model_id, modified to replace slashes (/)
+      schema:
+        type: string
+    - name: task_type
+      in: query
+      required: false
+      description: The task type of the typehead filter values to get.
+      schema:
+        type: string
     get:
       tags:
-        - Process Instance Events
+      - Process Instance Events
       operationId: spiffworkflow_backend.routes.process_instance_events_controller.typeahead_filter_values
       summary: returns a list of task types and event typs. useful for building log queries.
       responses:
@@ -3594,27 +3594,27 @@ paths:
 
   /event-error-details/{modified_process_model_identifier}/{process_instance_id}/{process_instance_event_id}:
     parameters:
-      - name: process_instance_id
-        in: path
-        required: true
-        description: the id of the process instance
-        schema:
-          type: integer
-      - name: modified_process_model_identifier
-        in: path
-        required: true
-        description: The process_model_id, modified to replace slashes (/)
-        schema:
-          type: string
-      - name: process_instance_event_id
-        in: path
-        required: true
-        description: the id of the process instance event
-        schema:
-          type: integer
+    - name: process_instance_id
+      in: path
+      required: true
+      description: the id of the process instance
+      schema:
+        type: integer
+    - name: modified_process_model_identifier
+      in: path
+      required: true
+      description: The process_model_id, modified to replace slashes (/)
+      schema:
+        type: string
+    - name: process_instance_event_id
+      in: path
+      required: true
+      description: the id of the process instance event
+      schema:
+        type: integer
     get:
       tags:
-        - Process Instance Events
+      - Process Instance Events
       operationId: spiffworkflow_backend.routes.process_instance_events_controller.error_detail_show
       summary: returns the error details for a given process instance event.
       responses:
@@ -3627,23 +3627,23 @@ paths:
 
   /secrets:
     parameters:
-      - name: page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
-      - name: per_page
-        in: query
-        required: false
-        description: The number of items to show per page. Defaults to 10.
-        schema:
-          type: integer
+    - name: page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
+    - name: per_page
+      in: query
+      required: false
+      description: The number of items to show per page. Defaults to 10.
+      schema:
+        type: integer
     post:
       operationId: spiffworkflow_backend.routes.secrets_controller.secret_create
       summary: Create a secret for a key and value
       tags:
-        - Secrets
+      - Secrets
       requestBody:
         required: true
         content:
@@ -3661,7 +3661,7 @@ paths:
       operationId: spiffworkflow_backend.routes.secrets_controller.secret_list
       summary: Return list of all secrets
       tags:
-        - Secrets
+      - Secrets
       responses:
         "200":
           description: list of secrets
@@ -3672,17 +3672,17 @@ paths:
 
   /secrets/{key}:
     parameters:
-      - name: key
-        in: path
-        required: true
-        description: The key we are using
-        schema:
-          type: string
+    - name: key
+      in: path
+      required: true
+      description: The key we are using
+      schema:
+        type: string
     get:
       operationId: spiffworkflow_backend.routes.secrets_controller.secret_show
       summary: Return info about a secret for a key. Does not include the value.
       tags:
-        - Secrets
+      - Secrets
       responses:
         "200":
           description: We return a secret
@@ -3694,7 +3694,7 @@ paths:
       operationId: spiffworkflow_backend.routes.secrets_controller.secret_delete
       summary: Delete an existing secret
       tags:
-        - Secrets
+      - Secrets
       responses:
         "204":
           description: The secret is deleted
@@ -3706,7 +3706,7 @@ paths:
       operationId: spiffworkflow_backend.routes.secrets_controller.secret_update
       summary: Modify an existing secret
       tags:
-        - Secrets
+      - Secrets
       requestBody:
         required: true
         content:
@@ -3727,17 +3727,17 @@ paths:
 
   /secrets/show-value/{key}:
     parameters:
-      - name: key
-        in: path
-        required: true
-        description: The key we are using
-        schema:
-          type: string
+    - name: key
+      in: path
+      required: true
+      description: The key we are using
+      schema:
+        type: string
     get:
       operationId: spiffworkflow_backend.routes.secrets_controller.secret_show_value
       summary: Return a secret value for a key
       tags:
-        - Secrets
+      - Secrets
       responses:
         "200":
           description: We return a secret
@@ -3752,7 +3752,7 @@ paths:
       summary: Checks if current user has access to given list of target uris and permissions.
       description: Batch permission check for multiple URIs and HTTP methods
       tags:
-        - Permissions
+      - Permissions
       requestBody:
         required: true
         content:
@@ -3760,7 +3760,7 @@ paths:
             schema:
               type: object
               required:
-                - requests_to_check
+              - requests_to_check
               properties:
                 requests_to_check:
                   type: object
@@ -3771,10 +3771,10 @@ paths:
                       type: string
                   example:
                     "/v1.0/process-groups":
-                      - "GET"
-                      - "POST"
+                    - "GET"
+                    - "POST"
                     "/v1.0/data-stores":
-                      - "GET"
+                    - "GET"
       responses:
         "200":
           description: Result of permission checks
@@ -3783,7 +3783,7 @@ paths:
               schema:
                 type: object
                 required:
-                  - results
+                - results
                 properties:
                   results:
                     type: object
@@ -3801,29 +3801,29 @@ paths:
 
   /connector-proxy/typeahead/{category}:
     parameters:
-      - name: category
-        in: path
-        required: true
-        description: The category for the typeahead search
-        schema:
-          type: string
-      - name: prefix
-        in: query
-        required: true
-        description: The prefix to search for
-        schema:
-          type: string
-      - name: limit
-        in: query
-        required: true
-        description: The maximum number of search results
-        schema:
-          type: integer
+    - name: category
+      in: path
+      required: true
+      description: The category for the typeahead search
+      schema:
+        type: string
+    - name: prefix
+      in: query
+      required: true
+      description: The prefix to search for
+      schema:
+        type: string
+    - name: limit
+      in: query
+      required: true
+      description: The maximum number of search results
+      schema:
+        type: integer
     get:
       operationId: spiffworkflow_backend.routes.connector_proxy_controller.typeahead
       summary: Return type ahead search results
       tags:
-        - Type Ahead
+      - Type Ahead
       responses:
         "200":
           description: We return type ahead search results
@@ -3832,36 +3832,36 @@ paths:
 
   /data-stores:
     parameters:
-      - name: process_group_identifier
-        in: query
-        required: false
-        description: Optional parameter to filter by a single group
-        schema:
-          type: string
-      - name: upsearch
-        in: query
-        required: false
-        description: Optional parameter to indicate if an upsearch should be performed
-        schema:
-          type: boolean
-      - name: page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
-      - name: per_page
-        in: query
-        required: false
-        description: The number of groups to show per page. Defaults to 10.
-        schema:
-          type: integer
+    - name: process_group_identifier
+      in: query
+      required: false
+      description: Optional parameter to filter by a single group
+      schema:
+        type: string
+    - name: upsearch
+      in: query
+      required: false
+      description: Optional parameter to indicate if an upsearch should be performed
+      schema:
+        type: boolean
+    - name: page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
+    - name: per_page
+      in: query
+      required: false
+      description: The number of groups to show per page. Defaults to 10.
+      schema:
+        type: integer
     get:
       operationId: spiffworkflow_backend.routes.data_store_controller.data_store_list
       summary: Return a list of the data store objects.
       description: Returns all data stores accessible to the user, optionally filtered by process group
       tags:
-        - Data Stores
+      - Data Stores
       responses:
         "200":
           description: Array of data store objects
@@ -3872,10 +3872,10 @@ paths:
                 items:
                   type: object
                   required:
-                    - id
-                    - type
-                    - name
-                    - location
+                  - id
+                  - type
+                  - name
+                  - location
                   properties:
                     id:
                       type: string
@@ -3907,7 +3907,7 @@ paths:
             schema:
               $ref: "#/components/schemas/DataStore"
       tags:
-        - Data Stores
+      - Data Stores
       responses:
         "200":
           description: The newly created data store instance
@@ -3921,7 +3921,7 @@ paths:
             schema:
               $ref: "#/components/schemas/DataStore"
       tags:
-        - Data Stores
+      - Data Stores
       responses:
         "200":
           description: The updated data store instance
@@ -3930,47 +3930,59 @@ paths:
       operationId: spiffworkflow_backend.routes.data_store_controller.data_store_types
       summary: Return a list of the data store types.
       tags:
-        - Data Stores
+      - Data Stores
       responses:
         "200":
           description: The list of currently defined data store types
   /data-stores/{data_store_type}/{identifier}/items:
     parameters:
-      - name: data_store_type
-        in: path
-        required: true
-        description: The type of datastore, such as "typeahead"
-        schema:
-          type: string
-      - name: identifier
-        in: path
-        required: true
-        description: The identifier of the datastore, such as "cities"
-        schema:
-          type: string
-      - name: location
-        in: query
-        required: false
-        description: The location of the data store
-        schema:
-          type: string
-      - name: page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
-      - name: per_page
-        in: query
-        required: false
-        description: The page number to return. Defaults to page 1.
-        schema:
-          type: integer
+    - name: data_store_type
+      in: path
+      required: true
+      description: The type of datastore, such as "typeahead"
+      schema:
+        type: string
+    - name: identifier
+      in: path
+      required: true
+      description: The identifier of the datastore, such as "cities"
+      schema:
+        type: string
+    - name: location
+      in: query
+      required: false
+      description: The location of the data store
+      schema:
+        type: string
+    - name: page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
+    - name: per_page
+      in: query
+      required: false
+      description: The page number to return. Defaults to page 1.
+      schema:
+        type: integer
+    - name: top_level_key
+      in: query
+      required: false
+      description: Filter KKV entries by top-level key (e.g. process instance ID). Requires a seconday_key.
+      schema:
+        type: string
+    - name: secondary_key
+      in: query
+      required: false
+      description: Filter KKV entries by secondary key (e.g. process model). Requires top_level_key.
+      schema:
+        type: string
     get:
       operationId: spiffworkflow_backend.routes.data_store_controller.data_store_item_list
       summary: Returns a paginated list of the contents of a data store.
       tags:
-        - Data Stores
+      - Data Stores
       responses:
         "200":
           description: The requested data store.
@@ -3978,35 +3990,59 @@ paths:
       operationId: spiffworkflow_backend.routes.data_store_controller.data_store_clear
       summary: Clears all items of a data store.
       tags:
-        - Data Stores
+      - Data Stores
       responses:
         "200":
           description: A list of the data stored in the requested data store.
+    put:
+      operationId: spiffworkflow_backend.routes.data_store_controller.data_store_write_items
+      summary: Write entries into a KKV data store.
+      description: >
+        Upserts entries into a KKV data store. Body is a JSON object mapping top_level_key to {secondary_key: value}. Set a value to null to delete that entry. Set a top_level_key to null to delete all entries for that key.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      tags:
+      - Data Stores
+      responses:
+        "200":
+          description: Confirmation that the entries were written.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
   /data-stores/{data_store_type}/{identifier}:
     parameters:
-      - name: data_store_type
-        in: path
-        required: true
-        description: The type of datastore, such as "typeahead"
-        schema:
-          type: string
-      - name: identifier
-        in: path
-        required: true
-        description: The identifier of the datastore, such as "cities"
-        schema:
-          type: string
-      - name: process_group_identifier
-        in: query
-        required: true
-        description: The process group
-        schema:
-          type: string
+    - name: data_store_type
+      in: path
+      required: true
+      description: The type of datastore, such as "typeahead"
+      schema:
+        type: string
+    - name: identifier
+      in: path
+      required: true
+      description: The identifier of the datastore, such as "cities"
+      schema:
+        type: string
+    - name: process_group_identifier
+      in: query
+      required: true
+      description: The process group
+      schema:
+        type: string
     get:
       operationId: spiffworkflow_backend.routes.data_store_controller.data_store_show
       summary: Returns a description of the data store.
       tags:
-        - Data Stores
+      - Data Stores
       responses:
         "200":
           description: The requested data store.
@@ -4014,7 +4050,7 @@ paths:
       operationId: spiffworkflow_backend.routes.data_store_controller.data_store_delete
       summary: Deletes the data store.
       tags:
-        - Data Stores
+      - Data Stores
       responses:
         "200":
           description: The requested data store.
@@ -4044,8 +4080,8 @@ components:
           type: string
           description: Expression used to retrieve the correlation value
       required:
-        - identifier
-        - retrieval_expression
+      - identifier
+      - retrieval_expression
 
     MessageModel:
       type: object
@@ -4065,10 +4101,10 @@ components:
             $ref: "#/components/schemas/MessageCorrelationProperty"
           description: List of correlation properties used for message correlation
       required:
-        - identifier
-        - location
-        - schema
-        - correlation_properties
+      - identifier
+      - location
+      - schema
+      - correlation_properties
 
     MessageModelListResponse:
       type: object
@@ -4079,7 +4115,7 @@ components:
             $ref: "#/components/schemas/MessageModel"
           description: List of message models
       required:
-        - messages
+      - messages
 
     ReportMetadataColumn:
       type: object
@@ -4292,7 +4328,7 @@ components:
     ProcessModelCopyRequest:
       type: object
       required:
-        - id
+      - id
       properties:
         id:
           type: string
@@ -4342,7 +4378,7 @@ components:
           format: int64
         status:
           type: string
-          enum: ["new", "user_input_required", "waiting", "complete"]
+          enum: [ "new", "user_input_required", "waiting", "complete" ]
         navigation:
           type: array
           items:
@@ -4372,7 +4408,10 @@ components:
           id: study_identification
           name: Study Identification
           title: IRB Review
-          documentation: "# Heading 1\n\nMarkdown documentation text goes here"
+          documentation: "# Heading 1
+
+
+            Markdown documentation text goes here"
           type: form
           state: ready
     TaskInstructionsForEndUser:
@@ -4470,7 +4509,7 @@ components:
           description: Additional metadata stored as JSON
         multi_instance_type:
           type: string
-          enum: ["none", "looping", "parallel", "sequential"]
+          enum: [ "none", "looping", "parallel", "sequential" ]
         multi_instance_count:
           type: number
         multi_instance_index:
@@ -4539,45 +4578,51 @@ components:
         id: study_identification
         name: Study Identification
         title: IRB Review
-        documentation: "# Heading 1\n\nMarkdown documentation text goes here"
+        documentation: "# Heading 1
+
+
+          Markdown documentation text goes here"
         type: form
         state: ready
         form:
           "key": "irb_review_form"
           "fields":
-            - "id": "irb_review_type"
-              "type": "enum"
-              "label": "Select IRB Review Type"
-              "options":
-                - id: "emergency_use"
-                  name: "Emergency Use"
-                - id: "humanitarian_device"
-                  name: "Humanitarian Device"
-                - id: "non_human"
-                  name: "Non-Human"
-                - id: "non_uva_agent"
-                  name: "Non-UVA Agent"
-                - id: "exempt"
-                  name: "Exempt"
-                - id: "non_engaged"
-                  name: "Non-Engaged"
-                - id: "expedited"
-                  name: "Expedited"
-                - id: "full_board"
-                  name: "Full Board"
-              "default_value": "Full Board"
-              "validation":
-                - name: "required"
-                  config: "true"
-              "properties":
-                - id: "description"
-                  value: "Description text goes here"
-                - id: "help"
-                  value: "# Heading 1\n\nMarkdown help text goes here"
-                - id: "required_expression"
-                  value: "model.my_boolean_field_id && model.my_enum_field_value !== 'something'"
-                - id: "hide_expression"
-                  value: "model.my_enum_field_value === 'something'"
+          - "id": "irb_review_type"
+            "type": "enum"
+            "label": "Select IRB Review Type"
+            "options":
+            - id: "emergency_use"
+              name: "Emergency Use"
+            - id: "humanitarian_device"
+              name: "Humanitarian Device"
+            - id: "non_human"
+              name: "Non-Human"
+            - id: "non_uva_agent"
+              name: "Non-UVA Agent"
+            - id: "exempt"
+              name: "Exempt"
+            - id: "non_engaged"
+              name: "Non-Engaged"
+            - id: "expedited"
+              name: "Expedited"
+            - id: "full_board"
+              name: "Full Board"
+            "default_value": "Full Board"
+            "validation":
+            - name: "required"
+              config: "true"
+            "properties":
+            - id: "description"
+              value: "Description text goes here"
+            - id: "help"
+              value: "# Heading 1
+
+
+                Markdown help text goes here"
+            - id: "required_expression"
+              value: "model.my_boolean_field_id && model.my_enum_field_value !== 'something'"
+            - id: "hide_expression"
+              value: "model.my_enum_field_value === 'something'"
     PaginatedTaskLog:
       properties:
         code:
@@ -4710,16 +4755,7 @@ components:
           example: 4
         state:
           type: string
-          enum:
-            [
-              "FUTURE",
-              "WAITING",
-              "READY",
-              "CANCELLED",
-              "COMPLETED",
-              "LIKELY",
-              "MAYBE",
-            ]
+          enum: [ "FUTURE", "WAITING", "READY", "CANCELLED", "COMPLETED", "LIKELY", "MAYBE" ]
           readOnly: true
         is_decision:
           type: boolean
@@ -4797,10 +4833,10 @@ components:
           example: staging
         changes:
           type: array
-          example: ["file_1.txt", "file_2.txt"]
+          example: [ "file_1.txt", "file_2.txt" ]
         untracked:
           type: array
-          example: ["a_file.txt", "b_file.txt"]
+          example: [ "a_file.txt", "b_file.txt" ]
     Secret:
       properties:
         key:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/api.yml
@@ -3963,7 +3963,7 @@ paths:
     - name: per_page
       in: query
       required: false
-      description: The page number to return. Defaults to page 1.
+      description: Number of items per page. Defaults to 100. Set to 0 to return all results without pagination.
       schema:
         type: integer
     - name: top_level_key

--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/kkv_data_store_entry.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/kkv_data_store_entry.py
@@ -13,7 +13,14 @@ from spiffworkflow_backend.models.kkv_data_store import KKVDataStoreModel
 @dataclass
 class KKVDataStoreEntryModel(SpiffworkflowBaseDBModel):
     __tablename__ = "kkv_data_store_entry"
-    __table_args__ = (UniqueConstraint("kkv_data_store_id", "top_level_key", "secondary_key", name="_instance_keys_unique"),)
+    __table_args__ = (
+        UniqueConstraint(
+            "kkv_data_store_id",
+            "top_level_key",
+            "secondary_key",
+            name="_instance_keys_unique",
+        ),
+    )
 
     id: int = db.Column(db.Integer, primary_key=True)
     kkv_data_store_id: int = db.Column(ForeignKey(KKVDataStoreModel.id), nullable=False, index=True)  # type: ignore

--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/kkv_data_store_entry.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/kkv_data_store_entry.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Any
 
 from sqlalchemy import ForeignKey
 from sqlalchemy import UniqueConstraint
@@ -18,7 +19,7 @@ class KKVDataStoreEntryModel(SpiffworkflowBaseDBModel):
     kkv_data_store_id: int = db.Column(ForeignKey(KKVDataStoreModel.id), nullable=False, index=True)  # type: ignore
     top_level_key: str = db.Column(db.String(255), nullable=False, index=True)
     secondary_key: str = db.Column(db.String(255), nullable=False, index=True)
-    value: dict = db.Column(db.JSON, nullable=False)
+    value: Any = db.Column(db.JSON, nullable=False)
     updated_at_in_seconds: int = db.Column(db.Integer, nullable=False)
     created_at_in_seconds: int = db.Column(db.Integer, nullable=False)
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
@@ -107,7 +107,7 @@ def data_store_item_list(
     top_level_key = top_level_key or None
     secondary_key = secondary_key or None
 
-    if top_level_key is not None and data_store_type == "kkv":
+    if (top_level_key is not None or secondary_key is not None) and data_store_type == "kkv":
         return _kkv_filtered_items(identifier, location, top_level_key, secondary_key, page, per_page)
 
     data_store_class, _ = DATA_STORES[data_store_type]
@@ -117,12 +117,12 @@ def data_store_item_list(
 def _kkv_filtered_items(
     identifier: str,
     location: str | None,
-    top_level_key: str,
+    top_level_key: str | None,
     secondary_key: str | None,
     page: int,
     per_page: int,
 ) -> flask.wrappers.Response:
-    """Return KKV entries filtered by top_level_key and optionally secondary_key."""
+    """Return KKV entries filtered by top_level_key and/or secondary_key."""
     store_model = db.session.query(KKVDataStoreModel).filter_by(identifier=identifier, location=location).first()
 
     if store_model is None:
@@ -132,10 +132,9 @@ def _kkv_filtered_items(
             status_code=404,
         )
 
-    query = db.session.query(KKVDataStoreEntryModel).filter_by(
-        kkv_data_store_id=store_model.id,
-        top_level_key=top_level_key,
-    )
+    query = db.session.query(KKVDataStoreEntryModel).filter_by(kkv_data_store_id=store_model.id)
+    if top_level_key is not None:
+        query = query.filter_by(top_level_key=top_level_key)
     if secondary_key is not None:
         query = query.filter_by(secondary_key=secondary_key)
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
@@ -11,6 +11,7 @@ from spiffworkflow_backend.data_stores.json import JSONDataStore
 from spiffworkflow_backend.data_stores.kkv import KKVDataStore
 from spiffworkflow_backend.data_stores.typeahead import TypeaheadDataStore
 from spiffworkflow_backend.exceptions.api_error import ApiError
+from spiffworkflow_backend.models.db import SpiffworkflowBaseDBModel
 from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.models.kkv_data_store import KKVDataStoreModel
 from spiffworkflow_backend.models.kkv_data_store_entry import KKVDataStoreEntryModel
@@ -146,6 +147,12 @@ def _kkv_filtered_items(
         query = query.filter_by(top_level_key=top_level_key)
     if secondary_key is not None:
         query = query.filter_by(secondary_key=secondary_key)
+
+    query = query.order_by(
+        KKVDataStoreEntryModel.top_level_key,
+        KKVDataStoreEntryModel.secondary_key,
+        KKVDataStoreEntryModel.id,
+    )
 
     if per_page == 0:
         items = query.all()
@@ -438,5 +445,5 @@ def data_store_write_items(data_store_type: str, identifier: str, location: str 
                 model.value = value
             db.session.add(model)
 
-    db.session.commit()
+    SpiffworkflowBaseDBModel.commit_with_rollback_on_exception()
     return make_response(jsonify({"ok": True}), 200)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
@@ -70,19 +70,28 @@ def _build_response(
     per_page: int,
 ) -> flask.wrappers.Response:
     data_store_query = data_store_class.get_data_store_query(identifier, location)
-    data = data_store_query.paginate(page=page, per_page=per_page, error_out=False)
-    results = []
-    for item in data.items:
-        result = data_store_class.build_response_item(item)
-        results.append(result)
-    response_json = {
-        "results": results,
-        "pagination": {
-            "count": len(data.items),
-            "total": data.total,
-            "pages": data.pages,
-        },
-    }
+    if per_page == 0:
+        items = data_store_query.all()
+        results = [data_store_class.build_response_item(item) for item in items]
+        response_json = {
+            "results": results,
+            "pagination": {
+                "count": len(results),
+                "total": len(results),
+                "pages": 1,
+            },
+        }
+    else:
+        data = data_store_query.paginate(page=page, per_page=per_page, error_out=False)
+        results = [data_store_class.build_response_item(item) for item in data.items]
+        response_json = {
+            "results": results,
+            "pagination": {
+                "count": len(data.items),
+                "total": data.total,
+                "pages": data.pages,
+            },
+        }
     return make_response(jsonify(response_json), 200)
 
 
@@ -107,7 +116,7 @@ def data_store_item_list(
     top_level_key = top_level_key or None
     secondary_key = secondary_key or None
 
-    if (top_level_key is not None or secondary_key is not None) and data_store_type == "kkv":
+    if data_store_type == "kkv":
         return _kkv_filtered_items(identifier, location, top_level_key, secondary_key, page, per_page)
 
     data_store_class, _ = DATA_STORES[data_store_type]
@@ -138,24 +147,42 @@ def _kkv_filtered_items(
     if secondary_key is not None:
         query = query.filter_by(secondary_key=secondary_key)
 
-    data = query.paginate(page=page, per_page=per_page, error_out=False)
-    results = [
-        {
-            "top_level_key": entry.top_level_key,
-            "secondary_key": entry.secondary_key,
-            "value": entry.value,
+    if per_page == 0:
+        items = query.all()
+        results = [
+            {
+                "top_level_key": entry.top_level_key,
+                "secondary_key": entry.secondary_key,
+                "value": entry.value,
+            }
+            for entry in items
+        ]
+        response_json = {
+            "results": results,
+            "pagination": {
+                "count": len(results),
+                "total": len(results),
+                "pages": 1,
+            },
         }
-        for entry in data.items
-    ]
-
-    response_json = {
-        "results": results,
-        "pagination": {
-            "count": len(data.items),
-            "total": data.total,
-            "pages": data.pages,
-        },
-    }
+    else:
+        data = query.paginate(page=page, per_page=per_page, error_out=False)
+        results = [
+            {
+                "top_level_key": entry.top_level_key,
+                "secondary_key": entry.secondary_key,
+                "value": entry.value,
+            }
+            for entry in data.items
+        ]
+        response_json = {
+            "results": results,
+            "pagination": {
+                "count": len(data.items),
+                "total": data.total,
+                "pages": data.pages,
+            },
+        }
     return make_response(jsonify(response_json), 200)
 
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
@@ -104,6 +104,9 @@ def data_store_item_list(
             status_code=400,
         )
 
+    top_level_key = top_level_key or None
+    secondary_key = secondary_key or None
+
     if top_level_key is not None and data_store_type == "kkv":
         return _kkv_filtered_items(identifier, location, top_level_key, secondary_key, page, per_page)
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
@@ -5,12 +5,15 @@ import flask.wrappers
 from flask import g
 from flask import jsonify
 from flask import make_response
+from flask import request
 
 from spiffworkflow_backend.data_stores.json import JSONDataStore
 from spiffworkflow_backend.data_stores.kkv import KKVDataStore
 from spiffworkflow_backend.data_stores.typeahead import TypeaheadDataStore
 from spiffworkflow_backend.exceptions.api_error import ApiError
 from spiffworkflow_backend.models.db import db
+from spiffworkflow_backend.models.kkv_data_store import KKVDataStoreModel
+from spiffworkflow_backend.models.kkv_data_store_entry import KKVDataStoreEntryModel
 from spiffworkflow_backend.routes.process_api_blueprint import _commit_and_push_to_git
 from spiffworkflow_backend.services.process_model_service import ProcessModelService
 from spiffworkflow_backend.services.upsearch_service import UpsearchService
@@ -23,7 +26,10 @@ DATA_STORES = {
 
 
 def data_store_list(
-    process_group_identifier: str | None = None, upsearch: bool = False, page: int = 1, per_page: int = 100
+    process_group_identifier: str | None = None,
+    upsearch: bool = False,
+    page: int = 1,
+    per_page: int = 100,
 ) -> flask.wrappers.Response:
     """Returns a list of the names of all the data stores."""
     data_stores = []
@@ -57,7 +63,11 @@ def data_store_types() -> flask.wrappers.Response:
 
 
 def _build_response(
-    data_store_class: Any, identifier: str, location: str | None, page: int, per_page: int
+    data_store_class: Any,
+    identifier: str,
+    location: str | None,
+    page: int,
+    per_page: int,
 ) -> flask.wrappers.Response:
     data_store_query = data_store_class.get_data_store_query(identifier, location)
     data = data_store_query.paginate(page=page, per_page=per_page, error_out=False)
@@ -77,24 +87,91 @@ def _build_response(
 
 
 def data_store_item_list(
-    data_store_type: str, identifier: str, location: str | None = None, page: int = 1, per_page: int = 100
+    data_store_type: str,
+    identifier: str,
+    location: str | None = None,
+    page: int = 1,
+    per_page: int = 100,
+    top_level_key: str | None = None,
+    secondary_key: str | None = None,
 ) -> flask.wrappers.Response:
     """Returns a list of the items in a data store."""
 
     if data_store_type not in DATA_STORES:
-        raise ApiError("unknown_data_store", f"Unknown data store type: {data_store_type}", status_code=400)
+        raise ApiError(
+            "unknown_data_store",
+            f"Unknown data store type: {data_store_type}",
+            status_code=400,
+        )
+
+    if top_level_key is not None and data_store_type == "kkv":
+        return _kkv_filtered_items(identifier, location, top_level_key, secondary_key, page, per_page)
 
     data_store_class, _ = DATA_STORES[data_store_type]
     return _build_response(data_store_class, identifier, location, page, per_page)
 
 
+def _kkv_filtered_items(
+    identifier: str,
+    location: str | None,
+    top_level_key: str,
+    secondary_key: str | None,
+    page: int,
+    per_page: int,
+) -> flask.wrappers.Response:
+    """Return KKV entries filtered by top_level_key and optionally secondary_key."""
+    store_model = db.session.query(KKVDataStoreModel).filter_by(identifier=identifier, location=location).first()
+
+    if store_model is None:
+        raise ApiError(
+            "could_not_locate_data_store",
+            f"Could not locate KKV data store '{identifier}' at location '{location}'.",
+            status_code=404,
+        )
+
+    query = db.session.query(KKVDataStoreEntryModel).filter_by(
+        kkv_data_store_id=store_model.id,
+        top_level_key=top_level_key,
+    )
+    if secondary_key is not None:
+        query = query.filter_by(secondary_key=secondary_key)
+
+    data = query.paginate(page=page, per_page=per_page, error_out=False)
+    results = [
+        {
+            "top_level_key": entry.top_level_key,
+            "secondary_key": entry.secondary_key,
+            "value": entry.value,
+        }
+        for entry in data.items
+    ]
+
+    response_json = {
+        "results": results,
+        "pagination": {
+            "count": len(data.items),
+            "total": data.total,
+            "pages": data.pages,
+        },
+    }
+    return make_response(jsonify(response_json), 200)
+
+
 def data_store_clear(
-    data_store_type: str, identifier: str, location: str | None = None, page: int = 1, per_page: int = 100
+    data_store_type: str,
+    identifier: str,
+    location: str | None = None,
+    page: int = 1,
+    per_page: int = 100,
 ) -> flask.wrappers.Response:
     """Clears the items in a data store."""
 
     if data_store_type not in DATA_STORES:
-        raise ApiError("unknown_data_store", f"Unknown data store type: {data_store_type}", status_code=400)
+        raise ApiError(
+            "unknown_data_store",
+            f"Unknown data store type: {data_store_type}",
+            status_code=400,
+        )
 
     data_store_class, _ = DATA_STORES[data_store_type]
     data_store_class.clear(identifier, location)
@@ -105,7 +182,11 @@ def data_store_delete(data_store_type: str, identifier: str, process_group_ident
     """Deletes a data store."""
 
     if data_store_type not in DATA_STORES:
-        raise ApiError("unknown_data_store", f"Unknown data store type: {data_store_type}", status_code=400)
+        raise ApiError(
+            "unknown_data_store",
+            f"Unknown data store type: {data_store_type}",
+            status_code=400,
+        )
 
     data_store_class, _ = DATA_STORES[data_store_type]
     data_store_class.delete(identifier, process_group_identifier)
@@ -150,7 +231,11 @@ def _data_store_upsert(body: dict, insert: bool) -> flask.wrappers.Response:
         ) from e
 
     if data_store_type not in DATA_STORES:
-        raise ApiError("unknown_data_store", f"Unknown data store type: {data_store_type}", status_code=400)
+        raise ApiError(
+            "unknown_data_store",
+            f"Unknown data store type: {data_store_type}",
+            status_code=400,
+        )
 
     data_store_class, _ = DATA_STORES[data_store_type]
 
@@ -173,10 +258,14 @@ def _data_store_upsert(body: dict, insert: bool) -> flask.wrappers.Response:
 
 
 def _write_specification_to_process_group(
-    data_store_type: str, data_store_model: JSONDataStore | KKVDataStore | TypeaheadDataStore
+    data_store_type: str,
+    data_store_model: JSONDataStore | KKVDataStore | TypeaheadDataStore,
 ) -> None:
     process_group = ProcessModelService.get_process_group(
-        data_store_model.location, find_direct_nested_items=False, find_all_nested_items=False, create_if_not_exists=True
+        data_store_model.location,
+        find_direct_nested_items=False,
+        find_all_nested_items=False,
+        create_if_not_exists=True,
     )
 
     if data_store_type not in process_group.data_store_specifications:
@@ -197,7 +286,11 @@ def data_store_show(data_store_type: str, identifier: str, process_group_identif
     """Returns a description of a data store."""
 
     if data_store_type not in DATA_STORES:
-        raise ApiError("unknown_data_store", f"Unknown data store type: {data_store_type}", status_code=400)
+        raise ApiError(
+            "unknown_data_store",
+            f"Unknown data store type: {data_store_type}",
+            status_code=400,
+        )
 
     data_store_class, _ = DATA_STORES[data_store_type]
     data_store_query = data_store_class.get_data_store_query(identifier, process_group_identifier)
@@ -220,3 +313,101 @@ def data_store_show(data_store_type: str, identifier: str, process_group_identif
     }
 
     return make_response(jsonify(response), 200)
+
+
+def data_store_write_items(data_store_type: str, identifier: str, location: str | None = None) -> flask.wrappers.Response:
+    """Write entries into a KKV data store.
+
+    Accepts a JSON body of the form:
+        {
+            "<top_level_key>": {
+                "<secondary_key>": <value>,
+                ...
+            },
+            ...
+        }
+
+    Follows the same semantics as KKVDataStore.set():
+    - If a top_level_key maps to None, all entries for that top_level_key are deleted.
+    - If a secondary_key maps to None, that specific entry is deleted.
+    - Otherwise, the entry is upserted (created or updated).
+    """
+    if data_store_type != "kkv":
+        raise ApiError(
+            "unsupported_data_store_type",
+            f"Writing items is only supported for KKV data stores, got: {data_store_type}",
+            status_code=400,
+        )
+
+    body = request.get_json(silent=True)
+    if not isinstance(body, dict):
+        raise ApiError(
+            "invalid_request_body",
+            "Request body must be a JSON object mapping top_level_key to {secondary_key: value}.",
+            status_code=400,
+        )
+
+    store_model = db.session.query(KKVDataStoreModel).filter_by(identifier=identifier, location=location).first()
+
+    if store_model is None:
+        raise ApiError(
+            "could_not_locate_data_store",
+            f"Could not locate KKV data store '{identifier}' at location '{location}'.",
+            status_code=404,
+        )
+
+    for top_level_key, second_level in body.items():
+        if not isinstance(top_level_key, str):
+            raise ApiError(
+                "invalid_top_level_key",
+                "Top-level keys must be strings.",
+                status_code=400,
+            )
+
+        if second_level is None:
+            models = (
+                db.session.query(KKVDataStoreEntryModel)
+                .filter_by(kkv_data_store_id=store_model.id, top_level_key=top_level_key)
+                .all()
+            )
+            for model_to_delete in models:
+                db.session.delete(model_to_delete)
+            continue
+
+        if not isinstance(second_level, dict):
+            raise ApiError(
+                "invalid_secondary_level",
+                f"Value for top_level_key '{top_level_key}' must be a dict or null.",
+                status_code=400,
+            )
+
+        for secondary_key, value in second_level.items():
+            model = (
+                db.session.query(KKVDataStoreEntryModel)
+                .filter_by(
+                    kkv_data_store_id=store_model.id,
+                    top_level_key=top_level_key,
+                    secondary_key=secondary_key,
+                )
+                .first()
+            )
+
+            if model is None and value is None:
+                continue
+            if value is None:
+                db.session.delete(model)
+                continue
+
+            if model is None:
+                model = KKVDataStoreEntryModel(
+                    kkv_data_store_id=store_model.id,
+                    top_level_key=top_level_key,
+                    secondary_key=secondary_key,
+                    value=value,
+                )
+            else:
+                model.value = value
+            db.session.add(model)
+
+    db.session.commit()
+    return make_response(jsonify({"ok": True}), 200)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
@@ -1,5 +1,7 @@
 import json
+from collections.abc import Callable
 from typing import Any
+from typing import TypeAlias
 
 import flask.wrappers
 from flask import g
@@ -7,6 +9,7 @@ from flask import jsonify
 from flask import make_response
 from flask import request
 
+from spiffworkflow_backend.data_stores.crud import DataStoreCRUD
 from spiffworkflow_backend.data_stores.json import JSONDataStore
 from spiffworkflow_backend.data_stores.kkv import KKVDataStore
 from spiffworkflow_backend.data_stores.typeahead import TypeaheadDataStore
@@ -19,7 +22,9 @@ from spiffworkflow_backend.routes.process_api_blueprint import _commit_and_push_
 from spiffworkflow_backend.services.process_model_service import ProcessModelService
 from spiffworkflow_backend.services.upsearch_service import UpsearchService
 
-DATA_STORES = {
+DataStoreClass: TypeAlias = type[DataStoreCRUD]
+
+DATA_STORES: dict[str, tuple[DataStoreClass, str]] = {
     "json": (JSONDataStore, "JSON Data Store"),
     "kkv": (KKVDataStore, "Keyed Key-Value Data Store"),
     "typeahead": (TypeaheadDataStore, "Typeahead Data Store"),
@@ -63,37 +68,38 @@ def data_store_types() -> flask.wrappers.Response:
     return make_response(jsonify(data_store_types), 200)
 
 
+def _paginated_response(
+    query: Any,
+    item_mapper: Callable,
+    page: int,
+    per_page: int,
+    paginate: bool,
+) -> flask.wrappers.Response:
+    if paginate:
+        data = query.paginate(page=page, per_page=per_page, error_out=False)
+        results = [item_mapper(item) for item in data.items]
+        pagination = {
+            "count": len(data.items),
+            "total": data.total,
+            "pages": data.pages,
+        }
+    else:
+        items = query.all()
+        results = [item_mapper(item) for item in items]
+        pagination = {"count": len(results), "total": len(results), "pages": 1}
+    return make_response(jsonify({"results": results, "pagination": pagination}), 200)
+
+
 def _build_response(
-    data_store_class: Any,
+    data_store_class: DataStoreClass,
     identifier: str,
     location: str | None,
     page: int,
     per_page: int,
+    paginate: bool,
 ) -> flask.wrappers.Response:
-    data_store_query = data_store_class.get_data_store_query(identifier, location)
-    if per_page == 0:
-        items = data_store_query.all()
-        results = [data_store_class.build_response_item(item) for item in items]
-        response_json = {
-            "results": results,
-            "pagination": {
-                "count": len(results),
-                "total": len(results),
-                "pages": 1,
-            },
-        }
-    else:
-        data = data_store_query.paginate(page=page, per_page=per_page, error_out=False)
-        results = [data_store_class.build_response_item(item) for item in data.items]
-        response_json = {
-            "results": results,
-            "pagination": {
-                "count": len(data.items),
-                "total": data.total,
-                "pages": data.pages,
-            },
-        }
-    return make_response(jsonify(response_json), 200)
+    query = data_store_class.get_data_store_query(identifier, location)
+    return _paginated_response(query, data_store_class.build_response_item, page, per_page, paginate)
 
 
 def data_store_item_list(
@@ -104,6 +110,7 @@ def data_store_item_list(
     per_page: int = 100,
     top_level_key: str | None = None,
     secondary_key: str | None = None,
+    paginate: bool = True,
 ) -> flask.wrappers.Response:
     """Returns a list of the items in a data store."""
 
@@ -118,10 +125,10 @@ def data_store_item_list(
     secondary_key = secondary_key or None
 
     if data_store_type == "kkv":
-        return _kkv_filtered_items(identifier, location, top_level_key, secondary_key, page, per_page)
+        return _kkv_filtered_items(identifier, location, top_level_key, secondary_key, page, per_page, paginate)
 
     data_store_class, _ = DATA_STORES[data_store_type]
-    return _build_response(data_store_class, identifier, location, page, per_page)
+    return _build_response(data_store_class, identifier, location, page, per_page, paginate)
 
 
 def _kkv_filtered_items(
@@ -131,6 +138,7 @@ def _kkv_filtered_items(
     secondary_key: str | None,
     page: int,
     per_page: int,
+    paginate: bool,
 ) -> flask.wrappers.Response:
     """Return KKV entries filtered by top_level_key and/or secondary_key."""
     store_model = db.session.query(KKVDataStoreModel).filter_by(identifier=identifier, location=location).first()
@@ -154,43 +162,14 @@ def _kkv_filtered_items(
         KKVDataStoreEntryModel.id,
     )
 
-    if per_page == 0:
-        items = query.all()
-        results = [
-            {
-                "top_level_key": entry.top_level_key,
-                "secondary_key": entry.secondary_key,
-                "value": entry.value,
-            }
-            for entry in items
-        ]
-        response_json = {
-            "results": results,
-            "pagination": {
-                "count": len(results),
-                "total": len(results),
-                "pages": 1,
-            },
+    def _kkv_item_mapper(entry: KKVDataStoreEntryModel) -> dict:
+        return {
+            "top_level_key": entry.top_level_key,
+            "secondary_key": entry.secondary_key,
+            "value": entry.value,
         }
-    else:
-        data = query.paginate(page=page, per_page=per_page, error_out=False)  # type: ignore[attr-defined]
-        results = [
-            {
-                "top_level_key": entry.top_level_key,
-                "secondary_key": entry.secondary_key,
-                "value": entry.value,
-            }
-            for entry in data.items
-        ]
-        response_json = {
-            "results": results,
-            "pagination": {
-                "count": len(data.items),
-                "total": data.total,
-                "pages": data.pages,
-            },
-        }
-    return make_response(jsonify(response_json), 200)
+
+    return _paginated_response(query, _kkv_item_mapper, page, per_page, paginate)
 
 
 def data_store_clear(
@@ -211,7 +190,7 @@ def data_store_clear(
 
     data_store_class, _ = DATA_STORES[data_store_type]
     data_store_class.clear(identifier, location)
-    return _build_response(data_store_class, identifier, location, page, per_page)
+    return _build_response(data_store_class, identifier, location, page, per_page, paginate=True)
 
 
 def data_store_delete(data_store_type: str, identifier: str, process_group_identifier: str) -> flask.wrappers.Response:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
@@ -173,7 +173,7 @@ def _kkv_filtered_items(
             },
         }
     else:
-        data = query.paginate(page=page, per_page=per_page, error_out=False)
+        data = query.paginate(page=page, per_page=per_page, error_out=False)  # type: ignore[attr-defined]
         results = [
             {
                 "top_level_key": entry.top_level_key,

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
@@ -682,7 +682,8 @@ class AuthorizationService:
         for permission in ["create", "read", "update", "delete"]:
             permissions_to_assign.append(PermissionToAssign(permission=permission, target_uri="/process-instances/*"))
 
-        permissions_to_assign.append(PermissionToAssign(permission="read", target_uri="/data-stores/*"))
+        for permission in ["create", "read", "update", "delete"]:
+            permissions_to_assign.append(PermissionToAssign(permission=permission, target_uri="/data-stores/*"))
         return permissions_to_assign
 
     @classmethod

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/authorization_service.py
@@ -148,7 +148,10 @@ class AuthorizationService:
 
     @classmethod
     def permission_assignments_include(
-        cls, permission_assignments: list[PermissionAssignmentModel], permission: str, target_uri: str
+        cls,
+        permission_assignments: list[PermissionAssignmentModel],
+        permission: str,
+        target_uri: str,
     ) -> bool:
         uri_with_percent = re.sub(r"\*", "%", target_uri)
         target_uri_normalized = remove_api_prefix(uri_with_percent)
@@ -647,9 +650,18 @@ class AuthorizationService:
     def set_support_permissions(cls) -> list[PermissionToAssign]:
         """Just like elevated permissions minus access to secrets."""
         permissions_to_assign = cls.set_basic_permissions()
-        for process_instance_action in ["migrate", "resume", "terminate", "suspend", "reset"]:
+        for process_instance_action in [
+            "migrate",
+            "resume",
+            "terminate",
+            "suspend",
+            "reset",
+        ]:
             permissions_to_assign.append(
-                PermissionToAssign(permission="create", target_uri=f"/process-instance-{process_instance_action}/*")
+                PermissionToAssign(
+                    permission="create",
+                    target_uri=f"/process-instance-{process_instance_action}/*",
+                )
             )
 
         # FIXME: we need to fix so that user that can start a process-model
@@ -849,7 +861,11 @@ class AuthorizationService:
 
         if "groups" in permission_configs:
             for group_identifier, group_config in permission_configs["groups"].items():
-                group_info: GroupPermissionsDict = {"name": group_identifier, "users": [], "permissions": []}
+                group_info: GroupPermissionsDict = {
+                    "name": group_identifier,
+                    "users": [],
+                    "permissions": [],
+                }
                 for username in group_config["users"]:
                     group_info["users"].append(username)
                 group_permissions_by_group[group_identifier] = group_info
@@ -902,7 +918,10 @@ class AuthorizationService:
                     f"ADD PERMISSIONS - Processing {len(group['users'])} users for group: {group_identifier}"
                 )
                 for user_index, username_or_email in enumerate(group["users"]):
-                    if user_model and username_or_email not in [user_model.username, user_model.email]:
+                    if user_model and username_or_email not in [
+                        user_model.username,
+                        user_model.email,
+                    ]:
                         continue
 
                     user_count = len(group["users"])
@@ -911,7 +930,7 @@ class AuthorizationService:
                         f"ADD PERMISSIONS - Processing user {user_num}/{user_count}: "
                         f"{username_or_email} for group: {group_identifier}"
                     )
-                    (wugam, new_user_to_group_identifiers) = UserService.add_user_to_group_or_add_to_waiting(
+                    wugam, new_user_to_group_identifiers = UserService.add_user_to_group_or_add_to_waiting(
                         username_or_email, group_identifier
                     )
                     if wugam is not None:
@@ -1038,7 +1057,11 @@ class AuthorizationService:
         db.session.commit()
 
     @classmethod
-    def refresh_permissions(cls, group_permissions: list[GroupPermissionsDict], group_permissions_only: bool = False) -> None:
+    def refresh_permissions(
+        cls,
+        group_permissions: list[GroupPermissionsDict],
+        group_permissions_only: bool = False,
+    ) -> None:
         """Adds new permission assignments and deletes old ones."""
         groups_count = len(group_permissions)
         current_app.logger.debug(
@@ -1051,7 +1074,10 @@ class AuthorizationService:
             initial_permission_assignments = (
                 PermissionAssignmentModel.query.outerjoin(
                     PrincipalModel,
-                    and_(PrincipalModel.id == PermissionAssignmentModel.principal_id, PrincipalModel.user_id.is_not(None)),
+                    and_(
+                        PrincipalModel.id == PermissionAssignmentModel.principal_id,
+                        PrincipalModel.user_id.is_not(None),
+                    ),
                 )
                 .outerjoin(UserModel, UserModel.id == PrincipalModel.user_id)
                 .filter(or_(UserModel.id.is_(None), UserModel.service != SPIFF_SERVICE_ACCOUNT_AUTH_SERVICE))  # type: ignore

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_data_store_item_list_filtering.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_data_store_item_list_filtering.py
@@ -149,13 +149,12 @@ class TestDataStoreItemListFiltering(BaseTest):
         with_super_admin_user: UserModel,
         with_populated_kkv_store: KKVDataStoreModel,
     ) -> None:
-        """When neither key is provided, should use the standard (non-filtered) code path."""
+        """When neither key is provided, should return all entries in flat format."""
         response = self._get(client, with_super_admin_user)
         assert response.status_code == 200
         results = response.json()["results"]
-        # Standard path returns a single result containing all entries in a "data" list
-        assert len(results) == 1
-        assert len(results[0]["data"]) == 5
+        assert len(results) == 5
+        assert all("top_level_key" in r and "secondary_key" in r and "value" in r for r in results)
 
     def test_filter_returns_404_for_nonexistent_store(
         self,
@@ -182,3 +181,36 @@ class TestDataStoreItemListFiltering(BaseTest):
         assert len(response.json()["results"]) == 1
         assert response.json()["pagination"]["total"] == 2
         assert response.json()["pagination"]["pages"] == 2
+
+    def test_per_page_zero_returns_all_results(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        with_populated_kkv_store: KKVDataStoreModel,
+    ) -> None:
+        url = "/v1.0/data-stores/kkv/test_store/items?location=test_location&per_page=0"
+        response = client.get(url, headers=self.logged_in_headers(with_super_admin_user))
+        assert response.status_code == 200
+        results = response.json()["results"]
+        assert len(results) == 5
+        assert response.json()["pagination"]["total"] == 5
+        assert response.json()["pagination"]["pages"] == 1
+
+    def test_per_page_zero_with_filter(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        with_populated_kkv_store: KKVDataStoreModel,
+    ) -> None:
+        url = "/v1.0/data-stores/kkv/test_store/items?location=test_location&secondary_key=model_a&per_page=0"
+        response = client.get(url, headers=self.logged_in_headers(with_super_admin_user))
+        assert response.status_code == 200
+        results = response.json()["results"]
+        assert len(results) == 2
+        assert all(r["secondary_key"] == "model_a" for r in results)
+        assert response.json()["pagination"]["total"] == 2
+        assert response.json()["pagination"]["pages"] == 1

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_data_store_item_list_filtering.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_data_store_item_list_filtering.py
@@ -183,7 +183,7 @@ class TestDataStoreItemListFiltering(BaseTest):
         assert response.json()["pagination"]["total"] == 2
         assert response.json()["pagination"]["pages"] == 2
 
-    def test_per_page_zero_returns_all_results(
+    def test_paginate_false_returns_all_results(
         self,
         app: Flask,
         client: TestClient,
@@ -191,7 +191,7 @@ class TestDataStoreItemListFiltering(BaseTest):
         with_super_admin_user: UserModel,
         with_populated_kkv_store: KKVDataStoreModel,
     ) -> None:
-        url = "/v1.0/data-stores/kkv/test_store/items?location=test_location&per_page=0"
+        url = "/v1.0/data-stores/kkv/test_store/items?location=test_location&paginate=false"
         response = client.get(url, headers=self.logged_in_headers(with_super_admin_user))
         assert response.status_code == 200
         results = response.json()["results"]
@@ -199,7 +199,7 @@ class TestDataStoreItemListFiltering(BaseTest):
         assert response.json()["pagination"]["total"] == 5
         assert response.json()["pagination"]["pages"] == 1
 
-    def test_per_page_zero_with_filter(
+    def test_paginate_false_with_filter(
         self,
         app: Flask,
         client: TestClient,
@@ -207,7 +207,7 @@ class TestDataStoreItemListFiltering(BaseTest):
         with_super_admin_user: UserModel,
         with_populated_kkv_store: KKVDataStoreModel,
     ) -> None:
-        url = "/v1.0/data-stores/kkv/test_store/items?location=test_location&secondary_key=model_a&per_page=0"
+        url = "/v1.0/data-stores/kkv/test_store/items?location=test_location&secondary_key=model_a&paginate=false"
         response = client.get(url, headers=self.logged_in_headers(with_super_admin_user))
         assert response.status_code == 200
         results = response.json()["results"]

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_data_store_item_list_filtering.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_data_store_item_list_filtering.py
@@ -1,0 +1,184 @@
+from collections.abc import Generator
+
+import pytest
+from flask import Flask
+from starlette.testclient import TestClient
+
+from spiffworkflow_backend.models.db import db
+from spiffworkflow_backend.models.kkv_data_store import KKVDataStoreModel
+from spiffworkflow_backend.models.kkv_data_store_entry import KKVDataStoreEntryModel
+from spiffworkflow_backend.models.user import UserModel
+from tests.spiffworkflow_backend.helpers.base_test import BaseTest
+
+
+@pytest.fixture()
+def with_populated_kkv_store(app: Flask, with_db_and_bpmn_file_cleanup: None) -> Generator[KKVDataStoreModel, None, None]:
+    db.session.query(KKVDataStoreEntryModel).delete()
+    db.session.query(KKVDataStoreModel).delete()
+    db.session.commit()
+
+    model = KKVDataStoreModel(identifier="test_store", name="Test Store", location="test_location", schema={})
+    db.session.add(model)
+    db.session.commit()
+
+    entries = [
+        KKVDataStoreEntryModel(
+            kkv_data_store_id=model.id,
+            top_level_key="instance_1",
+            secondary_key="model_a",
+            value={"status": "complete"},
+        ),
+        KKVDataStoreEntryModel(
+            kkv_data_store_id=model.id,
+            top_level_key="instance_1",
+            secondary_key="model_b",
+            value={"status": "pending"},
+        ),
+        KKVDataStoreEntryModel(
+            kkv_data_store_id=model.id,
+            top_level_key="instance_2",
+            secondary_key="model_a",
+            value={"status": "active"},
+        ),
+        KKVDataStoreEntryModel(
+            kkv_data_store_id=model.id,
+            top_level_key="instance_2",
+            secondary_key="model_c",
+            value={"status": "error"},
+        ),
+        KKVDataStoreEntryModel(
+            kkv_data_store_id=model.id,
+            top_level_key="instance_3",
+            secondary_key="model_b",
+            value={"status": "complete"},
+        ),
+    ]
+    db.session.add_all(entries)
+    db.session.commit()
+
+    yield model
+
+
+class TestDataStoreItemListFiltering(BaseTest):
+    """Tests for GET /data-stores/kkv/{identifier}/items with top_level_key and/or secondary_key filters."""
+
+    def _get(
+        self,
+        client: TestClient,
+        user: UserModel,
+        identifier: str = "test_store",
+        location: str = "test_location",
+        top_level_key: str | None = None,
+        secondary_key: str | None = None,
+    ) -> TestClient:
+        url = f"/v1.0/data-stores/kkv/{identifier}/items?location={location}"
+        if top_level_key is not None:
+            url += f"&top_level_key={top_level_key}"
+        if secondary_key is not None:
+            url += f"&secondary_key={secondary_key}"
+        return client.get(url, headers=self.logged_in_headers(user))
+
+    def test_filter_by_top_level_key_only(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        with_populated_kkv_store: KKVDataStoreModel,
+    ) -> None:
+        response = self._get(client, with_super_admin_user, top_level_key="instance_1")
+        assert response.status_code == 200
+        results = response.json()["results"]
+        assert len(results) == 2
+        assert all(r["top_level_key"] == "instance_1" for r in results)
+
+    def test_filter_by_secondary_key_only(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        with_populated_kkv_store: KKVDataStoreModel,
+    ) -> None:
+        response = self._get(client, with_super_admin_user, secondary_key="model_a")
+        assert response.status_code == 200
+        results = response.json()["results"]
+        assert len(results) == 2
+        assert all(r["secondary_key"] == "model_a" for r in results)
+
+    def test_filter_by_both_keys(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        with_populated_kkv_store: KKVDataStoreModel,
+    ) -> None:
+        response = self._get(
+            client,
+            with_super_admin_user,
+            top_level_key="instance_1",
+            secondary_key="model_b",
+        )
+        assert response.status_code == 200
+        results = response.json()["results"]
+        assert len(results) == 1
+        assert results[0]["top_level_key"] == "instance_1"
+        assert results[0]["secondary_key"] == "model_b"
+        assert results[0]["value"] == {"status": "pending"}
+
+    def test_filter_returns_empty_for_no_match(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        with_populated_kkv_store: KKVDataStoreModel,
+    ) -> None:
+        response = self._get(client, with_super_admin_user, top_level_key="nonexistent")
+        assert response.status_code == 200
+        results = response.json()["results"]
+        assert len(results) == 0
+        assert response.json()["pagination"]["total"] == 0
+
+    def test_no_filter_returns_all_items_via_standard_path(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        with_populated_kkv_store: KKVDataStoreModel,
+    ) -> None:
+        """When neither key is provided, should use the standard (non-filtered) code path."""
+        response = self._get(client, with_super_admin_user)
+        assert response.status_code == 200
+        results = response.json()["results"]
+        # Standard path returns a single result containing all entries in a "data" list
+        assert len(results) == 1
+        assert len(results[0]["data"]) == 5
+
+    def test_filter_returns_404_for_nonexistent_store(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        with_populated_kkv_store: KKVDataStoreModel,
+    ) -> None:
+        response = self._get(client, with_super_admin_user, identifier="no_such_store", top_level_key="x")
+        assert response.status_code == 404
+
+    def test_filter_pagination(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        with_populated_kkv_store: KKVDataStoreModel,
+    ) -> None:
+        url = "/v1.0/data-stores/kkv/test_store/items?location=test_location&secondary_key=model_b&per_page=1&page=1"
+        response = client.get(url, headers=self.logged_in_headers(with_super_admin_user))
+        assert response.status_code == 200
+        assert len(response.json()["results"]) == 1
+        assert response.json()["pagination"]["total"] == 2
+        assert response.json()["pagination"]["pages"] == 2

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_data_store_item_list_filtering.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_data_store_item_list_filtering.py
@@ -2,6 +2,7 @@ from collections.abc import Generator
 
 import pytest
 from flask import Flask
+from httpx import Response
 from starlette.testclient import TestClient
 
 from spiffworkflow_backend.models.db import db
@@ -70,7 +71,7 @@ class TestDataStoreItemListFiltering(BaseTest):
         location: str = "test_location",
         top_level_key: str | None = None,
         secondary_key: str | None = None,
-    ) -> TestClient:
+    ) -> Response:
         url = f"/v1.0/data-stores/kkv/{identifier}/items?location={location}"
         if top_level_key is not None:
             url += f"&top_level_key={top_level_key}"

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_data_store_write_items.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_data_store_write_items.py
@@ -2,6 +2,7 @@ from collections.abc import Generator
 
 import pytest
 from flask import Flask
+from httpx import Response
 from starlette.testclient import TestClient
 
 from spiffworkflow_backend.models.db import db
@@ -45,7 +46,7 @@ class TestDataStoreWriteItems(BaseTest):
         identifier: str,
         body: dict,
         location: str | None = "test_location",
-    ) -> TestClient:
+    ) -> Response:
         url = f"/v1.0/data-stores/kkv/{identifier}/items"
         if location is not None:
             url += f"?location={location}"
@@ -331,7 +332,7 @@ class TestDataStoreFilteredGet(BaseTest):
         identifier: str,
         body: dict,
         location: str = "test_location",
-    ) -> TestClient:
+    ) -> Response:
         return client.put(
             f"/v1.0/data-stores/kkv/{identifier}/items?location={location}",
             headers=self.logged_in_headers(user),
@@ -346,7 +347,7 @@ class TestDataStoreFilteredGet(BaseTest):
         location: str = "test_location",
         top_level_key: str | None = None,
         secondary_key: str | None = None,
-    ) -> TestClient:
+    ) -> Response:
         url = f"/v1.0/data-stores/kkv/{identifier}/items?location={location}"
         if top_level_key is not None:
             url += f"&top_level_key={top_level_key}"

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_data_store_write_items.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_data_store_write_items.py
@@ -442,5 +442,4 @@ class TestDataStoreFilteredGet(BaseTest):
         self._seed_data(client, with_super_admin_user)
         response = self._get(client, with_super_admin_user, "test_store")
         assert response.status_code == 200
-        data = response.json()["results"][0]["data"]
-        assert len(data) == 3
+        assert len(response.json()["results"]) == 3

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_data_store_write_items.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_data_store_write_items.py
@@ -1,0 +1,446 @@
+from collections.abc import Generator
+
+import pytest
+from flask import Flask
+from starlette.testclient import TestClient
+
+from spiffworkflow_backend.models.db import db
+from spiffworkflow_backend.models.kkv_data_store import KKVDataStoreModel
+from spiffworkflow_backend.models.kkv_data_store_entry import KKVDataStoreEntryModel
+from spiffworkflow_backend.models.user import UserModel
+from tests.spiffworkflow_backend.helpers.base_test import BaseTest
+
+
+@pytest.fixture()
+def with_clean_kkv_store(app: Flask, with_db_and_bpmn_file_cleanup: None) -> Generator[KKVDataStoreModel, None, None]:
+    db.session.query(KKVDataStoreModel).delete()
+    db.session.commit()
+
+    model = KKVDataStoreModel(identifier="test_store", name="Test Store", location="test_location", schema={})
+    db.session.add(model)
+    db.session.commit()
+
+    yield model
+
+
+def _entry_count(store: KKVDataStoreModel) -> int:
+    return db.session.query(KKVDataStoreEntryModel).filter_by(kkv_data_store_id=store.id).count()
+
+
+def _get_entry(store: KKVDataStoreModel, top_key: str, sec_key: str) -> KKVDataStoreEntryModel | None:
+    return (
+        db.session.query(KKVDataStoreEntryModel)
+        .filter_by(kkv_data_store_id=store.id, top_level_key=top_key, secondary_key=sec_key)
+        .first()
+    )
+
+
+class TestDataStoreWriteItems(BaseTest):
+    """Tests for PUT /data-stores/{data_store_type}/{identifier}/items."""
+
+    def _put(
+        self,
+        client: TestClient,
+        user: UserModel,
+        identifier: str,
+        body: dict,
+        location: str | None = "test_location",
+    ) -> TestClient:
+        url = f"/v1.0/data-stores/kkv/{identifier}/items"
+        if location is not None:
+            url += f"?location={location}"
+        return client.put(
+            url,
+            headers=self.logged_in_headers(user),
+            json=body,
+        )
+
+    # --- Insert tests ---
+
+    def test_can_insert_a_single_entry(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        with_clean_kkv_store: KKVDataStoreModel,
+    ) -> None:
+        response = self._put(
+            client,
+            with_super_admin_user,
+            "test_store",
+            {"top1": {"sec1": {"field": "value"}}},
+        )
+        assert response.status_code == 200
+        assert response.json()["ok"] is True
+        assert _entry_count(with_clean_kkv_store) == 1
+        entry = _get_entry(with_clean_kkv_store, "top1", "sec1")
+        assert entry is not None
+        assert entry.value == {"field": "value"}
+
+    def test_can_insert_multiple_secondary_keys(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        with_clean_kkv_store: KKVDataStoreModel,
+    ) -> None:
+        response = self._put(
+            client,
+            with_super_admin_user,
+            "test_store",
+            {"top1": {"sec1": "val1", "sec2": "val2"}},
+        )
+        assert response.status_code == 200
+        assert _entry_count(with_clean_kkv_store) == 2
+
+    def test_can_insert_multiple_top_level_keys(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        with_clean_kkv_store: KKVDataStoreModel,
+    ) -> None:
+        response = self._put(
+            client,
+            with_super_admin_user,
+            "test_store",
+            {
+                "top1": {"sec1": "val1"},
+                "top2": {"sec2": "val2"},
+            },
+        )
+        assert response.status_code == 200
+        assert _entry_count(with_clean_kkv_store) == 2
+
+    # --- Update tests ---
+
+    def test_can_update_an_existing_entry(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        with_clean_kkv_store: KKVDataStoreModel,
+    ) -> None:
+        self._put(client, with_super_admin_user, "test_store", {"top1": {"sec1": "original"}})
+        response = self._put(client, with_super_admin_user, "test_store", {"top1": {"sec1": "updated"}})
+        assert response.status_code == 200
+        assert _entry_count(with_clean_kkv_store) == 1
+        entry = _get_entry(with_clean_kkv_store, "top1", "sec1")
+        assert entry is not None
+        assert entry.value == "updated"
+
+    # --- Delete tests ---
+
+    def test_can_delete_entry_by_nulling_secondary_key(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        with_clean_kkv_store: KKVDataStoreModel,
+    ) -> None:
+        self._put(
+            client,
+            with_super_admin_user,
+            "test_store",
+            {"top1": {"sec1": "val1", "sec2": "val2"}},
+        )
+        assert _entry_count(with_clean_kkv_store) == 2
+
+        response = self._put(client, with_super_admin_user, "test_store", {"top1": {"sec1": None}})
+        assert response.status_code == 200
+        assert _entry_count(with_clean_kkv_store) == 1
+        assert _get_entry(with_clean_kkv_store, "top1", "sec1") is None
+        assert _get_entry(with_clean_kkv_store, "top1", "sec2") is not None
+
+    def test_can_delete_all_entries_by_nulling_top_level_key(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        with_clean_kkv_store: KKVDataStoreModel,
+    ) -> None:
+        self._put(
+            client,
+            with_super_admin_user,
+            "test_store",
+            {"top1": {"sec1": "val1", "sec2": "val2"}},
+        )
+        assert _entry_count(with_clean_kkv_store) == 2
+
+        response = self._put(client, with_super_admin_user, "test_store", {"top1": None})
+        assert response.status_code == 200
+        assert _entry_count(with_clean_kkv_store) == 0
+
+    def test_null_secondary_key_for_nonexistent_entry_is_noop(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        with_clean_kkv_store: KKVDataStoreModel,
+    ) -> None:
+        response = self._put(client, with_super_admin_user, "test_store", {"top1": {"sec1": None}})
+        assert response.status_code == 200
+        assert _entry_count(with_clean_kkv_store) == 0
+
+    # --- Error handling ---
+
+    def test_returns_404_for_nonexistent_store(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        with_clean_kkv_store: KKVDataStoreModel,
+    ) -> None:
+        response = self._put(
+            client,
+            with_super_admin_user,
+            "nonexistent_store",
+            {"top1": {"sec1": "val1"}},
+        )
+        assert response.status_code == 404
+
+    def test_returns_400_for_non_kkv_type(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        with_clean_kkv_store: KKVDataStoreModel,
+    ) -> None:
+        response = client.put(
+            "/v1.0/data-stores/json/test_store/items?location=test_location",
+            headers=self.logged_in_headers(with_super_admin_user),
+            json={"top1": {"sec1": "val1"}},
+        )
+        assert response.status_code == 400
+
+    def test_returns_400_for_invalid_body(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        with_clean_kkv_store: KKVDataStoreModel,
+    ) -> None:
+        headers = self.logged_in_headers(with_super_admin_user)
+        headers["Content-Type"] = "application/json"
+        response = client.put(
+            "/v1.0/data-stores/kkv/test_store/items?location=test_location",
+            headers=headers,
+            content=b"not json",
+        )
+        assert response.status_code == 400
+
+    def test_returns_400_for_non_dict_secondary_level(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        with_clean_kkv_store: KKVDataStoreModel,
+    ) -> None:
+        response = self._put(client, with_super_admin_user, "test_store", {"top1": "not_a_dict"})
+        assert response.status_code == 400
+
+    # --- Complex value types ---
+
+    def test_can_store_list_values(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        with_clean_kkv_store: KKVDataStoreModel,
+    ) -> None:
+        data = [{"name": "exclusionsText", "value": "CE text"}]
+        response = self._put(
+            client,
+            with_super_admin_user,
+            "test_store",
+            {"pid_42": {"BLM-MOAB-CE": data}},
+        )
+        assert response.status_code == 200
+        entry = _get_entry(with_clean_kkv_store, "pid_42", "BLM-MOAB-CE")
+        assert entry is not None
+        assert entry.value == data
+
+    def test_can_store_nested_object_values(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        with_clean_kkv_store: KKVDataStoreModel,
+    ) -> None:
+        data = {
+            "projectLead": {"value": "Analyst Arthur", "comment": {"saved": False}},
+            "applicant": {"value": "Various", "comment": {"saved": False}},
+        }
+        response = self._put(
+            client,
+            with_super_admin_user,
+            "test_store",
+            {"pid_42": {"BLM-MOAB-CE": data}},
+        )
+        assert response.status_code == 200
+        entry = _get_entry(with_clean_kkv_store, "pid_42", "BLM-MOAB-CE")
+        assert entry is not None
+        assert entry.value == data
+
+    # --- Top-level key scoping ---
+
+    def test_delete_does_not_affect_other_top_level_keys(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        with_clean_kkv_store: KKVDataStoreModel,
+    ) -> None:
+        self._put(
+            client,
+            with_super_admin_user,
+            "test_store",
+            {
+                "top1": {"sec1": "val1"},
+                "top2": {"sec2": "val2"},
+            },
+        )
+        assert _entry_count(with_clean_kkv_store) == 2
+
+        self._put(client, with_super_admin_user, "test_store", {"top1": None})
+        assert _entry_count(with_clean_kkv_store) == 1
+        assert _get_entry(with_clean_kkv_store, "top2", "sec2") is not None
+
+
+class TestDataStoreFilteredGet(BaseTest):
+    """Tests for GET /data-stores/kkv/{identifier}/items with top_level_key/secondary_key filters."""
+
+    def _put(
+        self,
+        client: TestClient,
+        user: UserModel,
+        identifier: str,
+        body: dict,
+        location: str = "test_location",
+    ) -> TestClient:
+        return client.put(
+            f"/v1.0/data-stores/kkv/{identifier}/items?location={location}",
+            headers=self.logged_in_headers(user),
+            json=body,
+        )
+
+    def _get(
+        self,
+        client: TestClient,
+        user: UserModel,
+        identifier: str,
+        location: str = "test_location",
+        top_level_key: str | None = None,
+        secondary_key: str | None = None,
+    ) -> TestClient:
+        url = f"/v1.0/data-stores/kkv/{identifier}/items?location={location}"
+        if top_level_key is not None:
+            url += f"&top_level_key={top_level_key}"
+        if secondary_key is not None:
+            url += f"&secondary_key={secondary_key}"
+        return client.get(url, headers=self.logged_in_headers(user))
+
+    def _seed_data(self, client: TestClient, user: UserModel) -> None:
+        self._put(
+            client,
+            user,
+            "test_store",
+            {
+                "pid_1": {
+                    "model_A": [{"name": "field1", "value": "a"}],
+                    "model_B": "data_b",
+                },
+                "pid_2": {"model_A": [{"name": "field2", "value": "c"}]},
+            },
+        )
+
+    def test_filter_by_top_level_key(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        with_clean_kkv_store: KKVDataStoreModel,
+    ) -> None:
+        self._seed_data(client, with_super_admin_user)
+        response = self._get(client, with_super_admin_user, "test_store", top_level_key="pid_1")
+        assert response.status_code == 200
+        results = response.json()["results"]
+        assert len(results) == 2
+        assert all(r["top_level_key"] == "pid_1" for r in results)
+
+    def test_filter_by_top_level_and_secondary_key(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        with_clean_kkv_store: KKVDataStoreModel,
+    ) -> None:
+        self._seed_data(client, with_super_admin_user)
+        response = self._get(
+            client,
+            with_super_admin_user,
+            "test_store",
+            top_level_key="pid_1",
+            secondary_key="model_A",
+        )
+        assert response.status_code == 200
+        results = response.json()["results"]
+        assert len(results) == 1
+        assert results[0]["top_level_key"] == "pid_1"
+        assert results[0]["secondary_key"] == "model_A"
+        assert results[0]["value"] == [{"name": "field1", "value": "a"}]
+
+    def test_filter_returns_empty_for_nonexistent_key(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        with_clean_kkv_store: KKVDataStoreModel,
+    ) -> None:
+        self._seed_data(client, with_super_admin_user)
+        response = self._get(client, with_super_admin_user, "test_store", top_level_key="nonexistent")
+        assert response.status_code == 200
+        assert response.json()["results"] == []
+        assert response.json()["pagination"]["total"] == 0
+
+    def test_filter_returns_404_for_nonexistent_store(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        with_clean_kkv_store: KKVDataStoreModel,
+    ) -> None:
+        response = self._get(client, with_super_admin_user, "no_such_store", top_level_key="pid_1")
+        assert response.status_code == 404
+
+    def test_unfiltered_get_still_works(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        with_clean_kkv_store: KKVDataStoreModel,
+    ) -> None:
+        self._seed_data(client, with_super_admin_user)
+        response = self._get(client, with_super_admin_user, "test_store")
+        assert response.status_code == 200
+        data = response.json()["results"][0]["data"]
+        assert len(data) == 3

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_authorization_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_authorization_service.py
@@ -544,7 +544,10 @@ class TestAuthorizationService(BaseTest):
             self._expected_basic_permissions()
             + [
                 ("/can-run-privileged-script/*", "create"),
+                ("/data-stores/*", "create"),
+                ("/data-stores/*", "delete"),
                 ("/data-stores/*", "read"),
+                ("/data-stores/*", "update"),
                 ("/debug/*", "create"),
                 ("/event-error-details/*", "read"),
                 ("/extensions-get-data/*", "read"),

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_authorization_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_authorization_service.py
@@ -97,9 +97,15 @@ class TestAuthorizationService(BaseTest):
     ) -> None:
         expected_permissions = sorted(
             [
-                ("/event-error-details/some-process-group:some-process-model:*", "read"),
+                (
+                    "/event-error-details/some-process-group:some-process-model:*",
+                    "read",
+                ),
                 ("/logs/some-process-group:some-process-model:*", "read"),
-                ("/logs/typeahead-filter-values/some-process-group:some-process-model:*", "read"),
+                (
+                    "/logs/typeahead-filter-values/some-process-group:some-process-model:*",
+                    "read",
+                ),
                 ("/message-models/some-process-group:some-process-model:*", "read"),
                 ("/all-message-models/some-process-group:some-process-model:*", "read"),
                 ("/process-data/some-process-group:some-process-model:*", "read"),
@@ -131,15 +137,39 @@ class TestAuthorizationService(BaseTest):
                     "/process-instances/some-process-group:some-process-model:*",
                     "delete",
                 ),
-                ("/process-instance-events/some-process-group:some-process-model:*", "read"),
-                ("/process-instance-run/some-process-group:some-process-model:*", "create"),
-                ("/process-instances/for-me/some-process-group:some-process-model:*", "read"),
+                (
+                    "/process-instance-events/some-process-group:some-process-model:*",
+                    "read",
+                ),
+                (
+                    "/process-instance-run/some-process-group:some-process-model:*",
+                    "create",
+                ),
+                (
+                    "/process-instances/for-me/some-process-group:some-process-model:*",
+                    "read",
+                ),
                 ("/process-instances/some-process-group:some-process-model:*", "read"),
-                ("/process-model-import/some-process-group:some-process-model:*", "create"),
-                ("/process-model-natural-language/some-process-group:some-process-model:*", "create"),
-                ("/process-model-publish/some-process-group:some-process-model:*", "create"),
-                ("/process-model-tests/create/some-process-group:some-process-model:*", "create"),
-                ("/process-model-tests/run/some-process-group:some-process-model:*", "create"),
+                (
+                    "/process-model-import/some-process-group:some-process-model:*",
+                    "create",
+                ),
+                (
+                    "/process-model-natural-language/some-process-group:some-process-model:*",
+                    "create",
+                ),
+                (
+                    "/process-model-publish/some-process-group:some-process-model:*",
+                    "create",
+                ),
+                (
+                    "/process-model-tests/create/some-process-group:some-process-model:*",
+                    "create",
+                ),
+                (
+                    "/process-model-tests/run/some-process-group:some-process-model:*",
+                    "create",
+                ),
                 ("/process-models/some-process-group:some-process-model:*", "create"),
                 ("/process-models/some-process-group:some-process-model:*", "delete"),
                 ("/process-models/some-process-group:some-process-model:*", "read"),
@@ -161,7 +191,10 @@ class TestAuthorizationService(BaseTest):
     ) -> None:
         expected_permissions = sorted(
             [
-                ("/event-error-details/some-process-group:some-process-model:*", "read"),
+                (
+                    "/event-error-details/some-process-group:some-process-model:*",
+                    "read",
+                ),
                 (
                     "/logs/some-process-group:some-process-model:*",
                     "read",
@@ -174,13 +207,22 @@ class TestAuthorizationService(BaseTest):
                     "/process-data-file-download/some-process-group:some-process-model:*",
                     "read",
                 ),
-                ("/process-instance-events/some-process-group:some-process-model:*", "read"),
-                ("/process-instance-run/some-process-group:some-process-model:*", "create"),
+                (
+                    "/process-instance-events/some-process-group:some-process-model:*",
+                    "read",
+                ),
+                (
+                    "/process-instance-run/some-process-group:some-process-model:*",
+                    "create",
+                ),
                 (
                     "/process-instances/for-me/some-process-group:some-process-model:*",
                     "read",
                 ),
-                ("/process-instances/some-process-group:some-process-model:*", "create"),
+                (
+                    "/process-instances/some-process-group:some-process-model:*",
+                    "create",
+                ),
             ]
         )
         permissions_to_assign = AuthorizationService.explode_permissions("start", "PG:/some-process-group/some-process-model")
@@ -195,13 +237,19 @@ class TestAuthorizationService(BaseTest):
     ) -> None:
         expected_permissions = sorted(
             [
-                ("/event-error-details/some-process-group:some-process-model/*", "read"),
+                (
+                    "/event-error-details/some-process-group:some-process-model/*",
+                    "read",
+                ),
                 ("/logs/some-process-group:some-process-model/*", "read"),
                 (
                     "/process-data-file-download/some-process-group:some-process-model/*",
                     "read",
                 ),
-                ("/logs/typeahead-filter-values/some-process-group:some-process-model/*", "read"),
+                (
+                    "/logs/typeahead-filter-values/some-process-group:some-process-model/*",
+                    "read",
+                ),
                 ("/message-models/some-process-group:some-process-model/*", "read"),
                 ("/all-message-models/some-process-group:some-process-model/*", "read"),
                 ("/process-data/some-process-group:some-process-model/*", "read"),
@@ -225,15 +273,39 @@ class TestAuthorizationService(BaseTest):
                     "/process-instances/some-process-group:some-process-model/*",
                     "delete",
                 ),
-                ("/process-instance-events/some-process-group:some-process-model/*", "read"),
-                ("/process-instance-run/some-process-group:some-process-model/*", "create"),
-                ("/process-instances/for-me/some-process-group:some-process-model/*", "read"),
+                (
+                    "/process-instance-events/some-process-group:some-process-model/*",
+                    "read",
+                ),
+                (
+                    "/process-instance-run/some-process-group:some-process-model/*",
+                    "create",
+                ),
+                (
+                    "/process-instances/for-me/some-process-group:some-process-model/*",
+                    "read",
+                ),
                 ("/process-instances/some-process-group:some-process-model/*", "read"),
-                ("/process-model-import/some-process-group:some-process-model/*", "create"),
-                ("/process-model-natural-language/some-process-group:some-process-model/*", "create"),
-                ("/process-model-publish/some-process-group:some-process-model/*", "create"),
-                ("/process-model-tests/create/some-process-group:some-process-model/*", "create"),
-                ("/process-model-tests/run/some-process-group:some-process-model/*", "create"),
+                (
+                    "/process-model-import/some-process-group:some-process-model/*",
+                    "create",
+                ),
+                (
+                    "/process-model-natural-language/some-process-group:some-process-model/*",
+                    "create",
+                ),
+                (
+                    "/process-model-publish/some-process-group:some-process-model/*",
+                    "create",
+                ),
+                (
+                    "/process-model-tests/create/some-process-group:some-process-model/*",
+                    "create",
+                ),
+                (
+                    "/process-model-tests/run/some-process-group:some-process-model/*",
+                    "create",
+                ),
                 ("/process-models/some-process-group:some-process-model/*", "create"),
                 ("/process-models/some-process-group:some-process-model/*", "delete"),
                 ("/process-models/some-process-group:some-process-model/*", "read"),
@@ -263,18 +335,30 @@ class TestAuthorizationService(BaseTest):
                     "/logs/some-process-group:some-process-model/*",
                     "read",
                 ),
-                ("/logs/typeahead-filter-values/some-process-group:some-process-model/*", "read"),
+                (
+                    "/logs/typeahead-filter-values/some-process-group:some-process-model/*",
+                    "read",
+                ),
                 (
                     "/process-data-file-download/some-process-group:some-process-model/*",
                     "read",
                 ),
-                ("/process-instance-events/some-process-group:some-process-model/*", "read"),
-                ("/process-instance-run/some-process-group:some-process-model/*", "create"),
+                (
+                    "/process-instance-events/some-process-group:some-process-model/*",
+                    "read",
+                ),
+                (
+                    "/process-instance-run/some-process-group:some-process-model/*",
+                    "create",
+                ),
                 (
                     "/process-instances/for-me/some-process-group:some-process-model/*",
                     "read",
                 ),
-                ("/process-instances/some-process-group:some-process-model/*", "create"),
+                (
+                    "/process-instances/some-process-group:some-process-model/*",
+                    "create",
+                ),
             ]
         )
         permissions_to_assign = AuthorizationService.explode_permissions("start", "PM:/some-process-group/some-process-model")
@@ -841,7 +925,10 @@ class TestAuthorizationService(BaseTest):
             )
             human_task_count = (
                 HumanTaskUserModel.query.join(HumanTaskModel)
-                .filter(HumanTaskUserModel.user_id == user_two.id, HumanTaskModel.completed == True)  # noqa: E712
+                .filter(
+                    HumanTaskUserModel.user_id == user_two.id,
+                    HumanTaskModel.completed,
+                )  # noqa: E712
                 .count()
             )
             assert human_task_count == 2
@@ -930,9 +1017,17 @@ class TestAuthorizationService(BaseTest):
             temp_yaml_file.close()
 
             # Mock the permissions file path
-            with self.app_config_mock(app, "SPIFFWORKFLOW_BACKEND_PERMISSIONS_FILE_ABSOLUTE_PATH", temp_yaml_file.name):
+            with self.app_config_mock(
+                app,
+                "SPIFFWORKFLOW_BACKEND_PERMISSIONS_FILE_ABSOLUTE_PATH",
+                temp_yaml_file.name,
+            ):
                 # Set OIDC as the authority for user groups
-                with self.app_config_mock(app, "SPIFFWORKFLOW_BACKEND_OPEN_ID_IS_AUTHORITY_FOR_USER_GROUPS", True):
+                with self.app_config_mock(
+                    app,
+                    "SPIFFWORKFLOW_BACKEND_OPEN_ID_IS_AUTHORITY_FOR_USER_GROUPS",
+                    True,
+                ):
                     # Create an OIDC user with the /admin group
                     oidc_user = AuthorizationService.create_user_from_sign_in(
                         {

--- a/uv.lock
+++ b/uv.lock
@@ -10,20 +10,20 @@ members = [
 
 [[package]]
 name = "attrs"
-version = "25.4.0"
+version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
 ]
 
 [[package]]
 name = "cfgv"
-version = "3.4.0"
+version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114, upload-time = "2023-08-12T20:38:17.776Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249, upload-time = "2023-08-12T20:38:16.269Z" },
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
 ]
 
 [[package]]
@@ -46,20 +46,20 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.19.1"
+version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/40/bb/0ab3e58d22305b6f5440629d20683af28959bf793d98d11950e305c1c326/filelock-3.19.1.tar.gz", hash = "sha256:66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58", size = 17687, upload-time = "2025-08-14T16:56:03.016Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/14/42b2651a2f46b022ccd948bca9f2d5af0fd8929c4eec235b8d6d844fbe67/filelock-3.19.1-py3-none-any.whl", hash = "sha256:d38e30481def20772f5baf097c122c3babc4fcdb7e14e57049eb9d88c6dc017d", size = 15988, upload-time = "2025-08-14T16:56:01.633Z" },
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
 ]
 
 [[package]]
 name = "identify"
-version = "2.6.13"
+version = "2.6.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/ca/ffbabe3635bb839aa36b3a893c91a9b0d368cb4d8073e03a12896970af82/identify-2.6.13.tar.gz", hash = "sha256:da8d6c828e773620e13bfa86ea601c5a5310ba4bcd65edf378198b56a1f9fb32", size = 99243, upload-time = "2025-08-09T19:35:00.6Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/ce/461b60a3ee109518c055953729bf9ed089a04db895d47e95444071dcdef2/identify-2.6.13-py2.py3-none-any.whl", hash = "sha256:60381139b3ae39447482ecc406944190f690d4a2997f2584062089848361b33b", size = 99153, upload-time = "2025-08-09T19:34:59.1Z" },
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
 ]
 
 [[package]]
@@ -85,7 +85,7 @@ wheels = [
 
 [[package]]
 name = "jsonschema"
-version = "4.25.1"
+version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -93,9 +93,9 @@ dependencies = [
     { name = "referencing" },
     { name = "rpds-py" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/69/f7185de793a29082a9f3c7728268ffb31cb5095131a9c139a74078e27336/jsonschema-4.25.1.tar.gz", hash = "sha256:e4a9655ce0da0c0b67a085847e00a3a51449e1157f4f75e9fb5aa545e122eb85", size = 357342, upload-time = "2025-08-18T17:03:50.038Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl", hash = "sha256:3fba0169e345c7175110351d456342c364814cfcf3b964ba4587f22915230a63", size = 90040, upload-time = "2025-08-18T17:03:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
 ]
 
 [[package]]
@@ -112,50 +112,50 @@ wheels = [
 
 [[package]]
 name = "lxml"
-version = "6.0.2"
+version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/aa/88/262177de60548e5a2bfc46ad28232c9e9cbde697bd94132aeb80364675cb/lxml-6.0.2.tar.gz", hash = "sha256:cd79f3367bd74b317dda655dc8fcfa304d9eb6e4fb06b7168c5cf27f96e0cd62", size = 4073426, upload-time = "2025-09-22T04:04:59.287Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/30/9abc9e34c657c33834eaf6cd02124c61bdf5944d802aa48e69be8da3585d/lxml-6.1.0.tar.gz", hash = "sha256:bfd57d8008c4965709a919c3e9a98f76c2c7cb319086b3d26858250620023b13", size = 4197006, upload-time = "2026-04-18T04:32:51.613Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/d5/becbe1e2569b474a23f0c672ead8a29ac50b2dc1d5b9de184831bda8d14c/lxml-6.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:13e35cbc684aadf05d8711a5d1b5857c92e5e580efa9a0d2be197199c8def607", size = 8634365, upload-time = "2025-09-22T04:00:45.672Z" },
-    { url = "https://files.pythonhosted.org/packages/28/66/1ced58f12e804644426b85d0bb8a4478ca77bc1761455da310505f1a3526/lxml-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3b1675e096e17c6fe9c0e8c81434f5736c0739ff9ac6123c87c2d452f48fc938", size = 4650793, upload-time = "2025-09-22T04:00:47.783Z" },
-    { url = "https://files.pythonhosted.org/packages/11/84/549098ffea39dfd167e3f174b4ce983d0eed61f9d8d25b7bf2a57c3247fc/lxml-6.0.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac6e5811ae2870953390452e3476694196f98d447573234592d30488147404d", size = 4944362, upload-time = "2025-09-22T04:00:49.845Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/bd/f207f16abf9749d2037453d56b643a7471d8fde855a231a12d1e095c4f01/lxml-6.0.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5aa0fc67ae19d7a64c3fe725dc9a1bb11f80e01f78289d05c6f62545affec438", size = 5083152, upload-time = "2025-09-22T04:00:51.709Z" },
-    { url = "https://files.pythonhosted.org/packages/15/ae/bd813e87d8941d52ad5b65071b1affb48da01c4ed3c9c99e40abb266fbff/lxml-6.0.2-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de496365750cc472b4e7902a485d3f152ecf57bd3ba03ddd5578ed8ceb4c5964", size = 5023539, upload-time = "2025-09-22T04:00:53.593Z" },
-    { url = "https://files.pythonhosted.org/packages/02/cd/9bfef16bd1d874fbe0cb51afb00329540f30a3283beb9f0780adbb7eec03/lxml-6.0.2-cp311-cp311-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:200069a593c5e40b8f6fc0d84d86d970ba43138c3e68619ffa234bc9bb806a4d", size = 5344853, upload-time = "2025-09-22T04:00:55.524Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/89/ea8f91594bc5dbb879734d35a6f2b0ad50605d7fb419de2b63d4211765cc/lxml-6.0.2-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d2de809c2ee3b888b59f995625385f74629707c9355e0ff856445cdcae682b7", size = 5225133, upload-time = "2025-09-22T04:00:57.269Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/37/9c735274f5dbec726b2db99b98a43950395ba3d4a1043083dba2ad814170/lxml-6.0.2-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:b2c3da8d93cf5db60e8858c17684c47d01fee6405e554fb55018dd85fc23b178", size = 4677944, upload-time = "2025-09-22T04:00:59.052Z" },
-    { url = "https://files.pythonhosted.org/packages/20/28/7dfe1ba3475d8bfca3878365075abe002e05d40dfaaeb7ec01b4c587d533/lxml-6.0.2-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:442de7530296ef5e188373a1ea5789a46ce90c4847e597856570439621d9c553", size = 5284535, upload-time = "2025-09-22T04:01:01.335Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/cf/5f14bc0de763498fc29510e3532bf2b4b3a1c1d5d0dff2e900c16ba021ef/lxml-6.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2593c77efde7bfea7f6389f1ab249b15ed4aa5bc5cb5131faa3b843c429fbedb", size = 5067343, upload-time = "2025-09-22T04:01:03.13Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/b0/bb8275ab5472f32b28cfbbcc6db7c9d092482d3439ca279d8d6fa02f7025/lxml-6.0.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:3e3cb08855967a20f553ff32d147e14329b3ae70ced6edc2f282b94afbc74b2a", size = 4725419, upload-time = "2025-09-22T04:01:05.013Z" },
-    { url = "https://files.pythonhosted.org/packages/25/4c/7c222753bc72edca3b99dbadba1b064209bc8ed4ad448af990e60dcce462/lxml-6.0.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:2ed6c667fcbb8c19c6791bbf40b7268ef8ddf5a96940ba9404b9f9a304832f6c", size = 5275008, upload-time = "2025-09-22T04:01:07.327Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/8c/478a0dc6b6ed661451379447cdbec77c05741a75736d97e5b2b729687828/lxml-6.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b8f18914faec94132e5b91e69d76a5c1d7b0c73e2489ea8929c4aaa10b76bbf7", size = 5248906, upload-time = "2025-09-22T04:01:09.452Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/d9/5be3a6ab2784cdf9accb0703b65e1b64fcdd9311c9f007630c7db0cfcce1/lxml-6.0.2-cp311-cp311-win32.whl", hash = "sha256:6605c604e6daa9e0d7f0a2137bdc47a2e93b59c60a65466353e37f8272f47c46", size = 3610357, upload-time = "2025-09-22T04:01:11.102Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/7d/ca6fb13349b473d5732fb0ee3eec8f6c80fc0688e76b7d79c1008481bf1f/lxml-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e5867f2651016a3afd8dd2c8238baa66f1e2802f44bc17e236f547ace6647078", size = 4036583, upload-time = "2025-09-22T04:01:12.766Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/a2/51363b5ecd3eab46563645f3a2c3836a2fc67d01a1b87c5017040f39f567/lxml-6.0.2-cp311-cp311-win_arm64.whl", hash = "sha256:4197fb2534ee05fd3e7afaab5d8bfd6c2e186f65ea7f9cd6a82809c887bd1285", size = 3680591, upload-time = "2025-09-22T04:01:14.874Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/c8/8ff2bc6b920c84355146cd1ab7d181bc543b89241cfb1ebee824a7c81457/lxml-6.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a59f5448ba2ceccd06995c95ea59a7674a10de0810f2ce90c9006f3cbc044456", size = 8661887, upload-time = "2025-09-22T04:01:17.265Z" },
-    { url = "https://files.pythonhosted.org/packages/37/6f/9aae1008083bb501ef63284220ce81638332f9ccbfa53765b2b7502203cf/lxml-6.0.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e8113639f3296706fbac34a30813929e29247718e88173ad849f57ca59754924", size = 4667818, upload-time = "2025-09-22T04:01:19.688Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/ca/31fb37f99f37f1536c133476674c10b577e409c0a624384147653e38baf2/lxml-6.0.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a8bef9b9825fa8bc816a6e641bb67219489229ebc648be422af695f6e7a4fa7f", size = 4950807, upload-time = "2025-09-22T04:01:21.487Z" },
-    { url = "https://files.pythonhosted.org/packages/da/87/f6cb9442e4bada8aab5ae7e1046264f62fdbeaa6e3f6211b93f4c0dd97f1/lxml-6.0.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:65ea18d710fd14e0186c2f973dc60bb52039a275f82d3c44a0e42b43440ea534", size = 5109179, upload-time = "2025-09-22T04:01:23.32Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/20/a7760713e65888db79bbae4f6146a6ae5c04e4a204a3c48896c408cd6ed2/lxml-6.0.2-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c371aa98126a0d4c739ca93ceffa0fd7a5d732e3ac66a46e74339acd4d334564", size = 5023044, upload-time = "2025-09-22T04:01:25.118Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/b0/7e64e0460fcb36471899f75831509098f3fd7cd02a3833ac517433cb4f8f/lxml-6.0.2-cp312-cp312-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:700efd30c0fa1a3581d80a748157397559396090a51d306ea59a70020223d16f", size = 5359685, upload-time = "2025-09-22T04:01:27.398Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/e1/e5df362e9ca4e2f48ed6411bd4b3a0ae737cc842e96877f5bf9428055ab4/lxml-6.0.2-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c33e66d44fe60e72397b487ee92e01da0d09ba2d66df8eae42d77b6d06e5eba0", size = 5654127, upload-time = "2025-09-22T04:01:29.629Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/d1/232b3309a02d60f11e71857778bfcd4acbdb86c07db8260caf7d008b08f8/lxml-6.0.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90a345bbeaf9d0587a3aaffb7006aa39ccb6ff0e96a57286c0cb2fd1520ea192", size = 5253958, upload-time = "2025-09-22T04:01:31.535Z" },
-    { url = "https://files.pythonhosted.org/packages/35/35/d955a070994725c4f7d80583a96cab9c107c57a125b20bb5f708fe941011/lxml-6.0.2-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:064fdadaf7a21af3ed1dcaa106b854077fbeada827c18f72aec9346847cd65d0", size = 4711541, upload-time = "2025-09-22T04:01:33.801Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/be/667d17363b38a78c4bd63cfd4b4632029fd68d2c2dc81f25ce9eb5224dd5/lxml-6.0.2-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fbc74f42c3525ac4ffa4b89cbdd00057b6196bcefe8bce794abd42d33a018092", size = 5267426, upload-time = "2025-09-22T04:01:35.639Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/47/62c70aa4a1c26569bc958c9ca86af2bb4e1f614e8c04fb2989833874f7ae/lxml-6.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6ddff43f702905a4e32bc24f3f2e2edfe0f8fde3277d481bffb709a4cced7a1f", size = 5064917, upload-time = "2025-09-22T04:01:37.448Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/55/6ceddaca353ebd0f1908ef712c597f8570cc9c58130dbb89903198e441fd/lxml-6.0.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:6da5185951d72e6f5352166e3da7b0dc27aa70bd1090b0eb3f7f7212b53f1bb8", size = 4788795, upload-time = "2025-09-22T04:01:39.165Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/e8/fd63e15da5e3fd4c2146f8bbb3c14e94ab850589beab88e547b2dbce22e1/lxml-6.0.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:57a86e1ebb4020a38d295c04fc79603c7899e0df71588043eb218722dabc087f", size = 5676759, upload-time = "2025-09-22T04:01:41.506Z" },
-    { url = "https://files.pythonhosted.org/packages/76/47/b3ec58dc5c374697f5ba37412cd2728f427d056315d124dd4b61da381877/lxml-6.0.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2047d8234fe735ab77802ce5f2297e410ff40f5238aec569ad7c8e163d7b19a6", size = 5255666, upload-time = "2025-09-22T04:01:43.363Z" },
-    { url = "https://files.pythonhosted.org/packages/19/93/03ba725df4c3d72afd9596eef4a37a837ce8e4806010569bedfcd2cb68fd/lxml-6.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6f91fd2b2ea15a6800c8e24418c0775a1694eefc011392da73bc6cef2623b322", size = 5277989, upload-time = "2025-09-22T04:01:45.215Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/80/c06de80bfce881d0ad738576f243911fccf992687ae09fd80b734712b39c/lxml-6.0.2-cp312-cp312-win32.whl", hash = "sha256:3ae2ce7d6fedfb3414a2b6c5e20b249c4c607f72cb8d2bb7cc9c6ec7c6f4e849", size = 3611456, upload-time = "2025-09-22T04:01:48.243Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/d7/0cdfb6c3e30893463fb3d1e52bc5f5f99684a03c29a0b6b605cfae879cd5/lxml-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:72c87e5ee4e58a8354fb9c7c84cbf95a1c8236c127a5d1b7683f04bed8361e1f", size = 4011793, upload-time = "2025-09-22T04:01:50.042Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/7b/93c73c67db235931527301ed3785f849c78991e2e34f3fd9a6663ffda4c5/lxml-6.0.2-cp312-cp312-win_arm64.whl", hash = "sha256:61cb10eeb95570153e0c0e554f58df92ecf5109f75eacad4a95baa709e26c3d6", size = 3672836, upload-time = "2025-09-22T04:01:52.145Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/11/29d08bc103a62c0eba8016e7ed5aeebbf1e4312e83b0b1648dd203b0e87d/lxml-6.0.2-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:1c06035eafa8404b5cf475bb37a9f6088b0aca288d4ccc9d69389750d5543700", size = 3949829, upload-time = "2025-09-22T04:04:45.608Z" },
-    { url = "https://files.pythonhosted.org/packages/12/b3/52ab9a3b31e5ab8238da241baa19eec44d2ab426532441ee607165aebb52/lxml-6.0.2-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c7d13103045de1bdd6fe5d61802565f1a3537d70cd3abf596aa0af62761921ee", size = 4226277, upload-time = "2025-09-22T04:04:47.754Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/33/1eaf780c1baad88224611df13b1c2a9dfa460b526cacfe769103ff50d845/lxml-6.0.2-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0a3c150a95fbe5ac91de323aa756219ef9cf7fde5a3f00e2281e30f33fa5fa4f", size = 4330433, upload-time = "2025-09-22T04:04:49.907Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/c1/27428a2ff348e994ab4f8777d3a0ad510b6b92d37718e5887d2da99952a2/lxml-6.0.2-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60fa43be34f78bebb27812ed90f1925ec99560b0fa1decdb7d12b84d857d31e9", size = 4272119, upload-time = "2025-09-22T04:04:51.801Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/d0/3020fa12bcec4ab62f97aab026d57c2f0cfd480a558758d9ca233bb6a79d/lxml-6.0.2-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:21c73b476d3cfe836be731225ec3421fa2f048d84f6df6a8e70433dff1376d5a", size = 4417314, upload-time = "2025-09-22T04:04:55.024Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/77/d7f491cbc05303ac6801651aabeb262d43f319288c1ea96c66b1d2692ff3/lxml-6.0.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:27220da5be049e936c3aca06f174e8827ca6445a4353a1995584311487fc4e3e", size = 3518768, upload-time = "2025-09-22T04:04:57.097Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/5d/3bccad330292946f97962df9d5f2d3ae129cce6e212732a781e856b91e07/lxml-6.1.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cec05be8c876f92a5aa07b01d60bbb4d11cfbdd654cad0561c0d7b5c043a61b9", size = 8526232, upload-time = "2026-04-18T04:27:40.389Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/51/adc8826570a112f83bb4ddb3a2ab510bbc2ccd62c1b9fe1f34fae2d90b57/lxml-6.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9c03e048b6ce8e77b09c734e931584894ecd58d08296804ca2d0b184c933ce50", size = 4595448, upload-time = "2026-04-18T04:27:44.208Z" },
+    { url = "https://files.pythonhosted.org/packages/54/84/5a9ec07cbe1d2334a6465f863b949a520d2699a755738986dcd3b6b89e3f/lxml-6.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:942454ff253da14218f972b23dc72fa4edf6c943f37edd19cd697618b626fac5", size = 4923771, upload-time = "2026-04-18T04:32:17.402Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/23/851cfa33b6b38adb628e45ad51fb27105fa34b2b3ba9d1d4aa7a9428dfe0/lxml-6.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d036ee7b99d5148072ac7c9b847193decdfeac633db350363f7bce4fff108f0e", size = 5068101, upload-time = "2026-04-18T04:32:21.437Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/38/41bf99c2023c6b79916ba057d83e9db21d642f473cac210201222882d38b/lxml-6.1.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ae5d8d5427f3cc317e7950f2da7ad276df0cfa37b8de2f5658959e618ea8512", size = 5002573, upload-time = "2026-04-18T04:32:25.373Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/20/053aa10bdc39747e1e923ce2d45413075e84f70a136045bb09e5eaca41d3/lxml-6.1.0-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:363e47283bde87051b821826e71dde47f107e08614e1aa312ba0c5711e77738c", size = 5202816, upload-time = "2026-04-18T04:32:29.393Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/da/bc710fad8bf04b93baee752c192eaa2210cd3a84f969d0be7830fea55802/lxml-6.1.0-cp311-cp311-manylinux_2_28_i686.whl", hash = "sha256:f504d861d9f2a8f94020130adac88d66de93841707a23a86244263d1e54682f5", size = 5329999, upload-time = "2026-04-18T04:32:34.019Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/cb/bf035dedbdf7fab49411aa52e4236f3445e98d38647d85419e6c0d2806b9/lxml-6.1.0-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:23a5dc68e08ed13331d61815c08f260f46b4a60fdd1640bbeb82cf89a9d90289", size = 4659643, upload-time = "2026-04-18T04:32:37.932Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4f/22be31f33727a5e4c7b01b0a874503026e50329b259d3587e0b923cf964b/lxml-6.1.0-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f15401d8d3dbf239e23c818afc10c7207f7b95f9a307e092122b6f86dd43209a", size = 5265963, upload-time = "2026-04-18T04:32:41.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2b/d44d0e5c79226017f4ab8c87a802ebe4f89f97e6585a8e4166dffcdd7b6e/lxml-6.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:fcf3da95e93349e0647d48d4b36a12783105bcc74cb0c416952f9988410846a3", size = 5045444, upload-time = "2026-04-18T04:32:44.512Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/c3/3f034fec1594c331a6dbf9491238fdcc9d66f68cc529e109ec75b97197e1/lxml-6.1.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:0d082495c5fcf426e425a6e28daaba1fcb6d8f854a4ff01effb1f1f381203eb9", size = 4712703, upload-time = "2026-04-18T04:32:47.16Z" },
+    { url = "https://files.pythonhosted.org/packages/12/16/0b83fccc158218aca75a7aa33e97441df737950734246b9fffa39301603d/lxml-6.1.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:e3c4f84b24a1fcba435157d111c4b755099c6ff00a3daee1ad281817de75ed11", size = 5252745, upload-time = "2026-04-18T04:32:50.427Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/ee/12e6c1b39a77666c02eaa77f94a870aaf63c4ac3a497b2d52319448b01c6/lxml-6.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:976a6b39b1b13e8c354ad8d3f261f3a4ac6609518af91bdb5094760a08f132c4", size = 5226822, upload-time = "2026-04-18T04:32:53.437Z" },
+    { url = "https://files.pythonhosted.org/packages/34/20/c7852904858b4723af01d2fc14b5d38ff57cb92f01934a127ebd9a9e51aa/lxml-6.1.0-cp311-cp311-win32.whl", hash = "sha256:857efde87d365706590847b916baff69c0bc9252dc5af030e378c9800c0b10e3", size = 3594026, upload-time = "2026-04-18T04:27:31.903Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/d60c732b56da5085175c07c74b2df4e6d181b0c9a61e1691474f06ef4b39/lxml-6.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:183bfb45a493081943be7ea2b5adfc2b611e1cf377cefa8b8a8be404f45ef9a7", size = 4025114, upload-time = "2026-04-18T04:27:34.077Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/df/c84dcc175fd690823436d15b41cb920cd5ba5e14cd8bfb00949d5903b320/lxml-6.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:19f4164243fc206d12ed3d866e80e74f5bc3627966520da1a5f97e42c32a3f39", size = 3667742, upload-time = "2026-04-18T04:27:38.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d4/9326838b59dc36dfae42eec9656b97520f9997eee1de47b8316aaeed169c/lxml-6.1.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d2f17a16cd8751e8eb233a7e41aecdf8e511712e00088bf9be455f604cd0d28d", size = 8570663, upload-time = "2026-04-18T04:27:48.253Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/a4/053745ce1f8303ccbb788b86c0db3a91b973675cefc42566a188637b7c40/lxml-6.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f0cea5b1d3e6e77d71bd2b9972eb2446221a69dc52bb0b9c3c6f6e5700592d93", size = 4624024, upload-time = "2026-04-18T04:27:52.594Z" },
+    { url = "https://files.pythonhosted.org/packages/90/97/a517944b20f8fd0932ad2109482bee4e29fe721416387a363306667941f6/lxml-6.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc46da94826188ed45cb53bd8e3fc076ae22675aea2087843d4735627f867c6d", size = 4930895, upload-time = "2026-04-18T04:32:56.29Z" },
+    { url = "https://files.pythonhosted.org/packages/94/7c/e08a970727d556caa040a44773c7b7e3ad0f0d73dedc863543e9a8b931f2/lxml-6.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9147d8e386ec3b82c3b15d88927f734f565b0aaadef7def562b853adca45784a", size = 5093820, upload-time = "2026-04-18T04:32:58.94Z" },
+    { url = "https://files.pythonhosted.org/packages/88/ee/2a5c2aa2c32016a226ca25d3e1056a8102ea6e1fe308bf50213586635400/lxml-6.1.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5715e0e28736a070f3f34a7ccc09e2fdcba0e3060abbcf61a1a5718ff6d6b105", size = 5005790, upload-time = "2026-04-18T04:33:01.272Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/38/a0db9be8f38ad6043ab9429487c128dd1d30f07956ef43040402f8da49e8/lxml-6.1.0-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4937460dc5df0cdd2f06a86c285c28afda06aefa3af949f9477d3e8df430c485", size = 5630827, upload-time = "2026-04-18T04:33:04.036Z" },
+    { url = "https://files.pythonhosted.org/packages/31/ba/3c13d3fc24b7cacf675f808a3a1baabf43a30d0cd24c98f94548e9aa58eb/lxml-6.1.0-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bc783ee3147e60a25aa0445ea82b3e8aabb83b240f2b95d32cb75587ff781814", size = 5240445, upload-time = "2026-04-18T04:33:06.87Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ba/eeef4ccba09b2212fe239f46c1692a98db1878e0872ae320756488878a94/lxml-6.1.0-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:40d9189f80075f2e1f88db21ef815a2b17b28adf8e50aaf5c789bfe737027f32", size = 5350121, upload-time = "2026-04-18T04:33:09.365Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/01/1da87c7b587c38d0cbe77a01aae3b9c1c49ed47d76918ef3db8fc151b1ca/lxml-6.1.0-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:05b9b8787e35bec69e68daf4952b2e6dfcfb0db7ecf1a06f8cdfbbac4eb71aad", size = 4694949, upload-time = "2026-04-18T04:33:11.628Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/88/7db0fe66d5aaf128443ee1623dec3db1576f3e4c17751ec0ef5866468590/lxml-6.1.0-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0f0f08beb0182e3e9a86fae124b3c47a7b41b7b69b225e1377db983802404e54", size = 5243901, upload-time = "2026-04-18T04:33:13.95Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a8/1346726af7d1f6fca1f11223ba34001462b0a3660416986d37641708d57c/lxml-6.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73becf6d8c81d4c76b1014dbd3584cb26d904492dcf73ca85dc8bff08dcd6d2d", size = 5048054, upload-time = "2026-04-18T04:33:16.965Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b7/85057012f035d1a0c87e02f8c723ca3c3e6e0728bcf4cb62080b21b1c1e3/lxml-6.1.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:1ae225f66e5938f4fa29d37e009a3bb3b13032ac57eb4eb42afa44f6e4054e69", size = 4777324, upload-time = "2026-04-18T04:33:19.832Z" },
+    { url = "https://files.pythonhosted.org/packages/75/6c/ad2f94a91073ef570f33718040e8e160d5fb93331cf1ab3ca1323f939e2d/lxml-6.1.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:690022c7fae793b0489aa68a658822cea83e0d5933781811cabbf5ea3bcfe73d", size = 5645702, upload-time = "2026-04-18T04:33:22.436Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/89/0bb6c0bd549c19004c60eea9dc554dd78fd647b72314ef25d460e0d208c6/lxml-6.1.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:63aeafc26aac0be8aff14af7871249e87ea1319be92090bfd632ec68e03b16a5", size = 5232901, upload-time = "2026-04-18T04:33:26.21Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d9/d609a11fb567da9399f525193e2b49847b5a409cdebe737f06a8b7126bdc/lxml-6.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:264c605ab9c0e4aa1a679636f4582c4d3313700009fac3ec9c3412ed0d8f3e1d", size = 5261333, upload-time = "2026-04-18T04:33:28.984Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3a/ac3f99ec8ac93089e7dd556f279e0d14c24de0a74a507e143a2e4b496e7c/lxml-6.1.0-cp312-cp312-win32.whl", hash = "sha256:56971379bc5ee8037c5a0f09fa88f66cdb7d37c3e38af3e45cf539f41131ac1f", size = 3596289, upload-time = "2026-04-18T04:27:42.819Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a7/0a915557538593cb1bbeedcd40e13c7a261822c26fecbbdb71dad0c2f540/lxml-6.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:bba078de0031c219e5dd06cf3e6bf8fb8e6e64a77819b358f53bb132e3e03366", size = 3997059, upload-time = "2026-04-18T04:27:46.764Z" },
+    { url = "https://files.pythonhosted.org/packages/92/96/a5dc078cf0126fbfbc35611d77ecd5da80054b5893e28fb213a5613b9e1d/lxml-6.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:c3592631e652afa34999a088f98ba7dfc7d6aff0d535c410bea77a71743f3819", size = 3659552, upload-time = "2026-04-18T04:27:51.133Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/88/55143966481409b1740a3ac669e611055f49efd68087a5ce41582325db3e/lxml-6.1.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:546b66c0dd1bb8d9fa89d7123e5fa19a8aff3a1f2141eb22df96112afb17b842", size = 3930134, upload-time = "2026-04-18T04:32:35.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/97/28b985c2983938d3cb696dd5501423afb90a8c3e869ef5d3c62569282c0f/lxml-6.1.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5cfa1a34df366d9dc0d5eaf420f4cf2bb1e1bebe1066d1c2fc28c179f8a4004c", size = 4210749, upload-time = "2026-04-18T04:36:03.626Z" },
+    { url = "https://files.pythonhosted.org/packages/29/67/dfab2b7d58214921935ccea7ce9b3df9b7d46f305d12f0f532ac7cf6b804/lxml-6.1.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db88156fcf544cdbf0d95588051515cfdfd4c876fc66444eb98bceb5d6db76de", size = 4318463, upload-time = "2026-04-18T04:36:06.309Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a2/4ac7eb32a4d997dd352c32c32399aae27b3f268d440e6f9cfa405b575d2f/lxml-6.1.0-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:07f98f5496f96bf724b1e3c933c107f0cbf2745db18c03d2e13a291c3afd2635", size = 4251124, upload-time = "2026-04-18T04:36:09.056Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ef/d6abd850bb4822f9b720cfe36b547a558e694881010ff7d012191e8769c6/lxml-6.1.0-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4642e04449a1e164b5ff71ffd901ddb772dfabf5c9adf1b7be5dffe1212bc037", size = 4401758, upload-time = "2026-04-18T04:36:11.803Z" },
+    { url = "https://files.pythonhosted.org/packages/40/44/3ee09a5b60cb44c4f2fbc1c9015cfd6ff5afc08f991cab295d3024dcbf2d/lxml-6.1.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:7da13bb6fbadfafb474e0226a30570a3445cfd47c86296f2446dafbd77079ace", size = 3508860, upload-time = "2026-04-18T04:32:48.619Z" },
 ]
 
 [[package]]
@@ -190,29 +190,29 @@ wheels = [
 
 [[package]]
 name = "nodeenv"
-version = "1.9.1"
+version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
 ]
 
 [[package]]
 name = "packaging"
-version = "25.0"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]
 name = "platformdirs"
-version = "4.3.8"
+version = "4.9.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/8b/3c73abc9c759ecd3f1f7ceff6685840859e8070c4d947c93fae71f6a0bf2/platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc", size = 21362, upload-time = "2025-05-07T22:47:42.121Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/39/979e8e21520d4e47a0bbe349e2713c0aac6f3d853d0e5b34d76206c439aa/platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4", size = 18567, upload-time = "2025-05-07T22:47:40.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
 ]
 
 [[package]]
@@ -226,7 +226,7 @@ wheels = [
 
 [[package]]
 name = "pre-commit"
-version = "4.3.0"
+version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cfgv" },
@@ -235,9 +235,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "virtualenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/29/7cf5bbc236333876e4b41f56e06857a87937ce4bf91e117a6991a2dbb02a/pre_commit-4.3.0.tar.gz", hash = "sha256:499fe450cc9d42e9d58e606262795ecb64dd05438943c62b66f6a8673da30b16", size = 193792, upload-time = "2025-08-09T18:56:14.651Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/a5/987a405322d78a73b66e39e4a90e4ef156fd7141bf71df987e50717c321b/pre_commit-4.3.0-py2.py3-none-any.whl", hash = "sha256:2b0747ad7e6e967169136edffee14c16e148a778a54e4f967921aa1ebf2308d8", size = 220965, upload-time = "2025-08-09T18:56:13.192Z" },
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
 ]
 
 [[package]]
@@ -254,16 +254,16 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -272,35 +272,49 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/e0/cc5a8653e9a24f6cf84768f05064aa8ed5a83dcefd5e2a043db14a1c5f44/python_discovery-1.3.0.tar.gz", hash = "sha256:d098f1e86be5d45fe4d14bf1029294aabbd332f4321179dec85e76cddce834b0", size = 63925, upload-time = "2026-05-05T14:38:39.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/d4/24d543ab8b8158b7f5a97113c831205f5c900c92c8762b1e7f44b7ea0405/python_discovery-1.3.0-py3-none-any.whl", hash = "sha256:441d9ced3dfce36e113beb35ca302c71c7ef06f3c0f9c227a0b9bb3bd49b9e9f", size = 33124, upload-time = "2026-05-05T14:38:38.539Z" },
 ]
 
 [[package]]
 name = "pyyaml"
-version = "6.0.2"
+version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631, upload-time = "2024-08-06T20:33:50.674Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/aa/7af4e81f7acba21a4c6be026da38fd2b872ca46226673c89a758ebdc4fd2/PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774", size = 184612, upload-time = "2024-08-06T20:32:03.408Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/62/b9faa998fd185f65c1371643678e4d58254add437edb764a08c5a98fb986/PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee", size = 172040, upload-time = "2024-08-06T20:32:04.926Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/0c/c804f5f922a9a6563bab712d8dcc70251e8af811fce4524d57c2c0fd49a4/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c", size = 736829, upload-time = "2024-08-06T20:32:06.459Z" },
-    { url = "https://files.pythonhosted.org/packages/51/16/6af8d6a6b210c8e54f1406a6b9481febf9c64a3109c541567e35a49aa2e7/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317", size = 764167, upload-time = "2024-08-06T20:32:08.338Z" },
-    { url = "https://files.pythonhosted.org/packages/75/e4/2c27590dfc9992f73aabbeb9241ae20220bd9452df27483b6e56d3975cc5/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85", size = 762952, upload-time = "2024-08-06T20:32:14.124Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/97/ecc1abf4a823f5ac61941a9c00fe501b02ac3ab0e373c3857f7d4b83e2b6/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4", size = 735301, upload-time = "2024-08-06T20:32:16.17Z" },
-    { url = "https://files.pythonhosted.org/packages/45/73/0f49dacd6e82c9430e46f4a027baa4ca205e8b0a9dce1397f44edc23559d/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e", size = 756638, upload-time = "2024-08-06T20:32:18.555Z" },
-    { url = "https://files.pythonhosted.org/packages/22/5f/956f0f9fc65223a58fbc14459bf34b4cc48dec52e00535c79b8db361aabd/PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5", size = 143850, upload-time = "2024-08-06T20:32:19.889Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/23/8da0bbe2ab9dcdd11f4f4557ccaf95c10b9811b13ecced089d43ce59c3c8/PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44", size = 161980, upload-time = "2024-08-06T20:32:21.273Z" },
-    { url = "https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873, upload-time = "2024-08-06T20:32:25.131Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302, upload-time = "2024-08-06T20:32:26.511Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154, upload-time = "2024-08-06T20:32:28.363Z" },
-    { url = "https://files.pythonhosted.org/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223, upload-time = "2024-08-06T20:32:30.058Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542, upload-time = "2024-08-06T20:32:31.881Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164, upload-time = "2024-08-06T20:32:37.083Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611, upload-time = "2024-08-06T20:32:38.898Z" },
-    { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591, upload-time = "2024-08-06T20:32:40.241Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338, upload-time = "2024-08-06T20:32:41.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
 ]
 
 [[package]]
@@ -319,116 +333,86 @@ wheels = [
 
 [[package]]
 name = "rpds-py"
-version = "0.29.0"
+version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/33/23b3b3419b6a3e0f559c7c0d2ca8fc1b9448382b25245033788785921332/rpds_py-0.29.0.tar.gz", hash = "sha256:fe55fe686908f50154d1dc599232016e50c243b438c3b7432f24e2895b0e5359", size = 69359, upload-time = "2025-11-16T14:50:39.532Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/ab/7fb95163a53ab122c74a7c42d2d2f012819af2cf3deb43fb0d5acf45cc1a/rpds_py-0.29.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:9b9c764a11fd637e0322a488560533112837f5334ffeb48b1be20f6d98a7b437", size = 372344, upload-time = "2025-11-16T14:47:57.279Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/45/f3c30084c03b0d0f918cb4c5ae2c20b0a148b51ba2b3f6456765b629bedd/rpds_py-0.29.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3fd2164d73812026ce970d44c3ebd51e019d2a26a4425a5dcbdfa93a34abc383", size = 363041, upload-time = "2025-11-16T14:47:58.908Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/e9/4d044a1662608c47a87cbb37b999d4d5af54c6d6ebdda93a4d8bbf8b2a10/rpds_py-0.29.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4a097b7f7f7274164566ae90a221fd725363c0e9d243e2e9ed43d195ccc5495c", size = 391775, upload-time = "2025-11-16T14:48:00.197Z" },
-    { url = "https://files.pythonhosted.org/packages/50/c9/7616d3ace4e6731aeb6e3cd85123e03aec58e439044e214b9c5c60fd8eb1/rpds_py-0.29.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7cdc0490374e31cedefefaa1520d5fe38e82fde8748cbc926e7284574c714d6b", size = 405624, upload-time = "2025-11-16T14:48:01.496Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/e2/6d7d6941ca0843609fd2d72c966a438d6f22617baf22d46c3d2156c31350/rpds_py-0.29.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:89ca2e673ddd5bde9b386da9a0aac0cab0e76f40c8f0aaf0d6311b6bbf2aa311", size = 527894, upload-time = "2025-11-16T14:48:03.167Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/f7/aee14dc2db61bb2ae1e3068f134ca9da5f28c586120889a70ff504bb026f/rpds_py-0.29.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a5d9da3ff5af1ca1249b1adb8ef0573b94c76e6ae880ba1852f033bf429d4588", size = 412720, upload-time = "2025-11-16T14:48:04.413Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/e2/2293f236e887c0360c2723d90c00d48dee296406994d6271faf1712e94ec/rpds_py-0.29.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8238d1d310283e87376c12f658b61e1ee23a14c0e54c7c0ce953efdbdc72deed", size = 392945, upload-time = "2025-11-16T14:48:06.252Z" },
-    { url = "https://files.pythonhosted.org/packages/14/cd/ceea6147acd3bd1fd028d1975228f08ff19d62098078d5ec3eed49703797/rpds_py-0.29.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:2d6fb2ad1c36f91c4646989811e84b1ea5e0c3cf9690b826b6e32b7965853a63", size = 406385, upload-time = "2025-11-16T14:48:07.575Z" },
-    { url = "https://files.pythonhosted.org/packages/52/36/fe4dead19e45eb77a0524acfdbf51e6cda597b26fc5b6dddbff55fbbb1a5/rpds_py-0.29.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:534dc9df211387547267ccdb42253aa30527482acb38dd9b21c5c115d66a96d2", size = 423943, upload-time = "2025-11-16T14:48:10.175Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/7b/4551510803b582fa4abbc8645441a2d15aa0c962c3b21ebb380b7e74f6a1/rpds_py-0.29.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d456e64724a075441e4ed648d7f154dc62e9aabff29bcdf723d0c00e9e1d352f", size = 574204, upload-time = "2025-11-16T14:48:11.499Z" },
-    { url = "https://files.pythonhosted.org/packages/64/ba/071ccdd7b171e727a6ae079f02c26f75790b41555f12ca8f1151336d2124/rpds_py-0.29.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:a738f2da2f565989401bd6fd0b15990a4d1523c6d7fe83f300b7e7d17212feca", size = 600587, upload-time = "2025-11-16T14:48:12.822Z" },
-    { url = "https://files.pythonhosted.org/packages/03/09/96983d48c8cf5a1e03c7d9cc1f4b48266adfb858ae48c7c2ce978dbba349/rpds_py-0.29.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a110e14508fd26fd2e472bb541f37c209409876ba601cf57e739e87d8a53cf95", size = 562287, upload-time = "2025-11-16T14:48:14.108Z" },
-    { url = "https://files.pythonhosted.org/packages/40/f0/8c01aaedc0fa92156f0391f39ea93b5952bc0ec56b897763858f95da8168/rpds_py-0.29.0-cp311-cp311-win32.whl", hash = "sha256:923248a56dd8d158389a28934f6f69ebf89f218ef96a6b216a9be6861804d3f4", size = 221394, upload-time = "2025-11-16T14:48:15.374Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/a5/a8b21c54c7d234efdc83dc034a4d7cd9668e3613b6316876a29b49dece71/rpds_py-0.29.0-cp311-cp311-win_amd64.whl", hash = "sha256:539eb77eb043afcc45314d1be09ea6d6cafb3addc73e0547c171c6d636957f60", size = 235713, upload-time = "2025-11-16T14:48:16.636Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/1f/df3c56219523947b1be402fa12e6323fe6d61d883cf35d6cb5d5bb6db9d9/rpds_py-0.29.0-cp311-cp311-win_arm64.whl", hash = "sha256:bdb67151ea81fcf02d8f494703fb728d4d34d24556cbff5f417d74f6f5792e7c", size = 229157, upload-time = "2025-11-16T14:48:17.891Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/50/bc0e6e736d94e420df79be4deb5c9476b63165c87bb8f19ef75d100d21b3/rpds_py-0.29.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a0891cfd8db43e085c0ab93ab7e9b0c8fee84780d436d3b266b113e51e79f954", size = 376000, upload-time = "2025-11-16T14:48:19.141Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/3a/46676277160f014ae95f24de53bed0e3b7ea66c235e7de0b9df7bd5d68ba/rpds_py-0.29.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3897924d3f9a0361472d884051f9a2460358f9a45b1d85a39a158d2f8f1ad71c", size = 360575, upload-time = "2025-11-16T14:48:20.443Z" },
-    { url = "https://files.pythonhosted.org/packages/75/ba/411d414ed99ea1afdd185bbabeeaac00624bd1e4b22840b5e9967ade6337/rpds_py-0.29.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2a21deb8e0d1571508c6491ce5ea5e25669b1dd4adf1c9d64b6314842f708b5d", size = 392159, upload-time = "2025-11-16T14:48:22.12Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/b1/e18aa3a331f705467a48d0296778dc1fea9d7f6cf675bd261f9a846c7e90/rpds_py-0.29.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9efe71687d6427737a0a2de9ca1c0a216510e6cd08925c44162be23ed7bed2d5", size = 410602, upload-time = "2025-11-16T14:48:23.563Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/6c/04f27f0c9f2299274c76612ac9d2c36c5048bb2c6c2e52c38c60bf3868d9/rpds_py-0.29.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:40f65470919dc189c833e86b2c4bd21bd355f98436a2cef9e0a9a92aebc8e57e", size = 515808, upload-time = "2025-11-16T14:48:24.949Z" },
-    { url = "https://files.pythonhosted.org/packages/83/56/a8412aa464fb151f8bc0d91fb0bb888adc9039bd41c1c6ba8d94990d8cf8/rpds_py-0.29.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:def48ff59f181130f1a2cb7c517d16328efac3ec03951cca40c1dc2049747e83", size = 416015, upload-time = "2025-11-16T14:48:26.782Z" },
-    { url = "https://files.pythonhosted.org/packages/04/4c/f9b8a05faca3d9e0a6397c90d13acb9307c9792b2bff621430c58b1d6e76/rpds_py-0.29.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad7bd570be92695d89285a4b373006930715b78d96449f686af422debb4d3949", size = 395325, upload-time = "2025-11-16T14:48:28.055Z" },
-    { url = "https://files.pythonhosted.org/packages/34/60/869f3bfbf8ed7b54f1ad9a5543e0fdffdd40b5a8f587fe300ee7b4f19340/rpds_py-0.29.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:5a572911cd053137bbff8e3a52d31c5d2dba51d3a67ad902629c70185f3f2181", size = 410160, upload-time = "2025-11-16T14:48:29.338Z" },
-    { url = "https://files.pythonhosted.org/packages/91/aa/e5b496334e3aba4fe4c8a80187b89f3c1294c5c36f2a926da74338fa5a73/rpds_py-0.29.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d583d4403bcbf10cffc3ab5cee23d7643fcc960dff85973fd3c2d6c86e8dbb0c", size = 425309, upload-time = "2025-11-16T14:48:30.691Z" },
-    { url = "https://files.pythonhosted.org/packages/85/68/4e24a34189751ceb6d66b28f18159922828dd84155876551f7ca5b25f14f/rpds_py-0.29.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:070befbb868f257d24c3bb350dbd6e2f645e83731f31264b19d7231dd5c396c7", size = 574644, upload-time = "2025-11-16T14:48:31.964Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/cf/474a005ea4ea9c3b4f17b6108b6b13cebfc98ebaff11d6e1b193204b3a93/rpds_py-0.29.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:fc935f6b20b0c9f919a8ff024739174522abd331978f750a74bb68abd117bd19", size = 601605, upload-time = "2025-11-16T14:48:33.252Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/b1/c56f6a9ab8c5f6bb5c65c4b5f8229167a3a525245b0773f2c0896686b64e/rpds_py-0.29.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8c5a8ecaa44ce2d8d9d20a68a2483a74c07f05d72e94a4dff88906c8807e77b0", size = 564593, upload-time = "2025-11-16T14:48:34.643Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/13/0494cecce4848f68501e0a229432620b4b57022388b071eeff95f3e1e75b/rpds_py-0.29.0-cp312-cp312-win32.whl", hash = "sha256:ba5e1aeaf8dd6d8f6caba1f5539cddda87d511331714b7b5fc908b6cfc3636b7", size = 223853, upload-time = "2025-11-16T14:48:36.419Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/6a/51e9aeb444a00cdc520b032a28b07e5f8dc7bc328b57760c53e7f96997b4/rpds_py-0.29.0-cp312-cp312-win_amd64.whl", hash = "sha256:b5f6134faf54b3cb83375db0f113506f8b7770785be1f95a631e7e2892101977", size = 239895, upload-time = "2025-11-16T14:48:37.956Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/d4/8bce56cdad1ab873e3f27cb31c6a51d8f384d66b022b820525b879f8bed1/rpds_py-0.29.0-cp312-cp312-win_arm64.whl", hash = "sha256:b016eddf00dca7944721bf0cd85b6af7f6c4efaf83ee0b37c4133bd39757a8c7", size = 230321, upload-time = "2025-11-16T14:48:39.71Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/ac/b97e80bf107159e5b9ba9c91df1ab95f69e5e41b435f27bdd737f0d583ac/rpds_py-0.29.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:acd82a9e39082dc5f4492d15a6b6c8599aa21db5c35aaf7d6889aea16502c07d", size = 373963, upload-time = "2025-11-16T14:50:16.205Z" },
-    { url = "https://files.pythonhosted.org/packages/40/5a/55e72962d5d29bd912f40c594e68880d3c7a52774b0f75542775f9250712/rpds_py-0.29.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:715b67eac317bf1c7657508170a3e011a1ea6ccb1c9d5f296e20ba14196be6b3", size = 364644, upload-time = "2025-11-16T14:50:18.22Z" },
-    { url = "https://files.pythonhosted.org/packages/99/2a/6b6524d0191b7fc1351c3c0840baac42250515afb48ae40c7ed15499a6a2/rpds_py-0.29.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3b1b87a237cb2dba4db18bcfaaa44ba4cd5936b91121b62292ff21df577fc43", size = 393847, upload-time = "2025-11-16T14:50:20.012Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/b8/c5692a7df577b3c0c7faed7ac01ee3c608b81750fc5d89f84529229b6873/rpds_py-0.29.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1c3c3e8101bb06e337c88eb0c0ede3187131f19d97d43ea0e1c5407ea74c0cbf", size = 407281, upload-time = "2025-11-16T14:50:21.64Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/57/0546c6f84031b7ea08b76646a8e33e45607cc6bd879ff1917dc077bb881e/rpds_py-0.29.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2b8e54d6e61f3ecd3abe032065ce83ea63417a24f437e4a3d73d2f85ce7b7cfe", size = 529213, upload-time = "2025-11-16T14:50:23.219Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/c1/01dd5f444233605555bc11fe5fed6a5c18f379f02013870c176c8e630a23/rpds_py-0.29.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3fbd4e9aebf110473a420dea85a238b254cf8a15acb04b22a5a6b5ce8925b760", size = 413808, upload-time = "2025-11-16T14:50:25.262Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/0a/60f98b06156ea2a7af849fb148e00fbcfdb540909a5174a5ed10c93745c7/rpds_py-0.29.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80fdf53d36e6c72819993e35d1ebeeb8e8fc688d0c6c2b391b55e335b3afba5a", size = 394600, upload-time = "2025-11-16T14:50:26.956Z" },
-    { url = "https://files.pythonhosted.org/packages/37/f1/dc9312fc9bec040ece08396429f2bd9e0977924ba7a11c5ad7056428465e/rpds_py-0.29.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:ea7173df5d86f625f8dde6d5929629ad811ed8decda3b60ae603903839ac9ac0", size = 408634, upload-time = "2025-11-16T14:50:28.989Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/41/65024c9fd40c89bb7d604cf73beda4cbdbcebe92d8765345dd65855b6449/rpds_py-0.29.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:76054d540061eda273274f3d13a21a4abdde90e13eaefdc205db37c05230efce", size = 426064, upload-time = "2025-11-16T14:50:30.674Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/e0/cf95478881fc88ca2fdbf56381d7df36567cccc39a05394beac72182cd62/rpds_py-0.29.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:9f84c549746a5be3bc7415830747a3a0312573afc9f95785eb35228bb17742ec", size = 575871, upload-time = "2025-11-16T14:50:33.428Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/c0/df88097e64339a0218b57bd5f9ca49898e4c394db756c67fccc64add850a/rpds_py-0.29.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:0ea962671af5cb9a260489e311fa22b2e97103e3f9f0caaea6f81390af96a9ed", size = 601702, upload-time = "2025-11-16T14:50:36.051Z" },
-    { url = "https://files.pythonhosted.org/packages/87/f4/09ffb3ebd0cbb9e2c7c9b84d252557ecf434cd71584ee1e32f66013824df/rpds_py-0.29.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:f7728653900035fb7b8d06e1e5900545d8088efc9d5d4545782da7df03ec803f", size = 564054, upload-time = "2025-11-16T14:50:37.733Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425", size = 370157, upload-time = "2025-11-30T20:21:53.789Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ba/24e5ebb7c1c82e74c4e4f33b2112a5573ddc703915b13a073737b59b86e0/rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d", size = 359676, upload-time = "2025-11-30T20:21:55.475Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/04dbba1b087227747d64d80c3b74df946b986c57af0a9f0c98726d4d7a3b/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4", size = 389938, upload-time = "2025-11-30T20:21:57.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/bb/1463f0b1722b7f45431bdd468301991d1328b16cffe0b1c2918eba2c4eee/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f", size = 402932, upload-time = "2025-11-30T20:21:58.47Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/2520700a5c1f2d76631f948b0736cdf9b0acb25abd0ca8e889b5c62ac2e3/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4", size = 525830, upload-time = "2025-11-30T20:21:59.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ad/bd0331f740f5705cc555a5e17fdf334671262160270962e69a2bdef3bf76/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97", size = 412033, upload-time = "2025-11-30T20:22:00.991Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89", size = 390828, upload-time = "2025-11-30T20:22:02.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2b/d88bb33294e3e0c76bc8f351a3721212713629ffca1700fa94979cb3eae8/rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d", size = 404683, upload-time = "2025-11-30T20:22:04.367Z" },
+    { url = "https://files.pythonhosted.org/packages/50/32/c759a8d42bcb5289c1fac697cd92f6fe01a018dd937e62ae77e0e7f15702/rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038", size = 421583, upload-time = "2025-11-30T20:22:05.814Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/81/e729761dbd55ddf5d84ec4ff1f47857f4374b0f19bdabfcf929164da3e24/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7", size = 572496, upload-time = "2025-11-30T20:22:07.713Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f6/69066a924c3557c9c30baa6ec3a0aa07526305684c6f86c696b08860726c/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed", size = 598669, upload-time = "2025-11-30T20:22:09.312Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/48/905896b1eb8a05630d20333d1d8ffd162394127b74ce0b0784ae04498d32/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85", size = 561011, upload-time = "2025-11-30T20:22:11.309Z" },
+    { url = "https://files.pythonhosted.org/packages/22/16/cd3027c7e279d22e5eb431dd3c0fbc677bed58797fe7581e148f3f68818b/rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c", size = 221406, upload-time = "2025-11-30T20:22:13.101Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/e7b7aa136f28462b344e652ee010d4de26ee9fd16f1bfd5811f5153ccf89/rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825", size = 236024, upload-time = "2025-11-30T20:22:14.853Z" },
+    { url = "https://files.pythonhosted.org/packages/14/a6/364bba985e4c13658edb156640608f2c9e1d3ea3c81b27aa9d889fff0e31/rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229", size = 229069, upload-time = "2025-11-30T20:22:16.577Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/69/71/3f34339ee70521864411f8b6992e7ab13ac30d8e4e3309e07c7361767d91/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58", size = 372292, upload-time = "2025-11-30T20:24:16.537Z" },
+    { url = "https://files.pythonhosted.org/packages/57/09/f183df9b8f2d66720d2ef71075c59f7e1b336bec7ee4c48f0a2b06857653/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a", size = 362128, upload-time = "2025-11-30T20:24:18.086Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/5c2594e937253457342e078f0cc1ded3dd7b2ad59afdbf2d354869110a02/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb", size = 391542, upload-time = "2025-11-30T20:24:20.092Z" },
+    { url = "https://files.pythonhosted.org/packages/49/5c/31ef1afd70b4b4fbdb2800249f34c57c64beb687495b10aec0365f53dfc4/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c", size = 404004, upload-time = "2025-11-30T20:24:22.231Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/0cfbea38d05756f3440ce6534d51a491d26176ac045e2707adc99bb6e60a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3", size = 527063, upload-time = "2025-11-30T20:24:24.302Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e6/01e1f72a2456678b0f618fc9a1a13f882061690893c192fcad9f2926553a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5", size = 413099, upload-time = "2025-11-30T20:24:25.916Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/25/8df56677f209003dcbb180765520c544525e3ef21ea72279c98b9aa7c7fb/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738", size = 392177, upload-time = "2025-11-30T20:24:27.834Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b4/0a771378c5f16f8115f796d1f437950158679bcd2a7c68cf251cfb00ed5b/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f", size = 406015, upload-time = "2025-11-30T20:24:29.457Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d8/456dbba0af75049dc6f63ff295a2f92766b9d521fa00de67a2bd6427d57a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877", size = 423736, upload-time = "2025-11-30T20:24:31.22Z" },
+    { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
+    { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
 ]
 
 [[package]]
 name = "ruamel-yaml"
-version = "0.18.15"
+version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ruamel-yaml-clib", marker = "platform_python_implementation == 'CPython'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/db/f3950f5e5031b618aae9f423a39bf81a55c148aecd15a34527898e752cf4/ruamel.yaml-0.18.15.tar.gz", hash = "sha256:dbfca74b018c4c3fba0b9cc9ee33e53c371194a9000e694995e620490fd40700", size = 146865, upload-time = "2025-08-19T11:15:10.694Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/e5/f2a0621f1781b76a38194acae72f01e37b1941470407345b6e8653ad7640/ruamel.yaml-0.18.15-py3-none-any.whl", hash = "sha256:148f6488d698b7a5eded5ea793a025308b25eca97208181b6a026037f391f701", size = 119702, upload-time = "2025-08-19T11:15:07.696Z" },
-]
-
-[[package]]
-name = "ruamel-yaml-clib"
-version = "0.2.12"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/20/84/80203abff8ea4993a87d823a5f632e4d92831ef75d404c9fc78d0176d2b5/ruamel.yaml.clib-0.2.12.tar.gz", hash = "sha256:6c8fbb13ec503f99a91901ab46e0b07ae7941cd527393187039aec586fdfd36f", size = 225315, upload-time = "2024-10-20T10:10:56.22Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/8f/683c6ad562f558cbc4f7c029abcd9599148c51c54b5ef0f24f2638da9fbb/ruamel.yaml.clib-0.2.12-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:4a6679521a58256a90b0d89e03992c15144c5f3858f40d7c18886023d7943db6", size = 132224, upload-time = "2024-10-20T10:12:45.162Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/d2/b79b7d695e2f21da020bd44c782490578f300dd44f0a4c57a92575758a76/ruamel.yaml.clib-0.2.12-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:d84318609196d6bd6da0edfa25cedfbabd8dbde5140a0a23af29ad4b8f91fb1e", size = 641480, upload-time = "2024-10-20T10:12:46.758Z" },
-    { url = "https://files.pythonhosted.org/packages/68/6e/264c50ce2a31473a9fdbf4fa66ca9b2b17c7455b31ef585462343818bd6c/ruamel.yaml.clib-0.2.12-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb43a269eb827806502c7c8efb7ae7e9e9d0573257a46e8e952f4d4caba4f31e", size = 739068, upload-time = "2024-10-20T10:12:48.605Z" },
-    { url = "https://files.pythonhosted.org/packages/86/29/88c2567bc893c84d88b4c48027367c3562ae69121d568e8a3f3a8d363f4d/ruamel.yaml.clib-0.2.12-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:811ea1594b8a0fb466172c384267a4e5e367298af6b228931f273b111f17ef52", size = 703012, upload-time = "2024-10-20T10:12:51.124Z" },
-    { url = "https://files.pythonhosted.org/packages/11/46/879763c619b5470820f0cd6ca97d134771e502776bc2b844d2adb6e37753/ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:cf12567a7b565cbf65d438dec6cfbe2917d3c1bdddfce84a9930b7d35ea59642", size = 704352, upload-time = "2024-10-21T11:26:41.438Z" },
-    { url = "https://files.pythonhosted.org/packages/02/80/ece7e6034256a4186bbe50dee28cd032d816974941a6abf6a9d65e4228a7/ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7dd5adc8b930b12c8fc5b99e2d535a09889941aa0d0bd06f4749e9a9397c71d2", size = 737344, upload-time = "2024-10-21T11:26:43.62Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/ca/e4106ac7e80efbabdf4bf91d3d32fc424e41418458251712f5672eada9ce/ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1492a6051dab8d912fc2adeef0e8c72216b24d57bd896ea607cb90bb0c4981d3", size = 714498, upload-time = "2024-12-11T19:58:15.592Z" },
-    { url = "https://files.pythonhosted.org/packages/67/58/b1f60a1d591b771298ffa0428237afb092c7f29ae23bad93420b1eb10703/ruamel.yaml.clib-0.2.12-cp311-cp311-win32.whl", hash = "sha256:bd0a08f0bab19093c54e18a14a10b4322e1eacc5217056f3c063bd2f59853ce4", size = 100205, upload-time = "2024-10-20T10:12:52.865Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/4f/b52f634c9548a9291a70dfce26ca7ebce388235c93588a1068028ea23fcc/ruamel.yaml.clib-0.2.12-cp311-cp311-win_amd64.whl", hash = "sha256:a274fb2cb086c7a3dea4322ec27f4cb5cc4b6298adb583ab0e211a4682f241eb", size = 118185, upload-time = "2024-10-20T10:12:54.652Z" },
-    { url = "https://files.pythonhosted.org/packages/48/41/e7a405afbdc26af961678474a55373e1b323605a4f5e2ddd4a80ea80f628/ruamel.yaml.clib-0.2.12-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:20b0f8dc160ba83b6dcc0e256846e1a02d044e13f7ea74a3d1d56ede4e48c632", size = 133433, upload-time = "2024-10-20T10:12:55.657Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/b0/b850385604334c2ce90e3ee1013bd911aedf058a934905863a6ea95e9eb4/ruamel.yaml.clib-0.2.12-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:943f32bc9dedb3abff9879edc134901df92cfce2c3d5c9348f172f62eb2d771d", size = 647362, upload-time = "2024-10-20T10:12:57.155Z" },
-    { url = "https://files.pythonhosted.org/packages/44/d0/3f68a86e006448fb6c005aee66565b9eb89014a70c491d70c08de597f8e4/ruamel.yaml.clib-0.2.12-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95c3829bb364fdb8e0332c9931ecf57d9be3519241323c5274bd82f709cebc0c", size = 754118, upload-time = "2024-10-20T10:12:58.501Z" },
-    { url = "https://files.pythonhosted.org/packages/52/a9/d39f3c5ada0a3bb2870d7db41901125dbe2434fa4f12ca8c5b83a42d7c53/ruamel.yaml.clib-0.2.12-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:749c16fcc4a2b09f28843cda5a193e0283e47454b63ec4b81eaa2242f50e4ccd", size = 706497, upload-time = "2024-10-20T10:13:00.211Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/fa/097e38135dadd9ac25aecf2a54be17ddf6e4c23e43d538492a90ab3d71c6/ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:bf165fef1f223beae7333275156ab2022cffe255dcc51c27f066b4370da81e31", size = 698042, upload-time = "2024-10-21T11:26:46.038Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/d5/a659ca6f503b9379b930f13bc6b130c9f176469b73b9834296822a83a132/ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:32621c177bbf782ca5a18ba4d7af0f1082a3f6e517ac2a18b3974d4edf349680", size = 745831, upload-time = "2024-10-21T11:26:47.487Z" },
-    { url = "https://files.pythonhosted.org/packages/db/5d/36619b61ffa2429eeaefaab4f3374666adf36ad8ac6330d855848d7d36fd/ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b82a7c94a498853aa0b272fd5bc67f29008da798d4f93a2f9f289feb8426a58d", size = 715692, upload-time = "2024-12-11T19:58:17.252Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/82/85cb92f15a4231c89b95dfe08b09eb6adca929ef7df7e17ab59902b6f589/ruamel.yaml.clib-0.2.12-cp312-cp312-win32.whl", hash = "sha256:e8c4ebfcfd57177b572e2040777b8abc537cdef58a2120e830124946aa9b42c5", size = 98777, upload-time = "2024-10-20T10:13:01.395Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/8f/c3654f6f1ddb75daf3922c3d8fc6005b1ab56671ad56ffb874d908bfa668/ruamel.yaml.clib-0.2.12-cp312-cp312-win_amd64.whl", hash = "sha256:0467c5965282c62203273b838ae77c0d29d7638c8a4e3a1c8bdd3602c10904e4", size = 115523, upload-time = "2024-10-20T10:13:02.768Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
 ]
 
 [[package]]
 name = "ruff"
-version = "0.12.10"
+version = "0.15.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3b/eb/8c073deb376e46ae767f4961390d17545e8535921d2f65101720ed8bd434/ruff-0.12.10.tar.gz", hash = "sha256:189ab65149d11ea69a2d775343adf5f49bb2426fc4780f65ee33b423ad2e47f9", size = 5310076, upload-time = "2025-08-21T18:23:22.595Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/e7/560d049d15585d6c201f9eeacd2fd130def3741323e5ccf123786e0e3c95/ruff-0.12.10-py3-none-linux_armv6l.whl", hash = "sha256:8b593cb0fb55cc8692dac7b06deb29afda78c721c7ccfed22db941201b7b8f7b", size = 11935161, upload-time = "2025-08-21T18:22:26.965Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/b0/ad2464922a1113c365d12b8f80ed70fcfb39764288ac77c995156080488d/ruff-0.12.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ebb7333a45d56efc7c110a46a69a1b32365d5c5161e7244aaf3aa20ce62399c1", size = 12660884, upload-time = "2025-08-21T18:22:30.925Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/f1/97f509b4108d7bae16c48389f54f005b62ce86712120fd8b2d8e88a7cb49/ruff-0.12.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d59e58586829f8e4a9920788f6efba97a13d1fa320b047814e8afede381c6839", size = 11872754, upload-time = "2025-08-21T18:22:34.035Z" },
-    { url = "https://files.pythonhosted.org/packages/12/ad/44f606d243f744a75adc432275217296095101f83f966842063d78eee2d3/ruff-0.12.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:822d9677b560f1fdeab69b89d1f444bf5459da4aa04e06e766cf0121771ab844", size = 12092276, upload-time = "2025-08-21T18:22:36.764Z" },
-    { url = "https://files.pythonhosted.org/packages/06/1f/ed6c265e199568010197909b25c896d66e4ef2c5e1c3808caf461f6f3579/ruff-0.12.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:37b4a64f4062a50c75019c61c7017ff598cb444984b638511f48539d3a1c98db", size = 11734700, upload-time = "2025-08-21T18:22:39.822Z" },
-    { url = "https://files.pythonhosted.org/packages/63/c5/b21cde720f54a1d1db71538c0bc9b73dee4b563a7dd7d2e404914904d7f5/ruff-0.12.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2c6f4064c69d2542029b2a61d39920c85240c39837599d7f2e32e80d36401d6e", size = 13468783, upload-time = "2025-08-21T18:22:42.559Z" },
-    { url = "https://files.pythonhosted.org/packages/02/9e/39369e6ac7f2a1848f22fb0b00b690492f20811a1ac5c1fd1d2798329263/ruff-0.12.10-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:059e863ea3a9ade41407ad71c1de2badfbe01539117f38f763ba42a1206f7559", size = 14436642, upload-time = "2025-08-21T18:22:45.612Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/03/5da8cad4b0d5242a936eb203b58318016db44f5c5d351b07e3f5e211bb89/ruff-0.12.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1bef6161e297c68908b7218fa6e0e93e99a286e5ed9653d4be71e687dff101cf", size = 13859107, upload-time = "2025-08-21T18:22:48.886Z" },
-    { url = "https://files.pythonhosted.org/packages/19/19/dd7273b69bf7f93a070c9cec9494a94048325ad18fdcf50114f07e6bf417/ruff-0.12.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4f1345fbf8fb0531cd722285b5f15af49b2932742fc96b633e883da8d841896b", size = 12886521, upload-time = "2025-08-21T18:22:51.567Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/1d/b4207ec35e7babaee62c462769e77457e26eb853fbdc877af29417033333/ruff-0.12.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1f68433c4fbc63efbfa3ba5db31727db229fa4e61000f452c540474b03de52a9", size = 13097528, upload-time = "2025-08-21T18:22:54.609Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/00/58f7b873b21114456e880b75176af3490d7a2836033779ca42f50de3b47a/ruff-0.12.10-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:141ce3d88803c625257b8a6debf4a0473eb6eed9643a6189b68838b43e78165a", size = 13080443, upload-time = "2025-08-21T18:22:57.413Z" },
-    { url = "https://files.pythonhosted.org/packages/12/8c/9e6660007fb10189ccb78a02b41691288038e51e4788bf49b0a60f740604/ruff-0.12.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f3fc21178cd44c98142ae7590f42ddcb587b8e09a3b849cbc84edb62ee95de60", size = 11896759, upload-time = "2025-08-21T18:23:00.473Z" },
-    { url = "https://files.pythonhosted.org/packages/67/4c/6d092bb99ea9ea6ebda817a0e7ad886f42a58b4501a7e27cd97371d0ba54/ruff-0.12.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7d1a4e0bdfafcd2e3e235ecf50bf0176f74dd37902f241588ae1f6c827a36c56", size = 11701463, upload-time = "2025-08-21T18:23:03.211Z" },
-    { url = "https://files.pythonhosted.org/packages/59/80/d982c55e91df981f3ab62559371380616c57ffd0172d96850280c2b04fa8/ruff-0.12.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:e67d96827854f50b9e3e8327b031647e7bcc090dbe7bb11101a81a3a2cbf1cc9", size = 12691603, upload-time = "2025-08-21T18:23:06.935Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/37/63a9c788bbe0b0850611669ec6b8589838faf2f4f959647f2d3e320383ae/ruff-0.12.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:ae479e1a18b439c59138f066ae79cc0f3ee250712a873d00dbafadaad9481e5b", size = 13164356, upload-time = "2025-08-21T18:23:10.225Z" },
-    { url = "https://files.pythonhosted.org/packages/47/d4/1aaa7fb201a74181989970ebccd12f88c0fc074777027e2a21de5a90657e/ruff-0.12.10-py3-none-win32.whl", hash = "sha256:9de785e95dc2f09846c5e6e1d3a3d32ecd0b283a979898ad427a9be7be22b266", size = 11896089, upload-time = "2025-08-21T18:23:14.232Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/14/2ad38fd4037daab9e023456a4a40ed0154e9971f8d6aed41bdea390aabd9/ruff-0.12.10-py3-none-win_amd64.whl", hash = "sha256:7837eca8787f076f67aba2ca559cefd9c5cbc3a9852fd66186f4201b87c1563e", size = 13004616, upload-time = "2025-08-21T18:23:17.422Z" },
-    { url = "https://files.pythonhosted.org/packages/24/3c/21cf283d67af33a8e6ed242396863af195a8a6134ec581524fd22b9811b6/ruff-0.12.10-py3-none-win_arm64.whl", hash = "sha256:cc138cc06ed9d4bfa9d667a65af7172b47840e1a98b02ce7011c391e54635ffc", size = 12074225, upload-time = "2025-08-21T18:23:20.137Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
 ]
 
 [[package]]
@@ -507,14 +491,15 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "20.34.0"
+version = "21.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
     { name = "platformdirs" },
+    { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/14/37fcdba2808a6c615681cd216fecae00413c9dab44fb2e57805ecf3eaee3/virtualenv-20.34.0.tar.gz", hash = "sha256:44815b2c9dee7ed86e387b842a84f20b93f7f417f95886ca1996a72a4138eb1a", size = 6003808, upload-time = "2025-08-13T14:24:07.464Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/0d/915c02c94d207b85580eb09bffab54438a709e7288524094fe781da526c2/virtualenv-21.3.1.tar.gz", hash = "sha256:c2305bc1fddeec40699b8370d13f8d431b0701f00ce895061ce493aeded4426b", size = 7613791, upload-time = "2026-05-05T01:34:31.402Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/06/04c8e804f813cf972e3262f3f8584c232de64f0cde9f703b46cf53a45090/virtualenv-20.34.0-py3-none-any.whl", hash = "sha256:341f5afa7eee943e4984a9207c025feedd768baff6753cd660c857ceb3e36026", size = 5983279, upload-time = "2025-08-13T14:24:05.111Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/4f/f71e641e504111a5a74e3a20bc52d01bd86788b22699dd3fee1c63253cf6/virtualenv-21.3.1-py3-none-any.whl", hash = "sha256:d1a71cf58f2f9228fff23a1f6ec15d39785c6b32e03658d104974247145edd35", size = 7594539, upload-time = "2026-05-05T01:34:28.98Z" },
 ]


### PR DESCRIPTION
This PR allow users to interact more fully with the KKV data store.

1. Adds an API for RESTful PUT access to a data store using a top_level_key and secondary_key. It also adds a way to clear those data stores individually.
2. Adds selective filtering to the GET method for data store items.
3. (FINALLY, AND SOMEWHAT CONTROVERSIALLY) Normalizes the data structure for fetching a single entry or all entries by removing the nesting of the bulk fetch within a `data:` object.

I added tests of both features, and also ended up cleaning up formatting in the api.yml as I modified it, which adds most of the changes.

Let me know if Point 3 is a deal-breaker or if you want to discuss. IMO it's much easier to code around an endpoint that returns the same signature regardless of size but I'm cautious of potentially introducing a breaking change for other consumers.