### PR TITLE
Fix over counting in task coverage

### DIFF
--- a/spiff-arena-common/pyproject.toml
+++ b/spiff-arena-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spiff-arena-common"
-version = "0.1.30"
+version = "0.1.31"
 description = "Shared Python utilities for Spiff Arena frontend and backend components"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/spiff-arena-common/src/spiff_arena_common/coverage.py
+++ b/spiff-arena-common/src/spiff_arena_common/coverage.py
@@ -20,7 +20,8 @@ def tally(cov):
     all = 0
     breakdown = {}
     for id in cov.all:
-        c = len(cov.completed[id])
+        completed_tasks = cov.completed[id] & cov.all[id]
+        c = len(completed_tasks)
         a = len(cov.all[id])
         breakdown[id] = Tally(c, a, c / a * 100)
         completed += c
@@ -42,6 +43,7 @@ def task_coverage(ctx):
             completed[id] = set()
         spec = json.loads(spec)["spec"]
         all[id] = set([t for t in spec["task_specs"]])
+        completed[id] &= all[id]
         missing[id] = all[id] - completed[id]
 
     cov = TestCov(all, completed, missing)

--- a/spiff-arena-common/tests/spiff_arena_common/test_z_coverage.py
+++ b/spiff-arena-common/tests/spiff_arena_common/test_z_coverage.py
@@ -1,0 +1,105 @@
+from spiff_arena_common.coverage import task_coverage
+from spiff_arena_common.runner import specs_from_xml
+from spiff_arena_common.tester import run_tests
+
+
+subprocess = ("subprocess.bpmn", """
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="Definitions_Subprocess" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Subprocess" name="Subprocess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_Subprocess">
+      <bpmn:outgoing>Flow_Subprocess_Start</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:scriptTask id="Task_Subprocess" name="Subprocess Step">
+      <bpmn:incoming>Flow_Subprocess_Start</bpmn:incoming>
+      <bpmn:outgoing>Flow_Subprocess_End</bpmn:outgoing>
+      <bpmn:script>subprocess_ran = True</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:endEvent id="EndEvent_Subprocess">
+      <bpmn:incoming>Flow_Subprocess_End</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_Subprocess_Start" sourceRef="StartEvent_Subprocess" targetRef="Task_Subprocess" />
+    <bpmn:sequenceFlow id="Flow_Subprocess_End" sourceRef="Task_Subprocess" targetRef="EndEvent_Subprocess" />
+  </bpmn:process>
+</bpmn:definitions>
+""")
+
+parent = ("parent.bpmn", """
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="Definitions_Parent" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Parent" name="Parent" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_Parent">
+      <bpmn:outgoing>Flow_Parent_First</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:callActivity id="Call_First" name="Run Subprocess Once" calledElement="Subprocess">
+      <bpmn:incoming>Flow_Parent_First</bpmn:incoming>
+      <bpmn:outgoing>Flow_Parent_Second</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:callActivity id="Call_Second" name="Run Subprocess Twice" calledElement="Subprocess">
+      <bpmn:incoming>Flow_Parent_Second</bpmn:incoming>
+      <bpmn:outgoing>Flow_Parent_End</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:endEvent id="EndEvent_Parent">
+      <bpmn:incoming>Flow_Parent_End</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_Parent_First" sourceRef="StartEvent_Parent" targetRef="Call_First" />
+    <bpmn:sequenceFlow id="Flow_Parent_Second" sourceRef="Call_First" targetRef="Call_Second" />
+    <bpmn:sequenceFlow id="Flow_Parent_End" sourceRef="Call_Second" targetRef="EndEvent_Parent" />
+  </bpmn:process>
+</bpmn:definitions>
+""")
+
+parent_test = ("parent_test.bpmn", """
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="Definitions_Parent_Test" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Parent_Test" name="Parent_Test" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_Parent_Test">
+      <bpmn:outgoing>Flow_Test_Run</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:callActivity id="Call_Parent" name="Run Parent" calledElement="Parent">
+      <bpmn:incoming>Flow_Test_Run</bpmn:incoming>
+      <bpmn:outgoing>Flow_Test_Result</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:scriptTask id="Task_Test_Result" name="Test Result">
+      <bpmn:incoming>Flow_Test_Result</bpmn:incoming>
+      <bpmn:outgoing>Flow_Test_End</bpmn:outgoing>
+      <bpmn:script>
+def test():
+  import unittest
+
+  from spiff_arena_common.tester import run_test_cases
+
+  class ParentRunsTwice(unittest.TestCase):
+    def runTest(self):
+      self.assertTrue(subprocess_ran)
+
+  return run_test_cases([ParentRunsTwice()])
+
+spiff_testFixture = {"pendingTaskStack": []}
+spiff_testResult = test()
+      </bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:endEvent id="EndEvent_Parent_Test">
+      <bpmn:incoming>Flow_Test_End</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_Test_Run" sourceRef="StartEvent_Parent_Test" targetRef="Call_Parent" />
+    <bpmn:sequenceFlow id="Flow_Test_Result" sourceRef="Call_Parent" targetRef="Task_Test_Result" />
+    <bpmn:sequenceFlow id="Flow_Test_End" sourceRef="Task_Test_Result" targetRef="EndEvent_Parent_Test" />
+  </bpmn:process>
+</bpmn:definitions>
+""")
+
+
+def test_task_coverage_ignores_subprocess_tasks_completed_in_parent_state():
+    parsed = []
+    for file in [subprocess, parent, parent_test]:
+        specs, err = specs_from_xml([file])
+        assert err is None
+        parsed.append((file[0], specs))
+
+    ctx, result, _ = run_tests(parsed)
+
+    assert result.wasSuccessful()
+
+    _, tally = task_coverage(ctx)
+
+    parent_tally = tally.breakdown["Parent"]
+    assert parent_tally.completed == parent_tally.all
+    assert parent_tally.percent == 100

--- a/uv.lock
+++ b/uv.lock
@@ -433,7 +433,7 @@ wheels = [
 
 [[package]]
 name = "spiff-arena-common"
-version = "0.1.30"
+version = "0.1.31"
 source = { editable = "spiff-arena-common" }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Fixes a task coverage bug where if a parent bpmn file called the same call activity more than once, its tasks were over counted. The new test file has a `_z_` name temporarily which I am not proud of, but there is a weird collection/import order issues in the test suite and the changes are large in scope than this fix, so will follow up.