### PR TITLE
Add 'Last saved' indicator to the BPMN and DMN editors

### DIFF
--- a/spiffworkflow-frontend/packages/bpmn-js-spiffworkflow-react/src/components/DiagramActionBar.tsx
+++ b/spiffworkflow-frontend/packages/bpmn-js-spiffworkflow-react/src/components/DiagramActionBar.tsx
@@ -26,6 +26,7 @@ type DiagramActionBarProps = {
   referencesButton?: ReactNode;
   processInstanceRun?: ReactNode;
   activeUserElement?: ReactNode;
+  lastSavedElement?: ReactNode;
 };
 
 export default function DiagramActionBar({
@@ -52,6 +53,7 @@ export default function DiagramActionBar({
   referencesButton,
   processInstanceRun,
   activeUserElement,
+  lastSavedElement,
 }: DiagramActionBarProps) {
   const canRenderSaveButton = Boolean(canSave && onSave);
   const shouldShowSaveAttention =
@@ -106,6 +108,7 @@ export default function DiagramActionBar({
     >
       {saveAttentionMessage}
       {saveButton}
+      {lastSavedElement || null}
       {processInstanceRun || null}
       {canDelete ? deleteButton || null : null}
       {canSetPrimary && onSetPrimary ? (

--- a/spiffworkflow-frontend/src/components/DiagramActionBar.test.tsx
+++ b/spiffworkflow-frontend/src/components/DiagramActionBar.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import DiagramActionBar from '../../packages/bpmn-js-spiffworkflow-react/src/components/DiagramActionBar';
+
+// The "Last saved" indicator (issue #1642) is passed into the action bar as a
+// ready-to-render node via the lastSavedElement slot.
+describe('DiagramActionBar lastSavedElement', () => {
+  const requiredProps = {
+    saveLabel: 'Save',
+    setPrimaryLabel: 'Set as primary file',
+  };
+
+  it('renders the last saved element when provided', () => {
+    render(
+      <DiagramActionBar
+        {...requiredProps}
+        lastSavedElement={<span>Last saved: 2026-07-21 14:03:00</span>}
+      />,
+    );
+    expect(
+      screen.getByText('Last saved: 2026-07-21 14:03:00'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders nothing for the indicator when no last saved element is given', () => {
+    render(<DiagramActionBar {...requiredProps} />);
+    expect(screen.queryByText(/Last saved:/)).not.toBeInTheDocument();
+  });
+});

--- a/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
+++ b/spiffworkflow-frontend/src/components/ReactDiagramEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from 'react';
-import { Button, Box } from '@mui/material';
+import { Button, Box, Typography } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
@@ -27,6 +27,7 @@ import ProcessInstanceRun from './ProcessInstanceRun';
 import ConfirmButton from './ConfirmButton';
 import { TASK_METADATA } from '../config';
 import { spiffBpmnApiService } from '../services/SpiffBpmnApiService';
+import DateAndTimeService from '../services/DateAndTimeService';
 
 type OwnProps = {
   modifiedProcessModelId: string;
@@ -62,6 +63,7 @@ type OwnProps = {
   url?: string;
   navigationStack?: DiagramNavigationItem[];
   onNavigate?: (index: number) => void;
+  lastSaved?: string | null;
 };
 
 export default function ReactDiagramEditor({
@@ -98,6 +100,7 @@ export default function ReactDiagramEditor({
   url,
   navigationStack,
   onNavigate,
+  lastSaved,
 }: OwnProps) {
   const bpmnEditorRef = useRef<BpmnEditorRef>(null);
   const [showingReferences, setShowingReferences] = useState(false);
@@ -209,6 +212,33 @@ export default function ReactDiagramEditor({
     return null;
   };
 
+  // Shows the process model author when the current file was last saved to
+  // disk. Renders nothing until there is a valid timestamp (e.g. a brand new,
+  // never-saved file). See issue #1642.
+  const buildLastSavedElement = () => {
+    if (!lastSaved) {
+      return null;
+    }
+    const lastSavedSeconds = Date.parse(lastSaved) / 1000;
+    if (Number.isNaN(lastSavedSeconds)) {
+      return null;
+    }
+    const formattedDateTime =
+      DateAndTimeService.convertSecondsToFormattedDateTime(lastSavedSeconds);
+    if (!formattedDateTime) {
+      return null;
+    }
+    return (
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        data-testid="diagram-last-saved"
+      >
+        {t('diagram_last_saved', { datetime: formattedDateTime })}
+      </Typography>
+    );
+  };
+
   const userActionOptions = () => {
     if (diagramType === 'readonly') {
       return null;
@@ -226,6 +256,8 @@ export default function ReactDiagramEditor({
     const processInstanceRun = processModel ? (
       <ProcessInstanceRun processModel={processModel} />
     ) : null;
+
+    const lastSavedElement = buildLastSavedElement();
 
     return (
       <DiagramActionBar
@@ -245,6 +277,7 @@ export default function ReactDiagramEditor({
         onSetPrimary={handleSetPrimaryFile}
         setPrimaryLabel={t('diagram_set_as_primary_file')}
         referencesButton={getReferencesButton()}
+        lastSavedElement={lastSavedElement}
         processInstanceRun={processInstanceRun}
         activeUserElement={
           ability.can('PUT', targetUris.processModelFileShowPath)

--- a/spiffworkflow-frontend/src/locales/en_us/translation.json
+++ b/spiffworkflow-frontend/src/locales/en_us/translation.json
@@ -107,6 +107,7 @@
   "diagram_file_name_editor_label": "File Name:",
   "diagram_file_name_editor_title": "Process Model File Name",
   "diagram_json_schema_editor_title": "Edit JSON Schema",
+  "diagram_last_saved": "Last saved: {{datetime}}",
   "diagram_markdown_editor_title": "Edit Markdown",
   "diagram_message_editor_close": "Close (this does not save)",
   "diagram_message_editor_description": "Create or edit a message and manage its correlation properties",

--- a/spiffworkflow-frontend/src/views/ProcessModelEditDiagram.tsx
+++ b/spiffworkflow-frontend/src/views/ProcessModelEditDiagram.tsx
@@ -1219,6 +1219,7 @@ export default function ProcessModelEditDiagram() {
           modifiedProcessModelId={modifiedProcessModelId || ''}
           saveDiagram={saveDiagram}
           saveTooltip={unsavedChangesSaveTooltip}
+          lastSaved={processModelFile?.last_modified}
           navigationStack={navigationStack}
           onNavigate={(index) => {
             const item = navigationStack[index];
@@ -1274,6 +1275,7 @@ export default function ProcessModelEditDiagram() {
         modifiedProcessModelId={modifiedProcessModelId || ''}
         saveDiagram={saveDiagram}
         saveTooltip={unsavedChangesSaveTooltip}
+        lastSaved={processModelFile?.last_modified}
         navigationStack={navigationStack}
         onNavigate={(index) => {
           const item = navigationStack[index];


### PR DESCRIPTION
Add "Last saved" indicator to the BPMN and DMN editors

Fixes #1642.

Adds a "Last saved: <date time>" label next to the Save button in the diagram editor toolbar, so a process author can see when their diagram was last saved. Uses the file's existing on-disk timestamp and the app's standard date/time formatting. Shown only once a file has been saved, and it updates on each save.
