### PR TITLE
Remove version upper bounds

### DIFF
--- a/spiff-arena-common/pyproject.toml
+++ b/spiff-arena-common/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "spiff-arena-common"
-version = "0.1.36"
+version = "0.1.37"
 description = "Shared Python utilities for Spiff Arena frontend and backend components"
 readme = "README.md"
-requires-python = ">=3.10, <3.13"
+requires-python = ">=3.10"
 
 # Dependencies are intentionally commented out.
 # Specifying them causes issues when this package is loaded via micropip in Pyodide.

--- a/uv.lock
+++ b/uv.lock
@@ -417,7 +417,7 @@ wheels = [
 
 [[package]]
 name = "spiff-arena-common"
-version = "0.1.36"
+version = "0.1.37"
 source = { editable = "spiff-arena-common" }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Preps for the new pyodide release which supports python 3.14. Also more in line with how the backend and spiffworkflow's version support works.