### PR TITLE
Extract git commit from process_api_blueprint

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/data_store_controller.py
@@ -18,7 +18,7 @@ from spiffworkflow_backend.models.db import SpiffworkflowBaseDBModel
 from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.models.kkv_data_store import KKVDataStoreModel
 from spiffworkflow_backend.models.kkv_data_store_entry import KKVDataStoreEntryModel
-from spiffworkflow_backend.routes.process_api_blueprint import _commit_and_push_to_git
+from spiffworkflow_backend.services.git_service import GitService
 from spiffworkflow_backend.services.process_model_service import ProcessModelService
 from spiffworkflow_backend.services.upsearch_service import UpsearchService
 
@@ -268,7 +268,7 @@ def _data_store_upsert(body: dict, insert: bool) -> flask.wrappers.Response:
     db.session.add(data_store_model)
     db.session.commit()
 
-    _commit_and_push_to_git(f"User: {g.user.username} added data store {data_store_model.identifier}")
+    GitService.commit_on_save(f"User: {g.user.username} added data store {data_store_model.identifier}")
     return make_response(jsonify({"ok": True}), 200)
 
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_api_blueprint.py
@@ -315,14 +315,6 @@ def _get_required_parameter_or_raise(parameters: list[str], post_body: dict[str,
     return return_value, parameter_name
 
 
-def _commit_and_push_to_git(message: str) -> None:
-    if current_app.config["SPIFFWORKFLOW_BACKEND_GIT_COMMIT_ON_SAVE"]:
-        git_output = GitService.commit(message=message)
-        current_app.logger.info(f"git output: {git_output}")
-    else:
-        current_app.logger.info("Git commit on save is disabled")
-
-
 def _un_modify_modified_process_model_id(modified_process_model_identifier: str) -> str:
     return modified_process_model_identifier.replace(":", "/")
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_groups_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_groups_controller.py
@@ -14,9 +14,9 @@ from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.models.message_model import MessageModel
 from spiffworkflow_backend.models.process_group import PROCESS_GROUP_KEYS_TO_UPDATE_FROM_API
 from spiffworkflow_backend.models.process_group import ProcessGroup
-from spiffworkflow_backend.routes.process_api_blueprint import _commit_and_push_to_git
 from spiffworkflow_backend.routes.process_api_blueprint import _un_modify_modified_process_model_id
 from spiffworkflow_backend.services.authorization_service import AuthorizationService
+from spiffworkflow_backend.services.git_service import GitService
 from spiffworkflow_backend.services.message_definition_service import MessageDefinitionService
 from spiffworkflow_backend.services.process_model_service import ProcessModelService
 from spiffworkflow_backend.services.process_model_service import ProcessModelWithInstancesNotDeletableError
@@ -42,7 +42,7 @@ def process_group_create(body: dict) -> flask.wrappers.Response:
         )
 
     ProcessModelService.add_process_group(process_group)
-    _commit_and_push_to_git(f"User: {g.user.username} added process group {process_group.id}")
+    GitService.commit_on_save(f"User: {g.user.username} added process group {process_group.id}")
     return make_response(jsonify(process_group), 201)
 
 
@@ -63,7 +63,7 @@ def process_group_delete(modified_process_group_id: str) -> flask.wrappers.Respo
             status_code=400,
         ) from exception
 
-    _commit_and_push_to_git(f"User: {g.user.username} deleted process group {process_group_id}")
+    GitService.commit_on_save(f"User: {g.user.username} deleted process group {process_group_id}")
     return make_response(jsonify({"ok": True}), 200)
 
 
@@ -90,7 +90,7 @@ def process_group_update(modified_process_group_id: str, body: dict) -> flask.wr
     MessageDefinitionService.save_all_message_models(all_message_models)
     db.session.commit()
 
-    _commit_and_push_to_git(f"User: {g.user.username} updated process group {process_group_id}")
+    GitService.commit_on_save(f"User: {g.user.username} updated process group {process_group_id}")
     return make_response(jsonify(process_group), 200)
 
 
@@ -154,5 +154,7 @@ def process_group_show(
 def process_group_move(modified_process_group_identifier: str, new_location: str) -> flask.wrappers.Response:
     original_process_group_id = _un_modify_modified_process_model_id(modified_process_group_identifier)
     new_process_group = ProcessModelService.process_group_move(original_process_group_id, new_location)
-    _commit_and_push_to_git(f"User: {g.user.username} moved process group {original_process_group_id} to {new_process_group.id}")
+    GitService.commit_on_save(
+        f"User: {g.user.username} moved process group {original_process_group_id} to {new_process_group.id}"
+    )
     return make_response(jsonify(new_process_group), 200)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_model_import_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_model_import_controller.py
@@ -1,7 +1,7 @@
 from flask import g
 
 from spiffworkflow_backend.exceptions.api_error import ApiError
-from spiffworkflow_backend.routes.process_api_blueprint import _commit_and_push_to_git
+from spiffworkflow_backend.services.git_service import GitService
 from spiffworkflow_backend.services.process_model_import_service import ModelAliasNotFoundError
 from spiffworkflow_backend.services.process_model_import_service import ProcessModelImportService
 
@@ -34,6 +34,6 @@ def process_model_import(modified_process_group_id: str, body: dict) -> tuple[di
         f"User: {g.user.username} imported process model from {import_source_type} "
         f"({repository_url}) into {unmodified_process_group_id}"
     )
-    _commit_and_push_to_git(commit_message)
+    GitService.commit_on_save(commit_message)
 
     return {"process_model": process_model.to_dict(), "import_source": repository_url}, 201

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/process_models_controller.py
@@ -23,7 +23,6 @@ from spiffworkflow_backend.models.process_group import ProcessGroup
 from spiffworkflow_backend.models.process_instance_report import ProcessInstanceReportModel
 from spiffworkflow_backend.models.process_model import ProcessModelInfo
 from spiffworkflow_backend.models.reference_cache import ReferenceCacheModel
-from spiffworkflow_backend.routes.process_api_blueprint import _commit_and_push_to_git
 from spiffworkflow_backend.routes.process_api_blueprint import _find_process_instance_by_id_or_raise
 from spiffworkflow_backend.routes.process_api_blueprint import _get_process_model
 from spiffworkflow_backend.routes.process_api_blueprint import _un_modify_modified_process_model_id
@@ -101,7 +100,7 @@ def process_model_create(
 
     SpecFileService.update_file(process_model_info, f"{process_model_id_for_bpmn_file}.bpmn", contents.encode())
 
-    _commit_and_push_to_git(f"User: {g.user.username} created process model {process_model_info.id}")
+    GitService.commit_on_save(f"User: {g.user.username} created process model {process_model_info.id}")
     return make_response(jsonify(process_model_info.to_dict()), 201)
 
 
@@ -123,7 +122,7 @@ def process_model_delete(
             status_code=400,
         ) from exception
 
-    _commit_and_push_to_git(f"User: {g.user.username} deleted process model {process_model_identifier}")
+    GitService.commit_on_save(f"User: {g.user.username} deleted process model {process_model_identifier}")
     return make_response(jsonify({"ok": True}), 200)
 
 
@@ -166,7 +165,7 @@ def process_model_update(
         primary_file_contents = SpecFileService.get_data(process_model, process_model.primary_file_name)
         SpecFileService.update_file(process_model, process_model.primary_file_name, primary_file_contents)
 
-    _commit_and_push_to_git(f"User: {g.user.username} updated process model {process_model_identifier}")
+    GitService.commit_on_save(f"User: {g.user.username} updated process model {process_model_identifier}")
 
     if "metadata_extraction_paths" in body_filtered:
         try:
@@ -228,7 +227,9 @@ def process_model_show(modified_process_model_identifier: str, include_file_refe
 def process_model_move(modified_process_model_identifier: str, new_location: str) -> flask.wrappers.Response:
     original_process_model_id = _un_modify_modified_process_model_id(modified_process_model_identifier)
     new_process_model = ProcessModelService.process_model_move(original_process_model_id, new_location)
-    _commit_and_push_to_git(f"User: {g.user.username} moved process model {original_process_model_id} to {new_process_model.id}")
+    GitService.commit_on_save(
+        f"User: {g.user.username} moved process model {original_process_model_id} to {new_process_model.id}"
+    )
     return make_response(jsonify(new_process_model), 200)
 
 
@@ -241,7 +242,9 @@ def process_model_copy(modified_process_model_identifier: str, body: dict[str, s
         display_name = body["id"].split("/")[-1]
 
     new_process_model = ProcessModelService.copy_process_model(process_model_identifier, body["id"], display_name)
-    _commit_and_push_to_git(f"User: {g.user.username} copied process model {process_model_identifier} to {new_process_model.id}")
+    GitService.commit_on_save(
+        f"User: {g.user.username} copied process model {process_model_identifier} to {new_process_model.id}"
+    )
 
     # Update the process model cache for the new copied model
     DataSetupService.refresh_single_process_model_cache(new_process_model.id)
@@ -340,7 +343,7 @@ def process_model_file_delete(modified_process_model_identifier: str, file_name:
             )
         ) from exception
 
-    _commit_and_push_to_git(f"User: {g.user.username} deleted process model file {process_model_identifier}/{file_name}")
+    GitService.commit_on_save(f"User: {g.user.username} deleted process model file {process_model_identifier}/{file_name}")
     return make_response(jsonify({"ok": True}), 200)
 
 
@@ -525,7 +528,7 @@ def process_model_create_with_natural_language(modified_process_group_id: str, b
     for file_name, contents in files_to_update.items():
         SpecFileService.update_file(process_model_info, file_name, contents)
 
-    _commit_and_push_to_git(f"User: {g.user.username} created process model via natural language: {process_model_info.id}")
+    GitService.commit_on_save(f"User: {g.user.username} created process model via natural language: {process_model_info.id}")
 
     default_report_metadata = ProcessInstanceReportService.system_metadata_map("default")
     if default_report_metadata is None:
@@ -634,7 +637,7 @@ def _create_or_update_process_model_file(
     file.process_model_id = process_model.id
     file_contents_hash = sha256(file_contents).hexdigest()
     file.file_contents_hash = file_contents_hash
-    _commit_and_push_to_git(f"{message_for_git_commit} {process_model_identifier}/{file.name}")
+    GitService.commit_on_save(f"{message_for_git_commit} {process_model_identifier}/{file.name}")
 
     if is_new_file and file.name.endswith(".bpmn"):
         DataSetupService.refresh_single_process_model_cache(process_model_identifier)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/git_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/git_service.py
@@ -128,6 +128,14 @@ class GitService:
         return cls.run_shell_command_to_get_stdout(shell_command, prepend_with_git=False)
 
     @classmethod
+    def commit_on_save(cls, message: str) -> None:
+        if current_app.config["SPIFFWORKFLOW_BACKEND_GIT_COMMIT_ON_SAVE"]:
+            git_output = cls.commit(message=message)
+            current_app.logger.info(f"git output: {git_output}")
+        else:
+            current_app.logger.info("Git commit on save is disabled")
+
+    @classmethod
     def check_for_basic_configs(cls, raise_on_missing: bool = True) -> bool:
         if current_app.config["SPIFFWORKFLOW_BACKEND_GIT_SOURCE_BRANCH"] is None:
             if raise_on_missing:

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_git_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_git_service.py
@@ -60,6 +60,30 @@ class TestGitService(BaseTest):
         )
         assert output == "This output should not end in space"
 
+    def test_commit_on_save_commits_when_enabled(
+        self,
+        app: Flask,
+        mocker: MockerFixture,
+    ) -> None:
+        mock_commit = mocker.patch.object(GitService, "commit", return_value="commit output")
+
+        with self.app_config_mock(app, "SPIFFWORKFLOW_BACKEND_GIT_COMMIT_ON_SAVE", True):
+            GitService.commit_on_save("User: test commit")
+
+        mock_commit.assert_called_once_with(message="User: test commit")
+
+    def test_commit_on_save_skips_commit_when_disabled(
+        self,
+        app: Flask,
+        mocker: MockerFixture,
+    ) -> None:
+        mock_commit = mocker.patch.object(GitService, "commit")
+
+        with self.app_config_mock(app, "SPIFFWORKFLOW_BACKEND_GIT_COMMIT_ON_SAVE", False):
+            GitService.commit_on_save("User: test commit")
+
+        mock_commit.assert_not_called()
+
     def test_force_sync_to_webhook_revision_stashes_and_backs_up_local_state(
         self,
         app: Flask,


### PR DESCRIPTION
Previously other routes/controllers would import process_api_blueprint to `_commit_and_push_to_git`. Moved this method into GitService to start making this route more of a route. Also renamed to `commit_on_save` since it does not actually push and there is another `commit` method already.