### PR TITLE
Move message about unsaved changes next to save button

### DIFF
--- a/spiffworkflow-frontend/packages/bpmn-js-spiffworkflow-react/src/components/DiagramActionBar.tsx
+++ b/spiffworkflow-frontend/packages/bpmn-js-spiffworkflow-react/src/components/DiagramActionBar.tsx
@@ -1,11 +1,14 @@
 import React, { ReactNode } from 'react';
-import { Button, Stack } from '@mui/material';
+import { Button, Stack, Typography } from '@mui/material';
+import { WarningAmber } from '@mui/icons-material';
 
 type DiagramActionBarProps = {
   canSave?: boolean;
   onSave?: () => void;
   saveDisabled?: boolean;
   saveLabel: string;
+  saveRequiresAttention?: boolean;
+  saveTooltip?: ReactNode;
   canDelete?: boolean;
   onDelete?: () => void;
   deleteLabel?: string;
@@ -30,6 +33,8 @@ export default function DiagramActionBar({
   onSave,
   saveDisabled,
   saveLabel,
+  saveRequiresAttention,
+  saveTooltip,
   canDelete,
   onDelete,
   deleteLabel,
@@ -48,6 +53,47 @@ export default function DiagramActionBar({
   processInstanceRun,
   activeUserElement,
 }: DiagramActionBarProps) {
+  const shouldShowSaveAttention = saveRequiresAttention && !saveDisabled;
+
+  const saveButton = canSave && onSave ? (
+    <Button
+      onClick={onSave}
+      variant="contained"
+      size="small"
+      color="primary"
+      disabled={saveDisabled}
+      data-testid="process-model-file-save-button"
+    >
+      {saveLabel}
+    </Button>
+  ) : null;
+
+  const saveAttentionMessage =
+    shouldShowSaveAttention && saveTooltip ? (
+      <Stack
+        direction="row"
+        spacing={0.5}
+        alignItems="center"
+        role="status"
+        aria-live="polite"
+        data-testid="process-model-file-unsaved-message"
+        sx={{
+          color: 'warning.dark',
+          minHeight: 30,
+          maxWidth: { xs: '100%', md: 380 },
+        }}
+      >
+        <WarningAmber fontSize="small" />
+        <Typography
+          component="span"
+          variant="body2"
+          sx={{ fontWeight: 700, lineHeight: 1.25 }}
+        >
+          {saveTooltip}
+        </Typography>
+      </Stack>
+    ) : null;
+
   return (
     <Stack
       className="diagram-action-bar"
@@ -56,17 +102,8 @@ export default function DiagramActionBar({
       alignItems="center"
       sx={{ flexWrap: 'wrap' }}
     >
-      {canSave && onSave ? (
-        <Button
-          onClick={onSave}
-          variant="contained"
-          size="small"
-          disabled={saveDisabled}
-          data-testid="process-model-file-save-button"
-        >
-          {saveLabel}
-        </Button>
-      ) : null}
+      {saveAttentionMessage}
+      {saveButton}
       {processInstanceRun || null}
       {canDelete ? deleteButton || null : null}
       {canSetPrimary && onSetPrimary ? (

--- a/spiffworkflow-frontend/packages/bpmn-js-spiffworkflow-react/src/components/DiagramActionBar.tsx
+++ b/spiffworkflow-frontend/packages/bpmn-js-spiffworkflow-react/src/components/DiagramActionBar.tsx
@@ -55,24 +55,25 @@ export default function DiagramActionBar({
 }: DiagramActionBarProps) {
   const shouldShowSaveAttention = saveRequiresAttention && !saveDisabled;
 
-  const saveButton = canSave && onSave ? (
-    <Button
-      onClick={onSave}
-      variant="contained"
-      size="small"
-      color="primary"
-      disabled={saveDisabled}
-      data-testid="process-model-file-save-button"
-    >
-      {saveLabel}
-    </Button>
-  ) : null;
+  const saveButton =
+    canSave && onSave ? (
+      <Button
+        onClick={onSave}
+        variant="contained"
+        size="small"
+        color="primary"
+        disabled={saveDisabled}
+        data-testid="process-model-file-save-button"
+      >
+        {saveLabel}
+      </Button>
+    ) : null;
 
   const saveAttentionMessage =
     shouldShowSaveAttention && saveTooltip ? (
       <Stack
         direction="row"
-        spacing={0.5}
+        spacing={0.25}
         alignItems="center"
         role="status"
         aria-live="polite"
@@ -80,14 +81,14 @@ export default function DiagramActionBar({
         sx={{
           color: 'warning.dark',
           minHeight: 30,
-          maxWidth: { xs: '100%', md: 380 },
+          maxWidth: { xs: '100%', md: 420 },
         }}
       >
         <WarningAmber fontSize="small" />
         <Typography
           component="span"
           variant="body2"
-          sx={{ fontWeight: 700, lineHeight: 1.25 }}
+          sx={{ fontWeight: 700, lineHeight: 1.2 }}
         >
           {saveTooltip}
         </Typography>

--- a/spiffworkflow-frontend/packages/bpmn-js-spiffworkflow-react/src/components/DiagramActionBar.tsx
+++ b/spiffworkflow-frontend/packages/bpmn-js-spiffworkflow-react/src/components/DiagramActionBar.tsx
@@ -53,21 +53,22 @@ export default function DiagramActionBar({
   processInstanceRun,
   activeUserElement,
 }: DiagramActionBarProps) {
-  const shouldShowSaveAttention = saveRequiresAttention && !saveDisabled;
+  const canRenderSaveButton = Boolean(canSave && onSave);
+  const shouldShowSaveAttention =
+    canRenderSaveButton && saveRequiresAttention && !saveDisabled;
 
-  const saveButton =
-    canSave && onSave ? (
-      <Button
-        onClick={onSave}
-        variant="contained"
-        size="small"
-        color="primary"
-        disabled={saveDisabled}
-        data-testid="process-model-file-save-button"
-      >
-        {saveLabel}
-      </Button>
-    ) : null;
+  const saveButton = canRenderSaveButton ? (
+    <Button
+      onClick={onSave}
+      variant="contained"
+      size="small"
+      color="primary"
+      disabled={saveDisabled}
+      data-testid="process-model-file-save-button"
+    >
+      {saveLabel}
+    </Button>
+  ) : null;
 
   const saveAttentionMessage =
     shouldShowSaveAttention && saveTooltip ? (

--- a/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
+++ b/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
@@ -36,6 +36,7 @@ type OwnProps = {
   diagramXML?: string | null;
   disableSaveButton?: boolean;
   fileName?: string;
+  hasUnsavedChanges?: boolean;
   isPrimaryFile?: boolean;
   processModel?: ProcessModel | null;
   onCallActivityOverlayClick?: (..._args: any[]) => any;
@@ -56,6 +57,7 @@ type OwnProps = {
   onServiceTasksRequested?: (..._args: any[]) => any;
   onSetPrimaryFile?: (..._args: any[]) => any;
   saveDiagram?: (..._args: any[]) => any;
+  saveTooltip?: React.ReactNode;
   tasks?: BasicTask[] | null;
   url?: string;
   navigationStack?: DiagramNavigationItem[];
@@ -69,6 +71,7 @@ export default function ReactDiagramEditor({
   diagramXML,
   disableSaveButton,
   fileName,
+  hasUnsavedChanges,
   isPrimaryFile,
   processModel,
   onCallActivityOverlayClick,
@@ -90,6 +93,7 @@ export default function ReactDiagramEditor({
   onSetPrimaryFile,
   modifiedProcessModelId,
   saveDiagram,
+  saveTooltip,
   tasks,
   url,
   navigationStack,
@@ -229,6 +233,8 @@ export default function ReactDiagramEditor({
         onSave={handleSave}
         saveDisabled={disableSaveButton}
         saveLabel={t('save')}
+        saveRequiresAttention={hasUnsavedChanges}
+        saveTooltip={saveTooltip}
         canDelete={ability.can('DELETE', targetUris.processModelFileShowPath)}
         deleteButton={deleteButton}
         canSetPrimary={
@@ -280,7 +286,16 @@ export default function ReactDiagramEditor({
         data-testid="process-model-file-show"
         data-filename={fileName}
       >
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            flex: '1 1 auto',
+            flexWrap: 'wrap',
+            minWidth: 0,
+          }}
+        >
           {navigationStack && onNavigate && (
             <DiagramNavigationBreadcrumbs
               stack={navigationStack}
@@ -299,14 +314,18 @@ export default function ReactDiagramEditor({
               viewXmlLabel={t('diagram_view_xml')}
             />
           )}
+          {diagramControlButtons()}
         </Box>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <div
-            className="diagram-toolbar__right"
-            style={{ position: 'static', transform: 'none' }}
-          >
-            {diagramControlButtons()}
-          </div>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            flex: '0 1 auto',
+            flexWrap: 'wrap',
+            justifyContent: 'flex-end',
+          }}
+        >
           <div
             className="diagram-toolbar__left"
             style={{ position: 'static', padding: 0 }}

--- a/spiffworkflow-frontend/src/views/ProcessModelEditDiagram.tsx
+++ b/spiffworkflow-frontend/src/views/ProcessModelEditDiagram.tsx
@@ -38,7 +38,6 @@ import { indentUnit } from '@codemirror/language';
 import { EditorView, Decoration, type DecorationSet } from '@codemirror/view';
 import { EditorState, StateField, StateEffect } from '@codemirror/state';
 
-import { Can } from '@casl/react';
 import MDEditor from '@uiw/react-md-editor';
 import HttpService from '../services/HttpService';
 import ReactDiagramEditor from '../components/ReactDiagramEditor';
@@ -1202,6 +1201,12 @@ export default function ProcessModelEditDiagram() {
     return searchParams.get('file_type') === 'dmn' || fileName.endsWith('.dmn');
   };
 
+  const unsavedChangesSaveTooltip = diagramHasChanges
+    ? `${t('diagram_notifications_unsaved_changes_title')} ${t(
+        'diagram_notifications_unsaved_changes_message',
+      )}`
+    : undefined;
+
   const appropriateEditor = () => {
     if (isDmn()) {
       return (
@@ -1209,9 +1214,11 @@ export default function ProcessModelEditDiagram() {
           diagramType="dmn"
           diagramXML={bpmnXmlForDiagramRendering}
           fileName={params.file_name}
+          hasUnsavedChanges={diagramHasChanges}
           onDeleteFile={onDeleteFile}
           modifiedProcessModelId={modifiedProcessModelId || ''}
           saveDiagram={saveDiagram}
+          saveTooltip={unsavedChangesSaveTooltip}
           navigationStack={navigationStack}
           onNavigate={(index) => {
             const item = navigationStack[index];
@@ -1243,6 +1250,7 @@ export default function ProcessModelEditDiagram() {
         diagramType="bpmn"
         diagramXML={bpmnXmlForDiagramRendering}
         disableSaveButton={!diagramHasChanges}
+        hasUnsavedChanges={diagramHasChanges}
         fileName={params.file_name}
         isPrimaryFile={params.file_name === processModel?.primary_file_name}
         processModel={processModel}
@@ -1265,6 +1273,7 @@ export default function ProcessModelEditDiagram() {
         onSetPrimaryFile={onSetPrimaryFileCallback}
         modifiedProcessModelId={modifiedProcessModelId || ''}
         saveDiagram={saveDiagram}
+        saveTooltip={unsavedChangesSaveTooltip}
         navigationStack={navigationStack}
         onNavigate={(index) => {
           const item = navigationStack[index];
@@ -1289,25 +1298,6 @@ export default function ProcessModelEditDiagram() {
         >
           {t('file_saved_message')}
         </Notification>
-      );
-    }
-    return null;
-  };
-
-  const unsavedChangesMessage = () => {
-    if (diagramHasChanges) {
-      return (
-        <Can I="PUT" a={targetUris.processModelFileShowPath} ability={ability}>
-          <Notification
-            title={t('diagram_notifications_unsaved_changes_title')}
-            type="error"
-            anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-            data-testid="process-model-file-changed"
-            hideCloseButton
-          >
-            {t('diagram_notifications_unsaved_changes_message')}
-          </Notification>
-        </Can>
       );
     }
     return null;
@@ -1406,7 +1396,6 @@ export default function ProcessModelEditDiagram() {
 
         {pageModals()}
 
-        {unsavedChangesMessage()}
         {messageModelWarning()}
         {saveFileMessage()}
         {appropriateEditor()}


### PR DESCRIPTION
It used to be in the top right, which covered part of the Save button. Then it moved to the lower right, which in some cases covered parts of the properties panel. Now it doesn't cover anything, since it has its own space next to the Save button. The zoom controls move to the left to accommodate.