### PR TITLE
Only count tasks with bpmn_id during task coverage

### DIFF
--- a/spiff-arena-common/pyproject.toml
+++ b/spiff-arena-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spiff-arena-common"
-version = "0.1.32"
+version = "0.1.33"
 description = "Shared Python utilities for Spiff Arena frontend and backend components"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/spiff-arena-common/src/spiff_arena_common/coverage.py
+++ b/spiff-arena-common/src/spiff_arena_common/coverage.py
@@ -42,7 +42,11 @@ def task_coverage(ctx):
         if id not in completed:
             completed[id] = set()
         spec = json.loads(spec)["spec"]
-        all[id] = set([t for t in spec["task_specs"]])
+        all[id] = set(
+            task_id
+            for task_id, task_spec in spec["task_specs"].items()
+            if task_spec.get("bpmn_id")
+        )
         completed[id] &= all[id]
         missing[id] = all[id] - completed[id]
 

--- a/spiff-arena-common/tests/spiff_arena_common/test_tester.py
+++ b/spiff-arena-common/tests/spiff_arena_common/test_tester.py
@@ -209,12 +209,11 @@ def test_tester(files):
     _, tally = task_coverage(ctx)
     for id, f in ctx.files:
         completed, all, percent = tally.breakdown[id]
-        assert completed == 6
-        assert all == 6
+        assert completed == 3
+        assert all == 3
         assert percent == int(100)
     
     completed, all, percent = tally.result
-    assert completed == 6
-    assert all == 6
+    assert completed == 3
+    assert all == 3
     assert percent == int(100)
-

--- a/spiff-arena-common/tests/spiff_arena_common/test_z_coverage.py
+++ b/spiff-arena-common/tests/spiff_arena_common/test_z_coverage.py
@@ -103,3 +103,42 @@ def test_task_coverage_ignores_subprocess_tasks_completed_in_parent_state():
     parent_tally = tally.breakdown["Parent"]
     assert parent_tally.completed == parent_tally.all
     assert parent_tally.percent == 100
+
+
+def test_task_coverage_counts_only_task_specs_with_bpmn_ids():
+    class FakeTestCase:
+        state = {
+            "subprocesses": {
+                "fake": {
+                    "spec": "FakeProcess",
+                    "tasks": {
+                        "generated": {"state": 64, "task_spec": "Start"},
+                        "real": {"state": 64, "task_spec": "Task_One"},
+                    },
+                },
+            },
+        }
+
+    class FakeContext:
+        test_cases = [FakeTestCase()]
+        specs = {
+            "FakeProcess": """
+                {
+                    "spec": {
+                        "task_specs": {
+                            "Start": {"bpmn_id": null},
+                            "Task_One": {"bpmn_id": "Task_One"},
+                            "Task_Two": {"bpmn_id": "Task_Two"}
+                        }
+                    }
+                }
+            """,
+        }
+
+    cov, tally = task_coverage(FakeContext())
+
+    assert cov.all["FakeProcess"] == {"Task_One", "Task_Two"}
+    assert cov.completed["FakeProcess"] == {"Task_One"}
+    assert cov.missing["FakeProcess"] == {"Task_Two"}
+    assert tally.breakdown["FakeProcess"].completed == 1
+    assert tally.breakdown["FakeProcess"].all == 2

--- a/uv.lock
+++ b/uv.lock
@@ -433,7 +433,7 @@ wheels = [
 
 [[package]]
 name = "spiff-arena-common"
-version = "0.1.32"
+version = "0.1.33"
 source = { editable = "spiff-arena-common" }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Aligns the task coverage report more closely with the expected task counts from viewing the diagram. This does change the percentages some but not drastically.