### PR TITLE
Adding debugging info for when a recording stops

### DIFF
--- a/spiff-arena-common/pyproject.toml
+++ b/spiff-arena-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spiff-arena-common"
-version = "0.1.31"
+version = "0.1.32"
 description = "Shared Python utilities for Spiff Arena frontend and backend components"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/spiff-arena-common/src/spiff_arena_common/runner.py
+++ b/spiff-arena-common/src/spiff_arena_common/runner.py
@@ -363,6 +363,23 @@ def next_task(workflow, state, from_task=None):
         return task
     return None
 
+
+def print_unittest_break(reason, **fields):
+    payload = {
+        "event": "unittest-break",
+        "strategy": "unittest",
+        "reason": reason,
+        **fields,
+    }
+    print(json.dumps(payload, sort_keys=True), flush=True)
+
+
+def print_progress(iteration):
+    print(json.dumps({
+        "event": "progress",
+        "iteration": iteration,
+    }, sort_keys=True), flush=True)
+
 def _advance_workflow(workflow, task, strategy_name, compress_response=False, session_id=None):
     iters = 0
     lazy_loads_list = None
@@ -386,7 +403,7 @@ def _advance_workflow(workflow, task, strategy_name, compress_response=False, se
 
         # Report progress every 50 iterations for UI feedback
         if iters % 50 == 0:
-            print(f"[progress] iteration: {iters}", flush=True)
+            print_progress(iters)
 
         if task.state == TaskState.STARTED:
             task.complete()
@@ -398,6 +415,14 @@ def _advance_workflow(workflow, task, strategy_name, compress_response=False, se
         if not (strategy_name == "unittest" and cached_fixture_file):
             lazy_loads_list = lazy_loads(workflow)
             if any(spec not in workflow.subprocess_specs for spec in lazy_loads_list):
+                if strategy_name == "unittest":
+                    print_unittest_break(
+                        "missing_lazy_loads",
+                        iteration=iters,
+                        missing_specs=[
+                            spec for spec in lazy_loads_list if spec not in workflow.subprocess_specs
+                        ],
+                    )
                 break
 
         # Optimization: try searching from completed task first (fast path)
@@ -406,6 +431,12 @@ def _advance_workflow(workflow, task, strategy_name, compress_response=False, se
         if not task:
             task = next_task(workflow, TaskState.READY)
         if not task:
+            if strategy_name == "unittest" and not workflow.completed:
+                print_unittest_break(
+                    "no_ready_task",
+                    iteration=iters,
+                    task_id=getattr(completed_task.task_spec, "bpmn_id", None),
+                )
             break
         elif strategy_name == "oneAtATime" and task.task_spec.bpmn_id:
             break
@@ -436,13 +467,36 @@ def _advance_workflow(workflow, task, strategy_name, compress_response=False, se
 
                     # If recording is exhausted (index < 0), let task run interactively
                     if index < 0:
+                        print_unittest_break(
+                            "fixture_exhausted",
+                            iteration=iters,
+                            task_id=task.task_spec.bpmn_id,
+                            fixture_file=fixture_file,
+                            fixture_index=index,
+                        )
                         break
 
                     if index >= len(stack):
+                        print_unittest_break(
+                            "fixture_index_out_of_bounds",
+                            iteration=iters,
+                            task_id=task.task_spec.bpmn_id,
+                            fixture_file=fixture_file,
+                            fixture_index=index,
+                            fixture_length=len(stack),
+                        )
                         break
 
                     expected = stack[index]
                     if task.task_spec.bpmn_id != expected["id"]:
+                        print_unittest_break(
+                            "fixture_task_mismatch",
+                            iteration=iters,
+                            task_id=task.task_spec.bpmn_id,
+                            expected_task_id=expected["id"],
+                            fixture_file=fixture_file,
+                            fixture_index=index,
+                        )
                         break
 
                     task.run()
@@ -452,9 +506,20 @@ def _advance_workflow(workflow, task, strategy_name, compress_response=False, se
                     # Fallback to inline fixture (process-models compatibility)
                     stack = task.data.get("spiff_testFixture", {}).get("pendingTaskStack", [])
                     if not stack:
+                        print_unittest_break(
+                            "missing_inline_fixture",
+                            iteration=iters,
+                            task_id=task.task_spec.bpmn_id,
+                        )
                         break
                     expected = stack.pop()
                     if task.task_spec.bpmn_id != expected["id"]:
+                        print_unittest_break(
+                            "fixture_task_mismatch",
+                            iteration=iters,
+                            task_id=task.task_spec.bpmn_id,
+                            expected_task_id=expected["id"],
+                        )
                         break
                     task.run()
                     task.data.update(expected["data"])

--- a/spiff-arena-common/tests/spiff_arena_common/test_runner.py
+++ b/spiff-arena-common/tests/spiff_arena_common/test_runner.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 
 from SpiffWorkflow.task import TaskState
@@ -6,9 +7,9 @@ from spiff_arena_common import runner
 
 
 class FakeTask:
-    def __init__(self):
+    def __init__(self, *, bpmn_id=None, task_spec=None):
         self.state = TaskState.READY
-        self.task_spec = SimpleNamespace(bpmn_id=None)
+        self.task_spec = task_spec or SimpleNamespace(bpmn_id=bpmn_id)
         self.data = {}
         self.run_calls = 0
 
@@ -70,3 +71,100 @@ def test_custom_environment_get_current_task_data_filters_internal_keys():
 
     assert result is True
     assert context["result"] == {"visible": 1}
+
+
+def test_advance_workflow_prints_unittest_break_when_no_ready_task_is_unexpected(monkeypatch, capsys):
+    task = FakeTask(bpmn_id="InitialTask")
+    workflow = SimpleNamespace(subprocess_specs={}, completed=False)
+
+    monkeypatch.setattr(runner, "lazy_loads", lambda workflow: [])
+    monkeypatch.setattr(runner, "next_task", lambda workflow, state, from_task=None: None)
+    monkeypatch.setattr(
+        runner,
+        "build_response",
+        lambda workflow, error, compress_response=False, lazy_loads_result=None, session_id=None: {
+            "status": "ok",
+            "error": error,
+            "lazy_loads": lazy_loads_result,
+        },
+    )
+
+    result = runner._advance_workflow(workflow, task, "unittest")
+
+    captured = capsys.readouterr()
+    event = json.loads(captured.out.strip())
+
+    assert result == {"status": "ok", "error": None, "lazy_loads": []}
+    assert event["event"] == "unittest-break"
+    assert event["reason"] == "no_ready_task"
+    assert event["strategy"] == "unittest"
+    assert event["task_id"] == "InitialTask"
+
+
+def test_advance_workflow_does_not_print_unittest_break_when_workflow_completed(monkeypatch, capsys):
+    task = FakeTask(bpmn_id="InitialTask")
+    workflow = SimpleNamespace(subprocess_specs={}, completed=True)
+
+    monkeypatch.setattr(runner, "lazy_loads", lambda workflow: [])
+    monkeypatch.setattr(runner, "next_task", lambda workflow, state, from_task=None: None)
+    monkeypatch.setattr(
+        runner,
+        "build_response",
+        lambda workflow, error, compress_response=False, lazy_loads_result=None, session_id=None: {
+            "status": "ok",
+            "error": error,
+            "lazy_loads": lazy_loads_result,
+        },
+    )
+
+    result = runner._advance_workflow(workflow, task, "unittest")
+
+    captured = capsys.readouterr()
+
+    assert result == {"status": "ok", "error": None, "lazy_loads": []}
+    assert captured.out == ""
+
+
+def test_advance_workflow_prints_unittest_break_when_fixture_task_mismatches(monkeypatch, capsys):
+    class CustomUserTaskSpec:
+        def __init__(self, bpmn_id):
+            self.bpmn_id = bpmn_id
+
+    initial_task = FakeTask(bpmn_id="InitialTask")
+    fixture_task = FakeTask(task_spec=CustomUserTaskSpec("ActualTask"))
+    fixture_task.data["spiff_testFixture"] = {
+        "pendingTaskStack": [{"id": "ExpectedTask", "data": {"ok": True}}],
+    }
+    workflow = SimpleNamespace(subprocess_specs={}, data={}, completed=False)
+
+    next_calls = []
+
+    def fake_next_task(workflow, state, from_task=None):
+        next_calls.append(from_task)
+        if from_task is initial_task:
+            return fixture_task
+        return None
+
+    monkeypatch.setattr(runner, "lazy_loads", lambda workflow: [])
+    monkeypatch.setattr(runner, "next_task", fake_next_task)
+    monkeypatch.setattr(
+        runner,
+        "build_response",
+        lambda workflow, error, compress_response=False, lazy_loads_result=None, session_id=None: {
+            "status": "ok",
+            "error": error,
+            "lazy_loads": lazy_loads_result,
+        },
+    )
+
+    result = runner._advance_workflow(workflow, initial_task, "unittest")
+
+    captured = capsys.readouterr()
+    event = json.loads(captured.out.strip())
+
+    assert result == {"status": "ok", "error": None, "lazy_loads": []}
+    assert next_calls == [initial_task]
+    assert event["event"] == "unittest-break"
+    assert event["reason"] == "fixture_task_mismatch"
+    assert event["task_id"] == "ActualTask"
+    assert event["expected_task_id"] == "ExpectedTask"

--- a/uv.lock
+++ b/uv.lock
@@ -433,7 +433,7 @@ wheels = [
 
 [[package]]
 name = "spiff-arena-common"
-version = "0.1.31"
+version = "0.1.32"
 source = { editable = "spiff-arena-common" }
 
 [package.optional-dependencies]


### PR DESCRIPTION
As we've been debugging recordings I've just been adding these in and removing them locally each session. However i've done that enough now that it seems like keeping them in at least for a while is less churn.