### PR TITLE
ignore expected error on process instance resume attempts

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/exceptions/api_error.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/exceptions/api_error.py
@@ -256,6 +256,8 @@ def should_notify_sentry(exception: Exception) -> bool:
         # when someone is looking for a process instance that doesn't exist or that they don't have access to
         if exception.error_code == "process_instance_cannot_be_found":
             return False
+        if exception.error_code == "process_instance_has_error_tasks":
+            return False
     if isinstance(exception, NotAuthorizedError):
         return False
 

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_monitoring_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_monitoring_service.py
@@ -104,6 +104,17 @@ class TestMonitoringService(unittest.TestCase):
             )
         )
 
+    def test_process_instance_has_error_tasks_api_error_is_not_captured(self) -> None:
+        self.assertFalse(
+            should_capture_exception_in_sentry(
+                ApiError(
+                    error_code="process_instance_has_error_tasks",
+                    message="Cannot resume a process instance while it has errored tasks.",
+                    status_code=400,
+                )
+            )
+        )
+
     def test_not_authorized_error_is_not_captured(self) -> None:
         self.assertFalse(should_capture_exception_in_sentry(NotAuthorizedError()))
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary error reporting for expected process-instance errors, preventing them from being captured in monitoring systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->