### PR TITLE
make ruff passes

### DIFF
--- a/spiff-arena-common/pyproject.toml
+++ b/spiff-arena-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spiff-arena-common"
-version = "0.1.29"
+version = "0.1.30"
 description = "Shared Python utilities for Spiff Arena frontend and backend components"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/spiff-arena-common/src/spiff_arena_common/runner.py
+++ b/spiff-arena-common/src/spiff_arena_common/runner.py
@@ -37,22 +37,22 @@ def spiff_json_object_hook(dct):
     return dct
 
 
-from spiff_arena_common.data_stores import JSONFileDataStore
+from spiff_arena_common.data_stores import JSONFileDataStore  # noqa: E402
 
-from SpiffWorkflow.bpmn.exceptions import WorkflowTaskException
-from SpiffWorkflow.bpmn.serializer import DefaultRegistry
-from SpiffWorkflow.bpmn.specs.mixins.multiinstance_task import LoopTask
-from SpiffWorkflow.bpmn.parser.util import full_tag
-from SpiffWorkflow.bpmn.script_engine import PythonScriptEngine, TaskDataEnvironment
-from SpiffWorkflow.bpmn.serializer.workflow import BpmnWorkflowSerializer
-from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
-from SpiffWorkflow.spiff.parser.process import SpiffBpmnParser
-from SpiffWorkflow.spiff.parser.event_parsers import SpiffReceiveTaskParser, SpiffSendTaskParser
-from SpiffWorkflow.spiff.parser.task_spec import ServiceTaskParser, SpiffTaskParser
-from SpiffWorkflow.spiff.serializer.config import SPIFF_CONFIG
-from SpiffWorkflow.spiff.serializer.task_spec import SendReceiveTaskConverter, ServiceTaskConverter, SpiffBpmnTaskConverter
-from SpiffWorkflow.spiff.specs.defaults import CallActivity, ManualTask, NoneTask, ReceiveTask, SendTask, ServiceTask, UserTask
-from SpiffWorkflow.util.task import TaskFilter, TaskState
+from SpiffWorkflow.bpmn.exceptions import WorkflowTaskException  # noqa: E402
+from SpiffWorkflow.bpmn.serializer import DefaultRegistry  # noqa: E402
+from SpiffWorkflow.bpmn.specs.mixins.multiinstance_task import LoopTask  # noqa: E402
+from SpiffWorkflow.bpmn.parser.util import full_tag  # noqa: E402
+from SpiffWorkflow.bpmn.script_engine import PythonScriptEngine, TaskDataEnvironment  # noqa: E402
+from SpiffWorkflow.bpmn.serializer.workflow import BpmnWorkflowSerializer  # noqa: E402
+from SpiffWorkflow.bpmn.workflow import BpmnWorkflow  # noqa: E402
+from SpiffWorkflow.spiff.parser.process import SpiffBpmnParser  # noqa: E402
+from SpiffWorkflow.spiff.parser.event_parsers import SpiffReceiveTaskParser, SpiffSendTaskParser  # noqa: E402
+from SpiffWorkflow.spiff.parser.task_spec import ServiceTaskParser, SpiffTaskParser  # noqa: E402
+from SpiffWorkflow.spiff.serializer.config import SPIFF_CONFIG  # noqa: E402
+from SpiffWorkflow.spiff.serializer.task_spec import SendReceiveTaskConverter, ServiceTaskConverter, SpiffBpmnTaskConverter  # noqa: E402
+from SpiffWorkflow.spiff.specs.defaults import CallActivity, ManualTask, NoneTask, ReceiveTask, SendTask, ServiceTask, UserTask  # noqa: E402
+from SpiffWorkflow.util.task import TaskFilter, TaskState  # noqa: E402
 
 logging.basicConfig(level=logging.ERROR)
 
@@ -485,7 +485,7 @@ def advance_workflow(specs, state, completed_task, strategy_name, start_params, 
     except Exception as e:
         try:
             return build_response(workflow, e, compress_response=compress_response, session_id=session_id)
-        except Exception as e2:
+        except Exception:
             return json.dumps({"status": "error", "message": f"{e}"})
 
 def get_tasks(workflow, task_filter):

--- a/uv.lock
+++ b/uv.lock
@@ -433,7 +433,7 @@ wheels = [
 
 [[package]]
 name = "spiff-arena-common"
-version = "0.1.28"
+version = "0.1.29"
 source = { editable = "spiff-arena-common" }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Was building the dev containers again and `make ruff` was failing. The imports needed to be `noqa` since they can't be at the top of the file in this case. The class/def above them need to be in scope before SpiffWorkflow related things are imported.