### PR TITLE
New entrypoint for running bpmn tests

### DIFF
--- a/spiff-arena-common/pyproject.toml
+++ b/spiff-arena-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spiff-arena-common"
-version = "0.1.33"
+version = "0.1.34"
 description = "Shared Python utilities for Spiff Arena frontend and backend components"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/spiff-arena-common/src/spiff_arena_common/coverage.py
+++ b/spiff-arena-common/src/spiff_arena_common/coverage.py
@@ -7,8 +7,14 @@ TestCov = namedtuple("TestCov", ["all", "completed", "missing"])
 Tally = namedtuple("Tally", ["completed", "all", "percent"])
 CovTally = namedtuple("CovTally", ["result", "breakdown"])
 
-def cov_tasks(states):
-    for state in states:
+def cov_tasks(test_cases):
+    for test_case in test_cases:
+        state = test_case.state
+        coverage_spec_id = getattr(test_case, "coverage_spec_id", None)
+        if coverage_spec_id:
+            for _, task in state["tasks"].items():
+                if task["state"] == 64:
+                    yield coverage_spec_id, task["task_spec"]
         for _, sp in state["subprocesses"].items():
             id = sp["spec"]
             for _, task in sp["tasks"].items():
@@ -30,11 +36,10 @@ def tally(cov):
     return CovTally(result, breakdown)
 
 def task_coverage(ctx):
-    states = [t.state for t in ctx.test_cases]
     all = {}
     completed = {}
     missing = {}
-    for id, task_id in cov_tasks(states):
+    for id, task_id in cov_tasks(ctx.test_cases):
         if id not in completed:
             completed[id] = set()
         completed[id].add(task_id)

--- a/spiff-arena-common/src/spiff_arena_common/tester.py
+++ b/spiff-arena-common/src/spiff_arena_common/tester.py
@@ -5,11 +5,14 @@ import unittest
 
 from collections import namedtuple
 
+import jsonschema
+
 from spiff_arena_common.runner import advance_workflow, SpiffJsonEncoder, spiff_json_object_hook, specs_from_xml
 
 Test = namedtuple("Test", ["file", "specs"])
 TestCtx = namedtuple("TestCtx", ["files", "specs", "tests", "test_cases"])
 TestRun = namedtuple("TestRun", ["ctx", "result", "output"])
+RecordingTest = namedtuple("RecordingTest", ["file", "recording_file", "schema_file"])
 
 class BpmnTestCase(unittest.TestCase):
     def __init__(self, file, specs, specs_by_id):
@@ -92,6 +95,94 @@ class BpmnTestCase(unittest.TestCase):
         self.wasSuccessful = completed and result["wasSuccessful"]
         self.assertTrue(self.wasSuccessful)
 
+
+class BpmnRecordingTestCase(unittest.TestCase):
+    def __init__(self, file, specs, specs_by_id, recording_file, schema_file=None):
+        self.file = file
+        self.specs = specs
+        self.coverage_spec_id = json.loads(specs)["spec"]["name"]
+        self.specs_by_id = specs_by_id
+        self.recording_file = recording_file
+        self.schema_file = schema_file
+        self.state = {}
+        self.output = ""
+        self.testsRun = 0
+        self.wasSuccessful = False
+        super().__init__()
+
+    def lazy_load(self, ids):
+        self.specs = json.loads(self.specs, object_hook=spiff_json_object_hook)
+        for id in ids:
+            specs = json.loads(self.specs_by_id[id], object_hook=spiff_json_object_hook)
+            subprocess_specs = self.specs["subprocess_specs"]
+            subprocess_specs[id] = specs["spec"]
+            subprocess_specs.update(specs["subprocess_specs"])
+        self.specs = json.dumps(self.specs, cls=SpiffJsonEncoder)
+
+    def _workflow_data(self, response):
+        completed = response.get("completed")
+        if completed:
+            self.assertIn("result", response)
+            return response["result"]
+
+        self.assertIn("pending_tasks", response)
+        pending = response["pending_tasks"]
+        if len(pending) == 0:
+            error_msg = f"Test file: {self.file}\n"
+            error_msg += "Expected pending tasks but found none (workflow not completed but stuck).\n"
+            response_copy = dict(response)
+            if "state" in response_copy:
+                del response_copy["state"]
+            error_msg += f"Response:\n{json.dumps(response_copy, indent=2)}\n"
+            self.fail(error_msg)
+        self.assertIn("data", pending[0])
+        return pending[0]["data"]
+
+    def _validate_schema(self, data):
+        if not self.schema_file:
+            return
+        with open(self.schema_file) as f:
+            schema = json.load(f)
+        try:
+            jsonschema.validate(data, schema)
+        except jsonschema.ValidationError as e:
+            self.fail(f"Schema validation failed for {self.schema_file}: {e.message}")
+
+    def runTest(self):
+        iters = 0
+        r = None
+        start_params = {"data": {"spiff_testFixture_file": self.recording_file}}
+        while iters < 100:
+            iters = iters + 1
+            r = json.loads(
+                advance_workflow(self.specs, self.state, None, "unittest", start_params),
+                object_hook=spiff_json_object_hook,
+            )
+            start_params = None
+            self.state = r["state"]
+
+            if r.get("status") != "ok":
+                error_msg = f"Test file: {self.file}\n"
+                error_msg += f"Recording file: {self.recording_file}\n"
+                error_msg += f"Error during workflow execution (iteration {iters}):\n"
+                error_msg += f"Message: {r.get('message', 'No message')}\n"
+                if r.get("error_tasks"):
+                    error_tasks = r.get("error_tasks")
+                    if error_tasks:
+                        error_msg += f"\nFailed task: {error_tasks[0].get('task_spec', {}).get('bpmn_name', 'unknown')}\n"
+                        error_msg += f"Task ID: {error_tasks[0].get('task_spec', {}).get('bpmn_id', 'unknown')}\n"
+                self.fail(error_msg)
+
+            lazy_loads = r.get("lazy_loads")
+            if not lazy_loads:
+                break
+            self.lazy_load(lazy_loads)
+
+        self.assertEqual(r.get("status"), "ok")
+        self._validate_schema(self._workflow_data(r))
+        self.testsRun = 1
+        self.wasSuccessful = True
+
 def files_to_parse(dir):
     for root, dirs, files in os.walk(dir, topdown=True):
         dirs[:] = [d for d in dirs if not d.startswith(".")]
@@ -117,6 +208,19 @@ def test_ctx(parsed):
     ctx.tests.sort()
     return ctx
 
+def _recording_test(recording):
+    if len(recording) == 2:
+        file, recording_file = recording
+        schema_file = None
+    elif len(recording) == 3:
+        file, recording_file, schema_file = recording
+    else:
+        raise ValueError("Recording tests must be (file, recording_file) or (file, recording_file, schema_file)")
+    return RecordingTest(file, recording_file, schema_file)
+
+def _specs_by_file(parsed):
+    return {file: specs for file, specs in parsed}
+
 def run_tests(parsed):
     ctx = test_ctx(parsed)
     suite = unittest.TestSuite()
@@ -132,6 +236,29 @@ def run_tests_in_dir(dir):
         assert not err
         parsed.append((file, specs))
     return run_tests(parsed)
+
+def run_tests_with_recordings(parsed, recordings):
+    ctx = test_ctx(parsed)
+    specs_by_file = _specs_by_file(parsed)
+    for recording in recordings:
+        recording_test = _recording_test(recording)
+        if recording_test.file not in specs_by_file:
+            raise ValueError(f"No parsed BPMN specs found for recording test file: {recording_test.file}")
+        ctx.test_cases.append(
+            BpmnRecordingTestCase(
+                recording_test.file,
+                specs_by_file[recording_test.file],
+                ctx.specs,
+                recording_test.recording_file,
+                recording_test.schema_file,
+            )
+        )
+
+    suite = unittest.TestSuite()
+    suite.addTests(ctx.test_cases)
+    stream = io.StringIO()
+    result = unittest.TextTestRunner(stream=stream).run(suite)
+    return TestRun(ctx, result, stream.getvalue())
 
 def run_test_cases(tests):
     suite = unittest.TestSuite()

--- a/spiff-arena-common/src/spiff_arena_common/tester.py
+++ b/spiff-arena-common/src/spiff_arena_common/tester.py
@@ -1,6 +1,7 @@
 import io
 import json
 import os
+import contextlib
 import unittest
 
 from collections import namedtuple
@@ -146,18 +147,27 @@ class BpmnRecordingTestCase(unittest.TestCase):
         try:
             jsonschema.validate(data, schema)
         except jsonschema.ValidationError as e:
+            last_task_data_schema = schema.get("properties", {}).get("last_task_data")
+            if last_task_data_schema:
+                try:
+                    jsonschema.validate(data, last_task_data_schema)
+                    return
+                except jsonschema.ValidationError:
+                    pass
             self.fail(f"Schema validation failed for {self.schema_file}: {e.message}")
 
     def runTest(self):
         iters = 0
         r = None
+        self.lazy_load([id for id in self.specs_by_id if id != self.coverage_spec_id])
         start_params = {"data": {"spiff_testFixture_file": self.recording_file}}
         while iters < 100:
             iters = iters + 1
-            r = json.loads(
-                advance_workflow(self.specs, self.state, None, "unittest", start_params),
-                object_hook=spiff_json_object_hook,
-            )
+            with contextlib.redirect_stdout(io.StringIO()):
+                r = json.loads(
+                    advance_workflow(self.specs, self.state, None, "unittest", start_params),
+                    object_hook=spiff_json_object_hook,
+                )
             start_params = None
             self.state = r["state"]
 

--- a/spiff-arena-common/tests/spiff_arena_common/test_tester.py
+++ b/spiff-arena-common/tests/spiff_arena_common/test_tester.py
@@ -188,6 +188,25 @@ spiff_testResult = test()</bpmn:script>
 </bpmn:definitions>
 """)
 
+ut_parent = ("ut_parent.bpmn", """
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="Definitions_Parent" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Parent_Process" name="Parent_Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_Parent">
+      <bpmn:outgoing>Flow_Parent_Start</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:callActivity id="Call_Ut" name="Run UT" calledElement="Process_1770128055928">
+      <bpmn:incoming>Flow_Parent_Start</bpmn:incoming>
+      <bpmn:outgoing>Flow_Parent_End</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:endEvent id="EndEvent_Parent">
+      <bpmn:incoming>Flow_Parent_End</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_Parent_Start" sourceRef="StartEvent_Parent" targetRef="Call_Ut" />
+    <bpmn:sequenceFlow id="Flow_Parent_End" sourceRef="Call_Ut" targetRef="EndEvent_Parent" />
+  </bpmn:process>
+</bpmn:definitions>
+""")
+
 @pytest.mark.parametrize(
     "files",
     [
@@ -293,3 +312,71 @@ def test_run_tests_with_recordings_reports_schema_failure(tmp_path):
     assert not result.wasSuccessful()
     assert not ctx.test_cases[0].wasSuccessful
     assert "ut.schema.json" in output
+
+
+def test_run_tests_with_recordings_accepts_artifact_outcome_schema(tmp_path):
+    recording_file = tmp_path / "ut_recording.json"
+    recording_file.write_text("""
+{
+  "pendingTaskStack": [
+    {
+      "id": "ut_task",
+      "data": {"some_field": "jj"}
+    }
+  ]
+}
+""")
+    schema_file = tmp_path / "outcome.schema.json"
+    schema_file.write_text("""
+{
+  "type": "object",
+  "properties": {
+    "case_id": {"type": "string"},
+    "last_task_data": {
+      "type": "object",
+      "properties": {
+        "some_field": {"const": "jj"}
+      },
+      "required": ["some_field"]
+    }
+  },
+  "required": ["case_id", "last_task_data"]
+}
+""")
+    specs, err = specs_from_xml([ut])
+    assert err is None
+
+    ctx, result, output = run_tests_with_recordings(
+        [("ut.bpmn", specs)],
+        [("ut.bpmn", str(recording_file), str(schema_file))],
+    )
+
+    assert result.wasSuccessful(), output
+    assert ctx.test_cases[0].wasSuccessful
+
+
+def test_run_tests_with_recordings_preloads_dependencies_for_call_activities(tmp_path):
+    recording_file = tmp_path / "ut_recording.json"
+    recording_file.write_text("""
+{
+  "pendingTaskStack": [
+    {
+      "id": "ut_task",
+      "data": {"some_field": "jj"}
+    }
+  ]
+}
+""")
+    parsed = []
+    for file in [ut_parent, ut]:
+        specs, err = specs_from_xml([file])
+        assert err is None
+        parsed.append((file[0], specs))
+
+    ctx, result, output = run_tests_with_recordings(
+        parsed,
+        [("ut_parent.bpmn", str(recording_file))],
+    )
+
+    assert result.wasSuccessful(), output
+    assert ctx.test_cases[0].wasSuccessful

--- a/spiff-arena-common/tests/spiff_arena_common/test_tester.py
+++ b/spiff-arena-common/tests/spiff_arena_common/test_tester.py
@@ -2,7 +2,7 @@ import pytest
 
 from spiff_arena_common.coverage import task_coverage
 from spiff_arena_common.runner import specs_from_xml
-from spiff_arena_common.tester import run_tests
+from spiff_arena_common.tester import run_tests, run_tests_with_recordings
 
 ut = ("ut.bpmn", """
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:spiffworkflow="http://spiffworkflow.org/bpmn/schema/1.0/core" id="Definitions_96f6665" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.0.0-dev">
@@ -217,3 +217,79 @@ def test_tester(files):
     assert completed == 3
     assert all == 3
     assert percent == int(100)
+
+
+def test_run_tests_with_recordings_runs_main_file_with_recording_and_schema(tmp_path):
+    recording_file = tmp_path / "ut_recording.json"
+    recording_file.write_text("""
+{
+  "pendingTaskStack": [
+    {
+      "id": "ut_task",
+      "data": {"some_field": "jj"}
+    }
+  ]
+}
+""")
+    schema_file = tmp_path / "ut.schema.json"
+    schema_file.write_text("""
+{
+  "type": "object",
+  "properties": {
+    "some_field": {"const": "jj"}
+  },
+  "required": ["some_field"]
+}
+""")
+    specs, err = specs_from_xml([ut])
+    assert err is None
+
+    ctx, result, output = run_tests_with_recordings(
+        [("ut.bpmn", specs)],
+        [("ut.bpmn", str(recording_file), str(schema_file))],
+    )
+
+    assert result.wasSuccessful(), output
+    assert result.testsRun == 1
+    assert ctx.test_cases[0].wasSuccessful
+
+    _, tally = task_coverage(ctx)
+    ut_tally = tally.breakdown["Process_1770128055928"]
+    assert ut_tally.completed == 3
+    assert ut_tally.all == 3
+    assert ut_tally.percent == 100
+
+
+def test_run_tests_with_recordings_reports_schema_failure(tmp_path):
+    recording_file = tmp_path / "ut_recording.json"
+    recording_file.write_text("""
+{
+  "pendingTaskStack": [
+    {
+      "id": "ut_task",
+      "data": {"some_field": "wrong"}
+    }
+  ]
+}
+""")
+    schema_file = tmp_path / "ut.schema.json"
+    schema_file.write_text("""
+{
+  "type": "object",
+  "properties": {
+    "some_field": {"const": "jj"}
+  },
+  "required": ["some_field"]
+}
+""")
+    specs, err = specs_from_xml([ut])
+    assert err is None
+
+    ctx, result, output = run_tests_with_recordings(
+        [("ut.bpmn", specs)],
+        [("ut.bpmn", str(recording_file), str(schema_file))],
+    )
+
+    assert not result.wasSuccessful()
+    assert not ctx.test_cases[0].wasSuccessful
+    assert "ut.schema.json" in output

--- a/uv.lock
+++ b/uv.lock
@@ -433,7 +433,7 @@ wheels = [
 
 [[package]]
 name = "spiff-arena-common"
-version = "0.1.33"
+version = "0.1.34"
 source = { editable = "spiff-arena-common" }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Besides `run_tests`, which will run all `_test.bpmn` files via test discovery, `run_tests_with_recording` will also run a specified list of tuples which point to a file under test, a recording, and an optional schema. This can be used in addition to, or instead of, manually writing `_test.bpmn` files.