### PR TITLE
safe json serialization for objects with mixed-type keys

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/json_data.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/json_data.py
@@ -89,7 +89,19 @@ class JsonDataModel(SpiffworkflowBaseDBModel):
     @classmethod
     def _normalize_json_object_keys(cls, data: object) -> Any:
         if isinstance(data, dict):
-            return {cls._json_object_key_to_string(key): cls._normalize_json_object_keys(value) for key, value in data.items()}
+            normalized_data: dict[str, Any] = {}
+            normalized_key_to_original_key: dict[str, object] = {}
+            for key, value in data.items():
+                normalized_key = cls._json_object_key_to_string(key)
+                if normalized_key in normalized_data:
+                    original_key = normalized_key_to_original_key[normalized_key]
+                    raise ValueError(
+                        f"JSON object key collision after normalization: {original_key!r} and {key!r} "
+                        f"both normalize to {normalized_key!r}"
+                    )
+                normalized_key_to_original_key[normalized_key] = key
+                normalized_data[normalized_key] = cls._normalize_json_object_keys(value)
+            return normalized_data
         if isinstance(data, list):
             return [cls._normalize_json_object_keys(value) for value in data]
         return data

--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/json_data.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/json_data.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from hashlib import sha256
+from typing import Any
 from typing import TypedDict
 
 from spiffworkflow_backend.models.db import SpiffworkflowBaseDBModel
@@ -78,8 +79,25 @@ class JsonDataModel(SpiffworkflowBaseDBModel):
         return json_data_dict["hash"]
 
     @classmethod
+    def _json_object_key_to_string(cls, key: object) -> str:
+        if isinstance(key, str):
+            return key
+        if key is None or isinstance(key, bool | int | float):
+            return json.dumps(key)
+        raise TypeError(f"keys must be str, int, float, bool or None, not {key.__class__.__name__}")
+
+    @classmethod
+    def _normalize_json_object_keys(cls, data: object) -> Any:
+        if isinstance(data, dict):
+            return {cls._json_object_key_to_string(key): cls._normalize_json_object_keys(value) for key, value in data.items()}
+        if isinstance(data, list):
+            return [cls._normalize_json_object_keys(value) for value in data]
+        return data
+
+    @classmethod
     def json_data_dict_from_dict(cls, data: dict) -> JsonDataDict:
-        task_data_json = json.dumps(data, sort_keys=True)
+        normalized_data = cls._normalize_json_object_keys(data)
+        task_data_json = json.dumps(normalized_data, sort_keys=True)
         task_data_hash: str = sha256(task_data_json.encode("utf8")).hexdigest()
-        json_data_dict: JsonDataDict = {"hash": task_data_hash, "data": data}
+        json_data_dict: JsonDataDict = {"hash": task_data_hash, "data": normalized_data}
         return json_data_dict

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/task_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/task_service.py
@@ -1,7 +1,5 @@
 import copy
-import json
 import time
-from hashlib import sha256
 from typing import TypedDict
 from uuid import UUID
 
@@ -649,9 +647,8 @@ class TaskService:
             data_dict_to_use = self.serializer.to_dict(bpmn_process_instance.data)
         if data_dict_to_use is None:
             data_dict_to_use = {}
-        bpmn_process_data_json = json.dumps(data_dict_to_use, sort_keys=True)
-        bpmn_process_data_hash: str = sha256(bpmn_process_data_json.encode("utf8")).hexdigest()
-        json_data_dict: JsonDataDict = {"hash": bpmn_process_data_hash, "data": data_dict_to_use}
+        json_data_dict = JsonDataModel.json_data_dict_from_dict(data_dict_to_use)
+        bpmn_process_data_hash = json_data_dict["hash"]
         if bpmn_process.json_data_hash != bpmn_process_data_hash:
             bpmn_process.json_data_hash = bpmn_process_data_hash
             self.json_data_dicts[bpmn_process_data_hash] = json_data_dict

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_json_data.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_json_data.py
@@ -1,6 +1,8 @@
 import json
 from hashlib import sha256
 
+import pytest
+
 from spiffworkflow_backend.models.json_data import JsonDataModel
 
 
@@ -42,3 +44,8 @@ def test_json_data_hash_treats_integer_keys_like_json_object_keys() -> None:
     string_key_data = {"1": "one"}
 
     assert JsonDataModel.json_data_dict_from_dict(int_key_data) == JsonDataModel.json_data_dict_from_dict(string_key_data)
+
+
+def test_json_data_dict_from_dict_rejects_normalized_key_collisions() -> None:
+    with pytest.raises(ValueError, match="JSON object key collision after normalization"):
+        JsonDataModel.json_data_dict_from_dict({1: "integer", "1": "string"})

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_json_data.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_json_data.py
@@ -1,0 +1,44 @@
+import json
+from hashlib import sha256
+
+from spiffworkflow_backend.models.json_data import JsonDataModel
+
+
+def test_json_data_dict_from_dict_handles_mixed_string_and_integer_keys() -> None:
+    data = {
+        "validation_results": {
+            1: {"valid": True},
+            "2": {"valid": False},
+        },
+        "nested_list": [
+            {
+                3: "three",
+                "4": "four",
+            }
+        ],
+    }
+
+    json_data_dict = JsonDataModel.json_data_dict_from_dict(data)
+
+    expected_data = {
+        "validation_results": {
+            "1": {"valid": True},
+            "2": {"valid": False},
+        },
+        "nested_list": [
+            {
+                "3": "three",
+                "4": "four",
+            }
+        ],
+    }
+    expected_hash = sha256(json.dumps(expected_data, sort_keys=True).encode("utf8")).hexdigest()
+
+    assert json_data_dict == {"hash": expected_hash, "data": expected_data}
+
+
+def test_json_data_hash_treats_integer_keys_like_json_object_keys() -> None:
+    int_key_data = {1: "one"}
+    string_key_data = {"1": "one"}
+
+    assert JsonDataModel.json_data_dict_from_dict(int_key_data) == JsonDataModel.json_data_dict_from_dict(string_key_data)


### PR DESCRIPTION
`{1: "hey", "another": "sure"}` used to crash when we saved it to the db because some keys were strings and others were numbers, and we were requesting that the keys be sorted. with this change, we now normalize to strings first, which is what json serialization does by default anyway since all json objects must use string keys.