### PR TITLE
Report coverage for task coverage in subprocesses

### DIFF
--- a/spiff-arena-common/pyproject.toml
+++ b/spiff-arena-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spiff-arena-common"
-version = "0.1.35"
+version = "0.1.36"
 description = "Shared Python utilities for Spiff Arena frontend and backend components"
 readme = "README.md"
 requires-python = ">=3.10, <3.13"

--- a/spiff-arena-common/src/spiff_arena_common/coverage.py
+++ b/spiff-arena-common/src/spiff_arena_common/coverage.py
@@ -7,7 +7,48 @@ TestCov = namedtuple("TestCov", ["all", "completed", "missing"])
 Tally = namedtuple("Tally", ["completed", "all", "percent"])
 CovTally = namedtuple("CovTally", ["result", "breakdown"])
 
-def cov_tasks(test_cases):
+def _embedded_subprocess_ids(spec, subprocess_specs, seen=None):
+    if seen is None:
+        seen = set()
+    embedded = set()
+    for task_spec in spec["task_specs"].values():
+        if task_spec.get("typename") != "SubWorkflowTask":
+            continue
+        subprocess_id = task_spec.get("spec")
+        if not subprocess_id or subprocess_id in seen:
+            continue
+        subprocess_spec = subprocess_specs.get(subprocess_id)
+        if not subprocess_spec:
+            continue
+        seen.add(subprocess_id)
+        embedded.add(subprocess_id)
+        embedded.update(_embedded_subprocess_ids(subprocess_spec, subprocess_specs, seen))
+    return embedded
+
+def _task_ids(spec, subprocess_specs, seen=None):
+    if seen is None:
+        seen = set()
+    ids = {
+        task_id
+        for task_id, task_spec in spec["task_specs"].items()
+        if task_spec.get("bpmn_id")
+    }
+    for subprocess_id in _embedded_subprocess_ids(spec, subprocess_specs, seen):
+        ids.update(_task_ids(subprocess_specs[subprocess_id], subprocess_specs, seen))
+    return ids
+
+def _embedded_subprocess_owners(specs):
+    owners = {}
+    for owner_id, spec_json in specs.items():
+        specs_dct = json.loads(spec_json)
+        subprocess_specs = specs_dct.get("subprocess_specs", {})
+        for subprocess_id in _embedded_subprocess_ids(specs_dct["spec"], subprocess_specs):
+            owners[subprocess_id] = owner_id
+    return owners
+
+def cov_tasks(test_cases, embedded_subprocess_owners=None):
+    if embedded_subprocess_owners is None:
+        embedded_subprocess_owners = {}
     for test_case in test_cases:
         state = test_case.state
         coverage_spec_id = getattr(test_case, "coverage_spec_id", None)
@@ -17,6 +58,7 @@ def cov_tasks(test_cases):
                     yield coverage_spec_id, task["task_spec"]
         for _, sp in state["subprocesses"].items():
             id = sp["spec"]
+            id = embedded_subprocess_owners.get(id, id)
             for _, task in sp["tasks"].items():
                 if task["state"] == 64:
                     yield id, task["task_spec"]
@@ -39,19 +81,16 @@ def task_coverage(ctx):
     all = {}
     completed = {}
     missing = {}
-    for id, task_id in cov_tasks(ctx.test_cases):
+    embedded_subprocess_owners = _embedded_subprocess_owners(ctx.specs)
+    for id, task_id in cov_tasks(ctx.test_cases, embedded_subprocess_owners):
         if id not in completed:
             completed[id] = set()
         completed[id].add(task_id)
     for id, spec in ctx.specs.items():
         if id not in completed:
             completed[id] = set()
-        spec = json.loads(spec)["spec"]
-        all[id] = set(
-            task_id
-            for task_id, task_spec in spec["task_specs"].items()
-            if task_spec.get("bpmn_id")
-        )
+        specs = json.loads(spec)
+        all[id] = _task_ids(specs["spec"], specs.get("subprocess_specs", {}))
         completed[id] &= all[id]
         missing[id] = all[id] - completed[id]
 

--- a/spiff-arena-common/src/spiff_arena_common/coverage.py
+++ b/spiff-arena-common/src/spiff_arena_common/coverage.py
@@ -57,11 +57,11 @@ def cov_tasks(test_cases, embedded_subprocess_owners=None):
                 if task["state"] == 64:
                     yield coverage_spec_id, task["task_spec"]
         for _, sp in state["subprocesses"].items():
-            id = sp["spec"]
-            id = embedded_subprocess_owners.get(id, id)
+            spec_id = sp["spec"]
+            spec_id = embedded_subprocess_owners.get(spec_id, spec_id)
             for _, task in sp["tasks"].items():
                 if task["state"] == 64:
-                    yield id, task["task_spec"]
+                    yield spec_id, task["task_spec"]
 
 def tally(cov):
     completed = 0

--- a/spiff-arena-common/tests/spiff_arena_common/test_z_coverage.py
+++ b/spiff-arena-common/tests/spiff_arena_common/test_z_coverage.py
@@ -1,3 +1,5 @@
+import json
+
 from spiff_arena_common.coverage import task_coverage
 from spiff_arena_common.runner import specs_from_xml
 from spiff_arena_common.tester import run_tests
@@ -142,3 +144,97 @@ def test_task_coverage_counts_only_task_specs_with_bpmn_ids():
     assert cov.missing["FakeProcess"] == {"Task_Two"}
     assert tally.breakdown["FakeProcess"].completed == 1
     assert tally.breakdown["FakeProcess"].all == 2
+
+
+def test_task_coverage_counts_embedded_subprocess_tasks_but_not_call_activity_tasks():
+    def specs(spec, subprocess_specs=None):
+        return {
+            "spec": spec,
+            "subprocess_specs": subprocess_specs or {},
+        }
+
+    parent_spec = {
+        "name": "Parent",
+        "task_specs": {
+            "Start": {"bpmn_id": "Start", "typename": "StartEvent"},
+            "Embedded": {
+                "bpmn_id": "Embedded",
+                "typename": "SubWorkflowTask",
+                "spec": "EmbeddedProcess",
+            },
+            "Call_Other": {
+                "bpmn_id": "Call_Other",
+                "typename": "CallActivity",
+                "spec": "CalledProcess",
+            },
+            "End": {"bpmn_id": "End", "typename": "EndEvent"},
+        },
+    }
+    embedded_spec = {
+        "name": "EmbeddedProcess",
+        "task_specs": {
+            "Embedded_Start": {"bpmn_id": "Embedded_Start", "typename": "StartEvent"},
+            "Embedded_Task": {"bpmn_id": "Embedded_Task", "typename": "ScriptTask"},
+            "Embedded_End": {"bpmn_id": "Embedded_End", "typename": "EndEvent"},
+        },
+    }
+    called_spec = {
+        "name": "CalledProcess",
+        "task_specs": {
+            "Called_Task": {"bpmn_id": "Called_Task", "typename": "ScriptTask"},
+        },
+    }
+    serialized_specs = {
+        "Parent": json.dumps(specs(parent_spec, {"EmbeddedProcess": embedded_spec})),
+        "CalledProcess": json.dumps(specs(called_spec)),
+    }
+
+    class FakeTestCase:
+        coverage_spec_id = "Parent"
+        state = {
+            "tasks": {
+                "start": {"state": 64, "task_spec": "Start"},
+                "embedded": {"state": 64, "task_spec": "Embedded"},
+                "call": {"state": 64, "task_spec": "Call_Other"},
+                "end": {"state": 64, "task_spec": "End"},
+            },
+            "subprocesses": {
+                "embedded": {
+                    "spec": "EmbeddedProcess",
+                    "tasks": {
+                        "embedded_start": {"state": 64, "task_spec": "Embedded_Start"},
+                        "embedded_task": {"state": 64, "task_spec": "Embedded_Task"},
+                        "embedded_end": {"state": 64, "task_spec": "Embedded_End"},
+                    },
+                },
+                "called": {
+                    "spec": "CalledProcess",
+                    "tasks": {
+                        "called_task": {"state": 64, "task_spec": "Called_Task"},
+                    },
+                },
+            },
+        }
+
+    class FakeContext:
+        test_cases = [FakeTestCase()]
+        specs = serialized_specs
+
+    cov, tally = task_coverage(FakeContext())
+
+    assert cov.all["Parent"] == {
+        "Start",
+        "Embedded",
+        "Call_Other",
+        "End",
+        "Embedded_Start",
+        "Embedded_Task",
+        "Embedded_End",
+    }
+    assert cov.completed["Parent"] == cov.all["Parent"]
+    assert cov.all["CalledProcess"] == {"Called_Task"}
+    assert cov.completed["CalledProcess"] == {"Called_Task"}
+    assert tally.breakdown["Parent"].completed == 7
+    assert tally.breakdown["Parent"].all == 7
+    assert tally.breakdown["CalledProcess"].completed == 1
+    assert tally.breakdown["CalledProcess"].all == 1

--- a/uv.lock
+++ b/uv.lock
@@ -417,7 +417,7 @@ wheels = [
 
 [[package]]
 name = "spiff-arena-common"
-version = "0.1.35"
+version = "0.1.36"
 source = { editable = "spiff-arena-common" }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Prior only top level tasks were counted, now all tasks in subprocesses are counted.