### PR TITLE
Batch process_group_delete instance checks

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_model_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_model_service.py
@@ -695,12 +695,18 @@ class ProcessModelService(FileSystemService):
         path = cls.full_path_from_id(process_group_id)
         if os.path.exists(path):
             nested_models = cls.__get_all_nested_models(path)
-            for process_model in nested_models:
-                instances = ProcessInstanceModel.query.filter(
-                    ProcessInstanceModel.process_model_identifier == process_model.id
-                ).all()
-                if len(instances) > 0:
-                    problem_models.append(process_model)
+            nested_model_identifiers = [process_model.id for process_model in nested_models]
+            models_with_instances: set[str] = set()
+            if nested_model_identifiers:
+                process_model_identifier_column: Any = ProcessInstanceModel.process_model_identifier
+                instance_rows = (
+                    ProcessInstanceModel.query.with_entities(process_model_identifier_column)
+                    .filter(process_model_identifier_column.in_(nested_model_identifiers))
+                    .all()
+                )
+                models_with_instances = {instance_row[0] for instance_row in instance_rows}
+
+            problem_models = [process_model for process_model in nested_models if process_model.id in models_with_instances]
             if len(problem_models) > 0:
                 raise ProcessModelWithInstancesNotDeletableError(
                     f"We cannot delete the group `{process_group_id}`, there are"

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_model_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_model_service.py
@@ -1,6 +1,7 @@
 import os
 import re
 import sys
+from types import SimpleNamespace
 
 import pytest
 from flask import Flask
@@ -8,12 +9,63 @@ from lxml import etree  # type: ignore
 
 from spiffworkflow_backend.services.authorization_service import AuthorizationService
 from spiffworkflow_backend.services.process_model_service import ProcessModelService
+from spiffworkflow_backend.services.process_model_service import ProcessModelWithInstancesNotDeletableError
 from spiffworkflow_backend.services.user_service import UserService
 from tests.spiffworkflow_backend.helpers.base_test import BaseTest
 from tests.spiffworkflow_backend.helpers.test_data import load_test_spec
 
 
 class TestProcessModelService(BaseTest):
+    def test_process_group_delete_bulk_checks_nested_models_for_instances(
+        self,
+        app: Flask,
+        with_db_and_bpmn_file_cleanup: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self.create_process_group("bulk_delete_group")
+
+        nested_models = [
+            SimpleNamespace(id="bulk_delete_group/model_one"),
+            SimpleNamespace(id="bulk_delete_group/model_two"),
+            SimpleNamespace(id="bulk_delete_group/model_three"),
+        ]
+
+        class QueryStub:
+            def __init__(self) -> None:
+                self.filter_call_count = 0
+                self.filtered_identifiers: list[str] = []
+
+            def with_entities(self, *_args: object) -> "QueryStub":
+                return self
+
+            def filter(self, criterion: object) -> "QueryStub":
+                self.filter_call_count += 1
+                right_value = getattr(getattr(criterion, "right", None), "value", None)
+                if isinstance(right_value, list):
+                    self.filtered_identifiers = right_value
+                elif right_value is not None:
+                    self.filtered_identifiers = [right_value]
+                return self
+
+            def all(self) -> list[tuple[str]]:
+                if "bulk_delete_group/model_two" in self.filtered_identifiers:
+                    return [("bulk_delete_group/model_two",)]
+                return []
+
+        query_stub = QueryStub()
+        monkeypatch.setattr(ProcessModelService, "_ProcessModelService__get_all_nested_models", lambda _path: nested_models)
+        monkeypatch.setattr(
+            __import__("spiffworkflow_backend.models.process_instance", fromlist=["ProcessInstanceModel"]).ProcessInstanceModel,
+            "query",
+            query_stub,
+        )
+
+        with pytest.raises(ProcessModelWithInstancesNotDeletableError, match="bulk_delete_group"):
+            ProcessModelService.process_group_delete("bulk_delete_group")
+
+        assert query_stub.filter_call_count == 1
+        assert query_stub.filtered_identifiers == [model.id for model in nested_models]
+
     def test_can_update_specified_attributes(
         self,
         app: Flask,


### PR DESCRIPTION
Before one query was performed for each model, now do one query for all models.