### PR TITLE
show the timezone explicitly in datetime tooltips

### DIFF
--- a/spiffworkflow-frontend/src/components/CellRenderer.tsx
+++ b/spiffworkflow-frontend/src/components/CellRenderer.tsx
@@ -1,7 +1,7 @@
 // react doesn't like the name "useTheme" but we don't control that
 /* eslint-disable react-hooks/rules-of-hooks */
 import { Chip, Stack, Typography, useTheme } from '@mui/material';
-import DateAndTimeService from '../services/DateAndTimeService';
+import FormattedDateTime from './FormattedDateTime';
 
 /** Used by the Processes datagrid in Dashboards to render things like chips on cells, etc. */
 export default function CellRenderer({
@@ -60,8 +60,7 @@ export default function CellRenderer({
         }}
       >
         <Typography variant="body2" title={title}>
-          {DateAndTimeService.convertSecondsToFormattedDateTime(data.value) ||
-            '-'}
+          <FormattedDateTime seconds={data.value} />
         </Typography>
       </Stack>
     );
@@ -76,7 +75,7 @@ export default function CellRenderer({
         }}
       >
         <Typography variant="body2" title={title}>
-          {DateAndTimeService.convertSecondsToFormattedDateTime(data.value)}
+          <FormattedDateTime seconds={data.value} />
         </Typography>
       </Stack>
     );

--- a/spiffworkflow-frontend/src/components/FormattedDateTime.tsx
+++ b/spiffworkflow-frontend/src/components/FormattedDateTime.tsx
@@ -1,0 +1,34 @@
+import DateAndTimeService from '../services/DateAndTimeService';
+import SpiffTooltip from './SpiffTooltip';
+
+type OwnProps = {
+  seconds: number | null | undefined;
+  placeholder?: string;
+};
+
+/**
+ * Renders a formatted date/time and, on hover, shows a tooltip that spells out
+ * the timezone explicitly (e.g. "2024-05-12 21:37:00 (Europe/Berlin, GMT+2)")
+ * so it is always obvious what timezone a datetime is in. See issue #1546.
+ */
+export default function FormattedDateTime({
+  seconds,
+  placeholder = '-',
+}: OwnProps) {
+  const formattedDateTime =
+    seconds == null
+      ? null
+      : DateAndTimeService.convertSecondsToFormattedDateTime(seconds);
+  if (!formattedDateTime) {
+    return <span>{placeholder}</span>;
+  }
+  const formattedDateTimeWithTimezone =
+    DateAndTimeService.convertSecondsToFormattedDateTimeWithTimezone(
+      seconds as number,
+    ) || formattedDateTime;
+  return (
+    <SpiffTooltip title={formattedDateTimeWithTimezone}>
+      <span>{formattedDateTime}</span>
+    </SpiffTooltip>
+  );
+}

--- a/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
+++ b/spiffworkflow-frontend/src/components/ProcessInstanceListTable.tsx
@@ -35,6 +35,7 @@ import {
   SpiffTableHeader,
 } from '../interfaces';
 import DateAndTimeService from '../services/DateAndTimeService';
+import FormattedDateTime from './FormattedDateTime';
 import HttpService from '../services/HttpService';
 import UserService from '../services/UserService';
 import PaginationForTable from './PaginationForTable';
@@ -321,7 +322,7 @@ export default function ProcessInstanceListTable({
   };
 
   const formatSecondsForDisplay = (_row: ProcessInstance, seconds: any) => {
-    return DateAndTimeService.convertSecondsToFormattedDateTime(seconds) || '-';
+    return <FormattedDateTime seconds={seconds} />;
   };
   const defaultFormatter = (_row: ProcessInstance, value: any) => {
     return value;

--- a/spiffworkflow-frontend/src/components/ProcessInstanceLogList.tsx
+++ b/spiffworkflow-frontend/src/components/ProcessInstanceLogList.tsx
@@ -39,6 +39,7 @@ import {
   errorForDisplayFromProcessInstanceErrorDetail,
 } from './ErrorDisplay';
 import DateAndTimeService from '../services/DateAndTimeService';
+import FormattedDateTime from './FormattedDateTime';
 
 type OwnProps = {
   variant: string; // 'all' or 'for-me'
@@ -331,9 +332,7 @@ export default function ProcessInstanceLogList({
 
     let timestampComponent = (
       <TableCell>
-        {DateAndTimeService.convertSecondsToFormattedDateTime(
-          logEntry.timestamp,
-        )}
+        <FormattedDateTime seconds={logEntry.timestamp} />
       </TableCell>
     );
     if (logEntry.spiff_task_guid && logEntry.event_type !== 'task_cancelled') {

--- a/spiffworkflow-frontend/src/components/ProcessInstanceLogList.tsx
+++ b/spiffworkflow-frontend/src/components/ProcessInstanceLogList.tsx
@@ -342,7 +342,11 @@ export default function ProcessInstanceLogList({
             reloadDocument
             data-testid="process-instance-show-link"
             to={`${processInstanceShowPageBaseUrl}/${logEntry.process_instance_id}/${logEntry.spiff_task_guid}`}
-            title={t('view_state_when_task_was_completed')}
+            title={`${t('view_state_when_task_was_completed')} — ${
+              DateAndTimeService.convertSecondsToFormattedDateTimeWithTimezone(
+                logEntry.timestamp,
+              ) ?? ''
+            }`}
           >
             {DateAndTimeService.convertSecondsToFormattedDateTime(
               logEntry.timestamp,

--- a/spiffworkflow-frontend/src/components/TableCellWithTimeAgoInWords.tsx
+++ b/spiffworkflow-frontend/src/components/TableCellWithTimeAgoInWords.tsx
@@ -16,8 +16,9 @@ export default function TableCellWithTimeAgoInWords({
   return (
     <td
       title={
-        DateAndTimeService.convertSecondsToFormattedDateTime(timeInSeconds) ||
-        '-'
+        DateAndTimeService.convertSecondsToFormattedDateTimeWithTimezone(
+          timeInSeconds,
+        ) || '-'
       }
       onClick={onClick}
       onKeyDown={onKeyDown}

--- a/spiffworkflow-frontend/src/components/TaskListTable.tsx
+++ b/spiffworkflow-frontend/src/components/TaskListTable.tsx
@@ -25,6 +25,7 @@ import { PaginationObject, ProcessInstanceTask, Task } from '../interfaces';
 import CustomForm from './CustomForm';
 import InstructionsForEndUser from './InstructionsForEndUser';
 import DateAndTimeService from '../services/DateAndTimeService';
+import FormattedDateTime from './FormattedDateTime';
 
 type OwnProps = {
   apiPath: string;
@@ -359,9 +360,9 @@ export default function TaskListTable({
     if (showDateStarted) {
       rowElements.push(
         <TableCell>
-          {DateAndTimeService.convertSecondsToFormattedDateTime(
-            processInstanceTask.created_at_in_seconds,
-          ) || '-'}
+          <FormattedDateTime
+            seconds={processInstanceTask.created_at_in_seconds}
+          />
         </TableCell>,
       );
     }
@@ -369,7 +370,7 @@ export default function TaskListTable({
       rowElements.push(
         <TableCell
           title={
-            DateAndTimeService.convertSecondsToFormattedDateTime(
+            DateAndTimeService.convertSecondsToFormattedDateTimeWithTimezone(
               processInstanceTask.updated_at_in_seconds,
             ) || '-'
           }

--- a/spiffworkflow-frontend/src/components/TaskTable.tsx
+++ b/spiffworkflow-frontend/src/components/TaskTable.tsx
@@ -135,7 +135,7 @@ export default function TaskTable({
             color="textSecondary"
             sx={{ display: 'flex', alignItems: 'center' }}
             title={
-              DateAndTimeService.convertSecondsToFormattedDateTime(
+              DateAndTimeService.convertSecondsToFormattedDateTimeWithTimezone(
                 entry.created_at_in_seconds,
               ) || '-'
             }
@@ -159,7 +159,7 @@ export default function TaskTable({
             color="textSecondary"
             sx={{ display: 'flex', alignItems: 'center' }}
             title={
-              DateAndTimeService.convertSecondsToFormattedDateTime(
+              DateAndTimeService.convertSecondsToFormattedDateTimeWithTimezone(
                 entry.updated_at_in_seconds,
               ) || '-'
             }

--- a/spiffworkflow-frontend/src/components/messages/MessageInstanceList.tsx
+++ b/spiffworkflow-frontend/src/components/messages/MessageInstanceList.tsx
@@ -40,6 +40,7 @@ import HttpService from '../../services/HttpService';
 import { FormatProcessModelDisplayName } from '../MiniComponents';
 import { ProcessModel, MessageInstance, MessageModel } from '../../interfaces';
 import DateAndTimeService from '../../services/DateAndTimeService';
+import FormattedDateTime from '../FormattedDateTime';
 import SpiffTooltip from '../SpiffTooltip';
 
 import ProcessModelSearch from '../ProcessModelSearch';
@@ -446,9 +447,7 @@ export default function MessageInstanceList({ processInstanceId }: OwnProps) {
           </TableCell>
           <TableCell>{getProcessStatus(row.status)}</TableCell>
           <TableCell>
-            {DateAndTimeService.convertSecondsToFormattedDateTime(
-              row.created_at_in_seconds,
-            )}
+            <FormattedDateTime seconds={row.created_at_in_seconds} />
           </TableCell>
         </TableRow>
       );

--- a/spiffworkflow-frontend/src/services/DateAndTimeService.test.tsx
+++ b/spiffworkflow-frontend/src/services/DateAndTimeService.test.tsx
@@ -43,6 +43,20 @@ test('it can keep the correct date when converting seconds to date', () => {
   expect(dateString).toEqual('2022-10-21');
 });
 
+test('it spells out the timezone when formatting a datetime with timezone', () => {
+  const seconds = 1666325400;
+  const formattedDateTime =
+    DateAndTimeService.convertSecondsToFormattedDateTime(seconds);
+  const withTimezone =
+    DateAndTimeService.convertSecondsToFormattedDateTimeWithTimezone(seconds);
+  expect(withTimezone).not.toBeNull();
+  // the visible date/time is unchanged, with the timezone appended in parentheses
+  expect((withTimezone as string).startsWith(formattedDateTime as string)).toBe(
+    true,
+  );
+  expect(withTimezone).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \(.+\)$/);
+});
+
 test('it can properly format a duration', () => {
   expect(DateAndTimeService.formatDurationForDisplay('0')).toEqual('0s');
   expect(DateAndTimeService.formatDurationForDisplay('60')).toEqual('1m');

--- a/spiffworkflow-frontend/src/services/DateAndTimeService.tsx
+++ b/spiffworkflow-frontend/src/services/DateAndTimeService.tsx
@@ -119,6 +119,47 @@ const convertSecondsToFormattedDateTime = (seconds: number) => {
   return null;
 };
 
+// The name of the viewer's timezone, e.g. "Europe/Berlin".
+const getUserTimeZoneName = (): string => {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || '';
+  } catch {
+    return '';
+  }
+};
+
+// The short GMT offset for a given moment, e.g. "GMT+2" (accounts for daylight saving).
+const getTimeZoneShortOffset = (dateObject: Date): string => {
+  try {
+    const parts = new Intl.DateTimeFormat(undefined, {
+      timeZoneName: 'shortOffset',
+    }).formatToParts(dateObject);
+    const timeZonePart = parts.find((part) => part.type === 'timeZoneName');
+    return timeZonePart ? timeZonePart.value : '';
+  } catch {
+    return '';
+  }
+};
+
+// Same formatted date/time as convertSecondsToFormattedDateTime, but with the
+// timezone spelled out explicitly, e.g. "2024-05-12 21:37:00 (Europe/Berlin, GMT+2)".
+// Used in hover tooltips so it is always obvious what timezone a datetime is in (issue #1546).
+const convertSecondsToFormattedDateTimeWithTimezone = (seconds: number) => {
+  const dateObject = convertSecondsToDateObject(seconds);
+  if (!dateObject) {
+    return null;
+  }
+  const formattedDateTime = format(dateObject, DATE_TIME_FORMAT);
+  const timeZoneParts = [
+    getUserTimeZoneName(),
+    getTimeZoneShortOffset(dateObject),
+  ].filter((part) => part !== '');
+  if (timeZoneParts.length === 0) {
+    return formattedDateTime;
+  }
+  return `${formattedDateTime} (${timeZoneParts.join(', ')})`;
+};
+
 const convertDateObjectToFormattedHoursMinutes = (dateObject: Date) => {
   if (dateObject) {
     return format(dateObject, TIME_FORMAT_HOURS_MINUTES);
@@ -262,6 +303,7 @@ const DateAndTimeService = {
   convertSecondsToDateObject,
   convertSecondsToFormattedDateString,
   convertSecondsToFormattedDateTime,
+  convertSecondsToFormattedDateTimeWithTimezone,
   convertSecondsToFormattedTimeHoursMinutes,
   convertStringToDate,
   dateStringToYMDFormat,

--- a/spiffworkflow-frontend/src/views/ProcessInstanceShow.tsx
+++ b/spiffworkflow-frontend/src/views/ProcessInstanceShow.tsx
@@ -98,6 +98,7 @@ import {
 } from '../components/ErrorDisplay';
 import { Notification } from '../components/Notification';
 import DateAndTimeService from '../services/DateAndTimeService';
+import FormattedDateTime from '../components/FormattedDateTime';
 import ProcessInstanceCurrentTaskInfo from '../components/ProcessInstanceCurrentTaskInfo';
 import useKeyboardShortcut from '../hooks/useKeyboardShortcut';
 import useProcessInstanceNavigate from '../hooks/useProcessInstanceNavigate';
@@ -548,9 +549,7 @@ export default function ProcessInstanceShow({ variant }: OwnProps) {
           {lastUpdatedTimeLabel}:
         </Typography>
         <Typography component="dd" variant="body2">
-          {DateAndTimeService.convertSecondsToFormattedDateTime(
-            lastUpdatedTime || 0,
-          ) || 'N/A'}
+          <FormattedDateTime seconds={lastUpdatedTime || 0} placeholder="N/A" />
         </Typography>
       </dl>
     );
@@ -620,9 +619,9 @@ export default function ProcessInstanceShow({ variant }: OwnProps) {
               {t('started')}:
             </Typography>
             <Typography component="dd" variant="body2">
-              {DateAndTimeService.convertSecondsToFormattedDateTime(
-                processInstance.start_in_seconds || 0,
-              )}
+              <FormattedDateTime
+                seconds={processInstance.start_in_seconds || 0}
+              />
             </Typography>
           </dl>
           {lastUpdatedTimeTag}
@@ -1579,7 +1578,7 @@ export default function ProcessInstanceShow({ variant }: OwnProps) {
               {t('next_retry_attempt')}:
             </Typography>
             <Typography component="dd" variant="body2">
-              {formattedRetryAt}
+              <FormattedDateTime seconds={retryAtInSeconds} />
             </Typography>
           </dl>
         ) : null}
@@ -1628,9 +1627,9 @@ export default function ProcessInstanceShow({ variant }: OwnProps) {
               <Grid size={{ xs: 11 }}>
                 <div className={`task-instance-modal-row-item ${buttonClass}`}>
                   {index + 1} {': '}
-                  {DateAndTimeService.convertSecondsToFormattedDateTime(
-                    task.properties_json.last_state_change,
-                  )}{' '}
+                  <FormattedDateTime
+                    seconds={task.properties_json.last_state_change}
+                  />{' '}
                   {' - '} {task.state}
                 </div>
               </Grid>


### PR DESCRIPTION
Fixes #1546 by showing the timezone explicitly in a tooltip when hovering over a date/time in the GUI.

Adds a small shared helper + a reusable FormattedDateTime component, applied across the date/time displays; includes a unit test.
