### PR TITLE
improve script engine import experience

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_processor.py
@@ -101,9 +101,10 @@ from spiffworkflow_backend.services.workflow_spec_service import IdToBpmnProcess
 WorkflowCompletedHandler = Callable[[ProcessInstanceModel], None]
 
 
-def _import(name: str, glbls: dict[str, Any], *args: Any) -> None:
+def _import(name: str, glbls: dict[str, Any], *args: Any) -> Any:
     if name not in glbls:
         raise ImportError(f"Import not allowed: {name}", name=name)
+    return glbls[name]
 
 
 # This number is a little arbitrary but seems like a good number.

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_model_test_runner_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_model_test_runner_service.py
@@ -120,9 +120,10 @@ class TestCaseResult:
     test_case_error_details: TestCaseErrorDetails | None = None
 
 
-def _import(name: str, glbls: dict[str, Any], *args: Any) -> None:
+def _import(name: str, glbls: dict[str, Any], *args: Any) -> Any:
     if name not in glbls:
         raise ImportError(f"Import not allowed: {name}", name=name)
+    return glbls[name]
 
 
 class ProcessModelTestRunnerScriptEngine(PythonScriptEngine):  # type: ignore

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_restricted_script_engine.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_restricted_script_engine.py
@@ -3,6 +3,7 @@ from flask.app import Flask
 from starlette.testclient import TestClient
 
 from spiffworkflow_backend.services.process_instance_processor import ProcessInstanceProcessor
+from spiffworkflow_backend.services.script_unit_test_runner import ScriptUnitTestRunner
 from spiffworkflow_backend.services.workflow_execution_service import WorkflowExecutionServiceError
 from tests.spiffworkflow_backend.helpers.base_test import BaseTest
 from tests.spiffworkflow_backend.helpers.test_data import load_test_spec
@@ -44,3 +45,19 @@ class TestRestrictedScriptEngine(BaseTest):
         with pytest.raises(WorkflowExecutionServiceError) as exception:
             processor.do_engine_steps(save=True)
         assert "Import not allowed: os" in str(exception.value)
+
+    def test_can_import_preloaded_re_module(self) -> None:
+        result = ScriptUnitTestRunner.run_with_script_and_pre_post_contexts(
+            "import re\nsnake_case = re.sub(r'(?<!^)(?=[A-Z])', '_', 'CamelCase').lower()",
+            {},
+            {"snake_case": "camel_case"},
+        )
+
+        assert result.result is True
+
+    def test_cannot_import_unapproved_module(self) -> None:
+        result = ScriptUnitTestRunner.run_with_script_and_pre_post_contexts("import pkgutil", {}, {})
+
+        assert result.result is False
+        assert result.error is not None
+        assert "Import not allowed: pkgutil" in result.error


### PR DESCRIPTION
previously if you did this in a script task:

`import pkgutil`

it would error loudly, but if you did:

`import re`

it would change `re` to None, so `re` would be unusable.

now if you `import re` it is essentially a no-op because it is already available.