### PR TITLE
Don't commit inside secret_service

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/secrets_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/secrets_controller.py
@@ -5,6 +5,7 @@ from flask import jsonify
 from flask import make_response
 from flask.wrappers import Response
 
+from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.models.secret_model import SecretModel
 from spiffworkflow_backend.models.user import UserModel
 from spiffworkflow_backend.services.secret_service import SecretService
@@ -58,12 +59,14 @@ def secret_list(
 def secret_create(body: dict) -> Response:
     """Add secret."""
     secret_model = SecretService().add_secret(body["key"], body["value"], g.user.id)
+    db.session.commit()
     return make_response(jsonify(secret_model.to_dict()), 201)
 
 
 def secret_update(key: str, body: dict) -> Response:
     """Update secret."""
     SecretService().update_secret(key, body["value"], g.user.id)
+    db.session.commit()
     return make_response(jsonify({"ok": True}), 200)
 
 
@@ -71,4 +74,5 @@ def secret_delete(key: str) -> Response:
     """Delete secret."""
     current_user = UserService.current_user()
     SecretService.delete_secret(key, current_user.id)
+    db.session.commit()
     return make_response(jsonify({"ok": True}), 200)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/service_tasks_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/service_tasks_controller.py
@@ -11,6 +11,7 @@ from flask import request
 
 from spiffworkflow_backend.exceptions.api_error import ApiError
 from spiffworkflow_backend.helpers.public_api_urls import build_public_api_v1_url
+from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.routes.authentication_controller import verify_token
 from spiffworkflow_backend.services.oauth_service import OAuthService
 from spiffworkflow_backend.services.secret_service import SecretService
@@ -76,4 +77,5 @@ def authentication_callback(
         verify_token(request.args.get("token"), force_run=True)
         response = request.args["response"]
         SecretService.update_secret(f"{service}/{auth_method}", response, g.user.id, create_if_not_exists=True)
+    db.session.commit()
     return redirect(f"{current_app.config['SPIFFWORKFLOW_BACKEND_URL_FOR_FRONTEND']}/configuration")

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/secret_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/secret_service.py
@@ -75,10 +75,7 @@ class SecretService:
             value = cls._encrypt(value)
             secret_model.value = value
             db.session.add(secret_model)
-            try:
-                db.session.flush()
-            except Exception:
-                raise
+            db.session.flush()
         elif create_if_not_exists:
             if user_id is None:
                 raise ApiError(

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/secret_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/secret_service.py
@@ -39,9 +39,8 @@ class SecretService:
         secret_model = SecretModel(key=key, value=value, user_id=user_id)
         db.session.add(secret_model)
         try:
-            db.session.commit()
+            db.session.flush()
         except Exception as e:
-            db.session.rollback()
             raise ApiError(
                 error_code="create_secret_error",
                 message=(
@@ -77,10 +76,9 @@ class SecretService:
             secret_model.value = value
             db.session.add(secret_model)
             try:
-                db.session.commit()
-            except Exception as e:
-                db.session.rollback()
-                raise e
+                db.session.flush()
+            except Exception:
+                raise
         elif create_if_not_exists:
             if user_id is None:
                 raise ApiError(
@@ -103,7 +101,7 @@ class SecretService:
         if secret_model:
             db.session.delete(secret_model)
             try:
-                db.session.commit()
+                db.session.flush()
             except Exception as e:
                 raise ApiError(
                     error_code="delete_secret_error",

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_secret_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_secret_service.py
@@ -3,6 +3,7 @@ from flask.app import Flask
 from starlette.testclient import TestClient
 
 from spiffworkflow_backend.exceptions.api_error import ApiError
+from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.models.process_model import ProcessModelInfo
 from spiffworkflow_backend.models.secret_model import SecretModel
 from spiffworkflow_backend.models.user import UserModel
@@ -21,7 +22,9 @@ class SecretServiceTestHelpers(BaseTest):
     test_process_model_description = "Om nom nom delicious cookies"
 
     def add_test_secret(self, user: UserModel) -> SecretModel:
-        return SecretService().add_secret(self.test_key, self.test_value, user.id)
+        secret = SecretService().add_secret(self.test_key, self.test_value, user.id)
+        db.session.commit()
+        return secret
 
     def add_test_process(self, client: TestClient, user: UserModel) -> ProcessModelInfo:
         self.create_process_group_with_api(
@@ -55,6 +58,24 @@ class TestSecretService(SecretServiceTestHelpers):
         assert test_secret.key == self.test_key
         assert SecretService._decrypt(test_secret.value) == self.test_value
         assert test_secret.user_id == with_super_admin_user.id
+
+    def test_add_secret_does_not_commit(
+        self,
+        app: Flask,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        commit_calls: list[None] = []
+
+        def fake_commit() -> None:
+            commit_calls.append(None)
+
+        monkeypatch.setattr(db.session, "commit", fake_commit)
+
+        SecretService.add_secret(self.test_key, self.test_value, with_super_admin_user.id)
+
+        assert commit_calls == []
 
     def test_add_secret_duplicate_key_fails(
         self,
@@ -107,6 +128,25 @@ class TestSecretService(SecretServiceTestHelpers):
         assert new_secret
         assert SecretService._decrypt(new_secret.value) == "new_secret_value"  # noqa: S105
 
+    def test_update_secret_does_not_commit(
+        self,
+        app: Flask,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self.add_test_secret(with_super_admin_user)
+        commit_calls: list[None] = []
+
+        def fake_commit() -> None:
+            commit_calls.append(None)
+
+        monkeypatch.setattr(db.session, "commit", fake_commit)
+
+        SecretService.update_secret(self.test_key, "new_secret_value", with_super_admin_user.id)
+
+        assert commit_calls == []
+
     def test_update_secret_bad_secret_fails(
         self,
         app: Flask,
@@ -135,6 +175,25 @@ class TestSecretService(SecretServiceTestHelpers):
         SecretService.delete_secret(self.test_key, with_super_admin_user.id)
         secrets = SecretModel.query.all()
         assert len(secrets) == 0
+
+    def test_delete_secret_does_not_commit(
+        self,
+        app: Flask,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self.add_test_secret(with_super_admin_user)
+        commit_calls: list[None] = []
+
+        def fake_commit() -> None:
+            commit_calls.append(None)
+
+        monkeypatch.setattr(db.session, "commit", fake_commit)
+
+        SecretService.delete_secret(self.test_key, with_super_admin_user.id)
+
+        assert commit_calls == []
 
     def test_delete_secret_bad_secret_fails(
         self,

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_secrets_controller.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_secrets_controller.py
@@ -3,6 +3,7 @@ from flask.app import Flask
 from starlette.testclient import TestClient
 
 from spiffworkflow_backend.exceptions.api_error import ApiError
+from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.models.secret_model import SecretModel
 from spiffworkflow_backend.models.user import UserModel
 from spiffworkflow_backend.services.secret_service import SecretService
@@ -10,6 +11,37 @@ from tests.spiffworkflow_backend.integration.test_secret_service import SecretSe
 
 
 class TestSecretsController(SecretServiceTestHelpers):
+    def test_add_secret_api_commits(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        commit_calls: list[None] = []
+        original_commit = db.session.commit
+
+        def recording_commit() -> None:
+            commit_calls.append(None)
+            original_commit()
+
+        monkeypatch.setattr(db.session, "commit", recording_commit)
+
+        secret_model = {
+            "key": self.test_key,
+            "value": self.test_value,
+            "user_id": with_super_admin_user.id,
+        }
+        response = client.post(
+            "/v1.0/secrets",
+            headers=self.logged_in_headers(with_super_admin_user, additional_headers={"Content-Type": "application/json"}),
+            json=secret_model,
+        )
+
+        assert response.status_code == 201
+        assert commit_calls == [None]
+
     def test_add_secret_api(
         self,
         app: Flask,
@@ -96,6 +128,33 @@ class TestSecretsController(SecretServiceTestHelpers):
         secret_model = SecretModel.query.filter(SecretModel.key == self.test_key).first()
         assert SecretService._decrypt(secret_model.value) == "new_secret_value"
 
+    def test_update_secret_api_commits(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self.add_test_secret(with_super_admin_user)
+        commit_calls: list[None] = []
+        original_commit = db.session.commit
+
+        def recording_commit() -> None:
+            commit_calls.append(None)
+            original_commit()
+
+        monkeypatch.setattr(db.session, "commit", recording_commit)
+
+        response = client.put(
+            f"/v1.0/secrets/{self.test_key}",
+            headers=self.logged_in_headers(with_super_admin_user, additional_headers={"Content-Type": "application/json"}),
+            json={"value": "new_secret_value"},
+        )
+
+        assert response.status_code == 200
+        assert commit_calls == [None]
+
     def test_delete_secret(
         self,
         app: Flask,
@@ -115,6 +174,32 @@ class TestSecretsController(SecretServiceTestHelpers):
         assert secret_response.status_code == 200
         with pytest.raises(ApiError):
             secret = SecretService.get_secret(self.test_key)
+
+    def test_delete_secret_api_commits(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        with_super_admin_user: UserModel,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self.add_test_secret(with_super_admin_user)
+        commit_calls: list[None] = []
+        original_commit = db.session.commit
+
+        def recording_commit() -> None:
+            commit_calls.append(None)
+            original_commit()
+
+        monkeypatch.setattr(db.session, "commit", recording_commit)
+
+        secret_response = client.delete(
+            f"/v1.0/secrets/{self.test_key}",
+            headers=self.logged_in_headers(with_super_admin_user),
+        )
+
+        assert secret_response.status_code == 200
+        assert commit_calls == [None]
 
     def test_delete_secret_bad_key(
         self,

--- a/uv.lock
+++ b/uv.lock
@@ -433,7 +433,7 @@ wheels = [
 
 [[package]]
 name = "spiff-arena-common"
-version = "0.1.29"
+version = "0.1.30"
 source = { editable = "spiff-arena-common" }
 
 [package.optional-dependencies]


### PR DESCRIPTION
This came up in a previous pr that I couldn't easily find, but the issue is that the `secret_service` would issue commits/rollbacks, which could result in a partial session being committed mid-run. This could be seen for instance if a service task call ended up modifying a secret.

This moves the secret service commits to flushes so we still get db constraint, etc errors surfaced and the secret update lives in the transaction, but leaves the commits/rollbacks to higher level code, like controllers.