### PR TITLE
Support completing timer events in recordings

### DIFF
--- a/spiff-arena-common/pyproject.toml
+++ b/spiff-arena-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spiff-arena-common"
-version = "0.1.42"
+version = "0.1.43"
 description = "Shared Python utilities for Spiff Arena frontend and backend components"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/spiff-arena-common/src/spiff_arena_common/runner.py
+++ b/spiff-arena-common/src/spiff_arena_common/runner.py
@@ -562,7 +562,27 @@ def _waiting_recorded_timer(workflow, entry):
     )
 
 
-def _replay_recorded_timer(workflow, reference_task, fixture_cache, iteration):
+def _is_unittest_fixture_checkpoint(task):
+    if task is None:
+        return True
+    if not task.task_spec.__class__.__name__.startswith("Custom"):
+        return False
+    return not (
+        isinstance(task.task_spec, CustomStartEvent)
+        and not isinstance(
+            task.task_spec.event_definition,
+            BpmnMessageEventDefinition,
+        )
+    )
+
+
+def _replay_recorded_timer(
+    workflow,
+    reference_task,
+    fixture_cache,
+    iteration,
+    diagnose_missing,
+):
     cursor = _unittest_fixture_cursor(workflow, reference_task, fixture_cache)
     entry = cursor.get("entry")
     if not entry or entry.get("force_timer") is not True:
@@ -570,6 +590,8 @@ def _replay_recorded_timer(workflow, reference_task, fixture_cache, iteration):
 
     timer_task = _waiting_recorded_timer(workflow, entry)
     if timer_task is None:
+        if not diagnose_missing:
+            return False, None
         print_unittest_break(
             "recorded_timer_not_waiting",
             iteration=iteration,
@@ -637,20 +659,29 @@ def _advance_workflow(workflow, task, strategy_name, compress_response=False, se
         task = next_task(workflow, TaskState.READY, completed_task)
         if not task:
             task = next_task(workflow, TaskState.READY)
-        if not task and strategy_name == "unittest":
-            handled_timer, timer_task = _replay_recorded_timer(
-                workflow,
-                completed_task,
-                fixture_cache,
-                iters,
-            )
-            if handled_timer:
+        recorded_timer_error = False
+        if strategy_name == "unittest":
+            while True:
+                reference_task = task or completed_task
+                handled_timer, timer_task = _replay_recorded_timer(
+                    workflow,
+                    reference_task,
+                    fixture_cache,
+                    iters,
+                    _is_unittest_fixture_checkpoint(task),
+                )
+                if not handled_timer:
+                    break
                 if timer_task is None:
+                    recorded_timer_error = True
                     break
                 completed_task = timer_task
                 task = next_task(workflow, TaskState.READY, completed_task)
                 if not task:
                     task = next_task(workflow, TaskState.READY)
+
+        if recorded_timer_error:
+            break
         if not task:
             if strategy_name == "unittest" and not workflow.completed:
                 print_unittest_break(

--- a/spiff-arena-common/src/spiff_arena_common/runner.py
+++ b/spiff-arena-common/src/spiff_arena_common/runner.py
@@ -485,22 +485,116 @@ def print_progress(iteration):
         "iteration": iteration,
     }, sort_keys=True), flush=True)
 
+
+def _unittest_fixture_cursor(workflow, task, cache):
+    workflow_data = getattr(workflow, "data", {})
+    fixture_file = task.data.get("spiff_testFixture_file")
+    if fixture_file:
+        if cache.get("file") != fixture_file or cache.get("recording") is None:
+            try:
+                with open(fixture_file) as f:
+                    cache["recording"] = json.load(f)
+                cache["file"] = fixture_file
+            except Exception as e:
+                raise Exception(f"Failed to load test fixture from {fixture_file}: {e}") from e
+
+        stack = cache["recording"].get("pendingTaskStack", [])
+        index = workflow_data.get("spiff_testFixture_index", len(stack) - 1)
+        if index < 0:
+            return {
+                "reason": "fixture_exhausted",
+                "file": fixture_file,
+                "index": index,
+                "stack": stack,
+            }
+        if index >= len(stack):
+            return {
+                "reason": "fixture_index_out_of_bounds",
+                "file": fixture_file,
+                "index": index,
+                "stack": stack,
+            }
+        return {
+            "entry": stack[index],
+            "file": fixture_file,
+            "index": index,
+            "stack": stack,
+        }
+
+    inline_fixture = (
+        task.data.get("spiff_testFixture")
+        or workflow_data.get("spiff_testFixture", {})
+    )
+    stack = inline_fixture.get("pendingTaskStack", [])
+    if not stack:
+        return {
+            "reason": "missing_inline_fixture",
+            "file": None,
+            "index": None,
+            "stack": stack,
+        }
+    return {
+        "entry": stack[-1],
+        "file": None,
+        "index": len(stack) - 1,
+        "stack": stack,
+    }
+
+
+def _consume_unittest_fixture(workflow, cursor):
+    if cursor["file"]:
+        workflow.data["spiff_testFixture_index"] = cursor["index"] - 1
+    else:
+        cursor["stack"].pop()
+
+
+def _waiting_recorded_timer(workflow, entry):
+    return next(
+        (
+            task
+            for task in workflow.get_tasks(
+                task_filter=TaskFilter(state=TaskState.WAITING)
+            )
+            if task.task_spec.bpmn_id == entry.get("id")
+            and _is_timer_event_task(task)
+        ),
+        None,
+    )
+
+
+def _replay_recorded_timer(workflow, reference_task, fixture_cache, iteration):
+    cursor = _unittest_fixture_cursor(workflow, reference_task, fixture_cache)
+    entry = cursor.get("entry")
+    if not entry or entry.get("force_timer") is not True:
+        return False, None
+
+    timer_task = _waiting_recorded_timer(workflow, entry)
+    if timer_task is None:
+        print_unittest_break(
+            "recorded_timer_not_waiting",
+            iteration=iteration,
+            expected_task_id=entry.get("id"),
+            **(
+                {
+                    "fixture_file": cursor["file"],
+                    "fixture_index": cursor["index"],
+                }
+                if cursor["file"]
+                else {}
+            ),
+        )
+        return True, None
+
+    timer_task.data.update(entry.get("data", {}))
+    _force_timer_event(timer_task)
+    _consume_unittest_fixture(workflow, cursor)
+    return True, timer_task
+
+
 def _advance_workflow(workflow, task, strategy_name, compress_response=False, session_id=None):
     iters = 0
     lazy_loads_list = None
-
-    # Cache fixture file for unittest strategy to avoid repeated file I/O
-    cached_fixture = None
-    cached_fixture_file = None
-    if strategy_name == "unittest" and task:
-        fixture_file = task.data.get("spiff_testFixture_file")
-        if fixture_file:
-            try:
-                with open(fixture_file) as f:
-                    cached_fixture = json.load(f)
-                cached_fixture_file = fixture_file
-            except Exception as e:
-                raise Exception(f"Failed to load test fixture from {fixture_file}: {e}") from e
+    fixture_cache = {"file": None, "recording": None}
 
     # TODO: make maxIters part of strategy, add cycle detection
     while task and iters < 5000:
@@ -521,7 +615,11 @@ def _advance_workflow(workflow, task, strategy_name, compress_response=False, se
 
         # Only check for missing lazy loads if not using file-based test fixtures
         # (file fixtures preload all specs recursively, so this check is redundant and expensive)
-        if not (strategy_name == "unittest" and cached_fixture_file):
+        fixture_file = task.data.get("spiff_testFixture_file")
+        if not (
+            strategy_name == "unittest"
+            and (fixture_file or fixture_cache["file"])
+        ):
             lazy_loads_list = lazy_loads(workflow)
             if any(spec not in workflow.subprocess_specs for spec in lazy_loads_list):
                 if strategy_name == "unittest":
@@ -539,6 +637,20 @@ def _advance_workflow(workflow, task, strategy_name, compress_response=False, se
         task = next_task(workflow, TaskState.READY, completed_task)
         if not task:
             task = next_task(workflow, TaskState.READY)
+        if not task and strategy_name == "unittest":
+            handled_timer, timer_task = _replay_recorded_timer(
+                workflow,
+                completed_task,
+                fixture_cache,
+                iters,
+            )
+            if handled_timer:
+                if timer_task is None:
+                    break
+                completed_task = timer_task
+                task = next_task(workflow, TaskState.READY, completed_task)
+                if not task:
+                    task = next_task(workflow, TaskState.READY)
         if not task:
             if strategy_name == "unittest" and not workflow.completed:
                 print_unittest_break(
@@ -562,84 +674,54 @@ def _advance_workflow(workflow, task, strategy_name, compress_response=False, se
                 if isinstance(task.task_spec, CustomStartEvent) and not isinstance(task.task_spec.event_definition, BpmnMessageEventDefinition):
                     pass
                 else:
-                    # Check for file-based fixture first (ed recording playback)
-                    fixture_file = task.data.get("spiff_testFixture_file")
-                    if fixture_file:
-                        # Use cached fixture data instead of re-reading from disk
-                        if cached_fixture_file != fixture_file or cached_fixture is None:
-                            # Fixture file changed or wasn't cached - shouldn't happen but handle it
-                            try:
-                                with open(fixture_file) as f:
-                                    cached_fixture = json.load(f)
-                                cached_fixture_file = fixture_file
-                            except Exception as e:
-                                raise Exception(f"Failed to load test fixture from {fixture_file}: {e}") from e
+                    cursor = _unittest_fixture_cursor(
+                        workflow,
+                        task,
+                        fixture_cache,
+                    )
+                    reason = cursor.get("reason")
+                    if reason:
+                        print_unittest_break(
+                            reason,
+                            iteration=iters,
+                            task_id=task.task_spec.bpmn_id,
+                            **(
+                                {
+                                    "fixture_file": cursor["file"],
+                                    "fixture_index": cursor["index"],
+                                    **(
+                                        {"fixture_length": len(cursor["stack"])}
+                                        if reason == "fixture_index_out_of_bounds"
+                                        else {}
+                                    ),
+                                }
+                                if cursor["file"]
+                                else {}
+                            ),
+                        )
+                        break
 
-                        stack = cached_fixture.get("pendingTaskStack", [])
+                    expected = cursor["entry"]
+                    if task.task_spec.bpmn_id != expected["id"]:
+                        print_unittest_break(
+                            "fixture_task_mismatch",
+                            iteration=iters,
+                            task_id=task.task_spec.bpmn_id,
+                            expected_task_id=expected["id"],
+                            **(
+                                {
+                                    "fixture_file": cursor["file"],
+                                    "fixture_index": cursor["index"],
+                                }
+                                if cursor["file"]
+                                else {}
+                            ),
+                        )
+                        break
 
-                        if "spiff_testFixture_index" not in workflow.data:
-                            index = len(stack) - 1
-                        else:
-                            index = workflow.data["spiff_testFixture_index"]
-
-                        # If recording is exhausted (index < 0), let task run interactively
-                        if index < 0:
-                            print_unittest_break(
-                                "fixture_exhausted",
-                                iteration=iters,
-                                task_id=task.task_spec.bpmn_id,
-                                fixture_file=fixture_file,
-                                fixture_index=index,
-                            )
-                            break
-
-                        if index >= len(stack):
-                            print_unittest_break(
-                                "fixture_index_out_of_bounds",
-                                iteration=iters,
-                                task_id=task.task_spec.bpmn_id,
-                                fixture_file=fixture_file,
-                                fixture_index=index,
-                                fixture_length=len(stack),
-                            )
-                            break
-
-                        expected = stack[index]
-                        if task.task_spec.bpmn_id != expected["id"]:
-                            print_unittest_break(
-                                "fixture_task_mismatch",
-                                iteration=iters,
-                                task_id=task.task_spec.bpmn_id,
-                                expected_task_id=expected["id"],
-                                fixture_file=fixture_file,
-                                fixture_index=index,
-                            )
-                            break
-
-                        task.run()
-                        task.data.update(expected["data"])
-                        workflow.data["spiff_testFixture_index"] = index - 1
-                    else:
-                        # Fallback to inline fixture (process-models compatibility)
-                        stack = task.data.get("spiff_testFixture", {}).get("pendingTaskStack", [])
-                        if not stack:
-                            print_unittest_break(
-                                "missing_inline_fixture",
-                                iteration=iters,
-                                task_id=task.task_spec.bpmn_id,
-                            )
-                            break
-                        expected = stack.pop()
-                        if task.task_spec.bpmn_id != expected["id"]:
-                            print_unittest_break(
-                                "fixture_task_mismatch",
-                                iteration=iters,
-                                task_id=task.task_spec.bpmn_id,
-                                expected_task_id=expected["id"],
-                            )
-                            break
-                        task.run()
-                        task.data.update(expected["data"])
+                    task.run()
+                    task.data.update(expected["data"])
+                    _consume_unittest_fixture(workflow, cursor)
     return build_response(workflow, None, compress_response=compress_response, lazy_loads_result=lazy_loads_list, session_id=session_id)
 
 def _is_timer_event_task(task):

--- a/spiff-arena-common/tests/spiff_arena_common/test_runner.py
+++ b/spiff-arena-common/tests/spiff_arena_common/test_runner.py
@@ -208,6 +208,94 @@ def timer_boundary_bpmn():
 """
 
 
+def timer_intermediate_bpmn():
+    return """
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_timer_intermediate" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_timer_intermediate" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1"><bpmn:outgoing>Flow_start_timer</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_start_timer" sourceRef="StartEvent_1" targetRef="Timer_1" />
+    <bpmn:intermediateCatchEvent id="Timer_1" name="Wait">
+      <bpmn:incoming>Flow_start_timer</bpmn:incoming><bpmn:outgoing>Flow_timer_script</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerDefinition_1"><bpmn:timeDuration xsi:type="bpmn:tFormalExpression">"PT1H"</bpmn:timeDuration></bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_timer_script" sourceRef="Timer_1" targetRef="Script_1" />
+    <bpmn:scriptTask id="Script_1">
+      <bpmn:incoming>Flow_timer_script</bpmn:incoming><bpmn:outgoing>Flow_script_end</bpmn:outgoing>
+      <bpmn:script>timer_replayed = True</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_script_end" sourceRef="Script_1" targetRef="EndEvent_1" />
+    <bpmn:endEvent id="EndEvent_1"><bpmn:incoming>Flow_script_end</bpmn:incoming></bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>
+"""
+
+
+def test_unittest_replays_recorded_intermediate_timer(tmp_path):
+    fixture_file = tmp_path / "timer-recording.json"
+    fixture_file.write_text(json.dumps({
+        "pendingTaskStack": [
+            {"id": "Timer_1", "data": {}, "force_timer": True},
+        ],
+    }))
+    specs, err = runner.specs_from_xml([("timer.bpmn", timer_intermediate_bpmn())])
+    assert err is None
+
+    result = json.loads(runner.advance_workflow(
+        specs,
+        {},
+        None,
+        "unittest",
+        {"data": {"spiff_testFixture_file": str(fixture_file)}},
+    ))
+
+    assert result["status"] == "ok"
+    assert result["completed"] is True
+    assert result["result"]["timer_replayed"] is True
+    assert result["result"]["spiff_testFixture_index"] == -1
+
+
+def test_unittest_replays_recorded_intermediate_timer_from_inline_fixture():
+    specs, err = runner.specs_from_xml([("timer.bpmn", timer_intermediate_bpmn())])
+    assert err is None
+
+    result = json.loads(runner.advance_workflow(
+        specs,
+        {},
+        None,
+        "unittest",
+        {"data": {"spiff_testFixture": {"pendingTaskStack": [
+            {"id": "Timer_1", "data": {}, "force_timer": True},
+        ]}}},
+    ))
+
+    assert result["completed"] is True
+    assert result["result"]["timer_replayed"] is True
+
+
+def test_unittest_reports_recorded_timer_that_is_not_waiting(tmp_path, capsys):
+    fixture_file = tmp_path / "bad-timer-recording.json"
+    fixture_file.write_text(json.dumps({
+        "pendingTaskStack": [
+            {"id": "Missing_Timer", "data": {}, "force_timer": True},
+        ],
+    }))
+    specs, err = runner.specs_from_xml([("timer.bpmn", timer_intermediate_bpmn())])
+    assert err is None
+
+    result = json.loads(runner.advance_workflow(
+        specs,
+        {},
+        None,
+        "unittest",
+        {"data": {"spiff_testFixture_file": str(fixture_file)}},
+    ))
+
+    event = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert event["reason"] == "recorded_timer_not_waiting"
+    assert event["expected_task_id"] == "Missing_Timer"
+    assert "spiff_testFixture_index" not in result["pending_tasks"][0]["data"]
+
+
 def advance_to_waiting_timer_boundary(specs, session_id="timer-boundary-test"):
     first_step = json.loads(
         runner.advance_workflow(specs, None, None, "oneAtATime", None, session_id=session_id)

--- a/spiff-arena-common/tests/spiff_arena_common/test_runner.py
+++ b/spiff-arena-common/tests/spiff_arena_common/test_runner.py
@@ -296,6 +296,46 @@ def test_unittest_reports_recorded_timer_that_is_not_waiting(tmp_path, capsys):
     assert "spiff_testFixture_index" not in result["pending_tasks"][0]["data"]
 
 
+def test_unittest_prioritizes_recorded_boundary_timer(tmp_path, capsys):
+    fixture_file = tmp_path / "boundary-recording.json"
+    fixture_file.write_text(json.dumps({
+        "pendingTaskStack": [
+            {"id": "Boundary_timer", "data": {}, "force_timer": True},
+        ],
+    }))
+    specs, err = runner.specs_from_xml([("boundary.bpmn", timer_boundary_bpmn())])
+    assert err is None
+
+    result = json.loads(runner.advance_workflow(
+        specs,
+        {},
+        None,
+        "unittest",
+        {"data": {"spiff_testFixture_file": str(fixture_file)}},
+    ))
+
+    assert result["status"] == "ok"
+    assert result["state"]["tasks"]
+    assert any(
+        task["task_spec"] == "Boundary_timer"
+        and task["state"] == TaskState.COMPLETED
+        for task in result["state"]["tasks"].values()
+    )
+    assert any(
+        task["task_spec"] == "Script_timer_fired"
+        and task["state"] == TaskState.COMPLETED
+        for task in result["state"]["tasks"].values()
+    )
+    assert any(
+        task["task_spec"]["bpmn_id"] == "UserTask_1"
+        and task["state"] == TaskState.READY
+        for task in result["pending_tasks"]
+    )
+    event = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert event["reason"] == "fixture_exhausted"
+    assert event["fixture_index"] == -1
+
+
 def advance_to_waiting_timer_boundary(specs, session_id="timer-boundary-test"):
     first_step = json.loads(
         runner.advance_workflow(specs, None, None, "oneAtATime", None, session_id=session_id)

--- a/uv.lock
+++ b/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "spiff-arena-common"
-version = "0.1.42"
+version = "0.1.43"
 source = { editable = "spiff-arena-common" }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
Previously a recording would always break when a timer event was encountered. Now if the recording included its completion, it will be automatically completed.