### PR TITLE
do not send sentries for anything without an exception object 

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/monitoring_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/monitoring_service.py
@@ -103,20 +103,39 @@ def scrub_transaction_event(event: dict[str, Any], _hint: Any) -> dict[str, Any]
     return event
 
 
+def filter_sentry_error_event(event: dict[str, Any], hint: dict[str, Any]) -> dict[str, Any] | None:
+    """Keep exception captures while dropping message-only logs and Flask duplicates."""
+    log_record = hint.get("log_record")
+    if log_record is not None:
+        # Plain error logs remain application logs and Sentry breadcrumbs, but do not create Sentry issues.
+        # logger.exception() and logger.error(..., exc_info=...) are retained as exception events.
+        exc_info = getattr(log_record, "exc_info", None)
+        if not exc_info or exc_info[0] is None:
+            return None
+
+    exception_values = event.get("exception", {}).get("values", [])
+
+    # we ignore all unhandled flask exceptions for purposes of sentry notification,
+    # because these go through handle_exception, where we capture_exception explicitly.
+    if any(
+        value.get("mechanism", {}).get("type") == "flask" and value.get("mechanism", {}).get("handled") is False
+        for value in exception_values
+    ):
+        return None
+
+    if "exc_info" in hint:
+        _exc_type, exc_value, _tb = hint["exc_info"]
+        if not should_capture_exception_in_sentry(exc_value):
+            return None
+    return event
+
+
 def configure_sentry(app: flask.app.Flask) -> None:
     sentry_dsn = app.config.get("SPIFFWORKFLOW_BACKEND_SENTRY_DSN")
 
     # Skip Sentry initialization if no DSN is configured (e.g., in tests)
     if not sentry_dsn:
         return
-
-    # get rid of NotFound errors
-    def before_send(event: Any, hint: Any) -> Any:
-        if "exc_info" in hint:
-            _exc_type, exc_value, _tb = hint["exc_info"]
-            if not should_capture_exception_in_sentry(exc_value):
-                return None
-        return event
 
     sentry_errors_sample_rate = app.config.get("SPIFFWORKFLOW_BACKEND_SENTRY_ERRORS_SAMPLE_RATE")
     if sentry_errors_sample_rate is None:
@@ -148,7 +167,7 @@ def configure_sentry(app: flask.app.Flask) -> None:
             default_sample_rate=float(sentry_traces_sample_rate),
         ),
         # The profiles_sample_rate setting is relative to the traces_sample_rate setting.
-        "before_send": before_send,
+        "before_send": filter_sentry_error_event,
         "before_send_transaction": scrub_transaction_event,
     }
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/monitoring_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/monitoring_service.py
@@ -3,6 +3,7 @@ import os
 import sys
 from functools import partial
 from typing import Any
+from typing import cast
 
 import flask.wrappers
 import sentry_sdk
@@ -103,15 +104,28 @@ def scrub_transaction_event(event: dict[str, Any], _hint: Any) -> dict[str, Any]
     return event
 
 
+def _has_usable_exception_info(exc_info: Any) -> bool:
+    return (
+        isinstance(exc_info, tuple)
+        and len(exc_info) == 3
+        and isinstance(exc_info[0], type)
+        and issubclass(exc_info[0], BaseException)
+        and isinstance(exc_info[1], BaseException)
+    )
+
+
 def filter_sentry_error_event(event: dict[str, Any], hint: dict[str, Any]) -> dict[str, Any] | None:
     """Keep exception captures while dropping message-only logs and Flask duplicates."""
     log_record = hint.get("log_record")
-    if log_record is not None:
-        # Plain error logs remain application logs and Sentry breadcrumbs, but do not create Sentry issues.
-        # logger.exception() and logger.error(..., exc_info=...) are retained as exception events.
-        exc_info = getattr(log_record, "exc_info", None)
-        if not exc_info or exc_info[0] is None:
-            return None
+    log_record_exc_info = getattr(log_record, "exc_info", None)
+    hint_exc_info = hint.get("exc_info")
+    exc_info = log_record_exc_info if _has_usable_exception_info(log_record_exc_info) else hint_exc_info
+
+    # Plain messages remain application logs and Sentry breadcrumbs, but do not create Sentry issues.
+    # logger.exception() and logger.error(..., exc_info=...) are retained as exception events.
+    if not _has_usable_exception_info(exc_info):
+        return None
+    usable_exc_info = cast(tuple[type[BaseException], BaseException, Any], exc_info)
 
     exception_values = event.get("exception", {}).get("values", [])
 
@@ -123,10 +137,9 @@ def filter_sentry_error_event(event: dict[str, Any], hint: dict[str, Any]) -> di
     ):
         return None
 
-    if "exc_info" in hint:
-        _exc_type, exc_value, _tb = hint["exc_info"]
-        if not should_capture_exception_in_sentry(exc_value):
-            return None
+    _exc_type, exc_value, _tb = usable_exc_info
+    if not should_capture_exception_in_sentry(exc_value):
+        return None
     return event
 
 

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_monitoring_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_monitoring_service.py
@@ -14,6 +14,7 @@ from spiffworkflow_backend.exceptions.api_error import ApiError
 from spiffworkflow_backend.exceptions.error import NotAuthorizedError
 from spiffworkflow_backend.services.monitoring_service import configure_sentry
 from spiffworkflow_backend.services.monitoring_service import ensure_prometheus_multiproc_dir
+from spiffworkflow_backend.services.monitoring_service import filter_sentry_error_event
 from spiffworkflow_backend.services.monitoring_service import get_public_version_info_data
 from spiffworkflow_backend.services.monitoring_service import scrub_transaction_event
 from spiffworkflow_backend.services.monitoring_service import should_capture_exception_in_sentry
@@ -95,8 +96,46 @@ class TestMonitoringService(unittest.TestCase):
 
         self.assertEqual([{"key": "environment", "value": "prod"}], scrubbed_event["tags"])
 
+    def test_filter_sentry_error_event_drops_log_without_exception_info(self) -> None:
+        event = {"logger": "spiffworkflow_backend.services.custom_service_task"}
+        hint = {"log_record": Mock(exc_info=None)}
+
+        self.assertIsNone(filter_sentry_error_event(event, hint))
+
+    def test_filter_sentry_error_event_keeps_log_with_exception_info(self) -> None:
+        exception = ValueError("boom")
+        exc_info = (ValueError, exception, None)
+        event = {
+            "logger": "spiffworkflow_backend.services.custom_service_task",
+            "exception": {"values": [{"mechanism": {"type": "logging", "handled": True}}]},
+        }
+        hint = {"log_record": Mock(exc_info=exc_info), "exc_info": exc_info}
+
+        self.assertIs(event, filter_sentry_error_event(event, hint))
+
+    def test_filter_sentry_error_event_drops_implicit_flask_exception(self) -> None:
+        exception = ValueError("boom")
+        event = {"exception": {"values": [{"mechanism": {"type": "flask", "handled": False}}]}}
+        hint = {"exc_info": (ValueError, exception, None)}
+
+        self.assertIsNone(filter_sentry_error_event(event, hint))
+
+    def test_filter_sentry_error_event_keeps_implicit_celery_exception(self) -> None:
+        exception = ValueError("boom")
+        event = {"exception": {"values": [{"mechanism": {"type": "celery", "handled": False}}]}}
+        hint = {"exc_info": (ValueError, exception, None)}
+
+        self.assertIs(event, filter_sentry_error_event(event, hint))
+
+    def test_filter_sentry_error_event_keeps_explicit_exception(self) -> None:
+        exception = ValueError("boom")
+        event = {"exception": {"values": [{"mechanism": {"type": "generic", "handled": True}}]}}
+        hint = {"exc_info": (ValueError, exception, None)}
+
+        self.assertIs(event, filter_sentry_error_event(event, hint))
+
     @patch("spiffworkflow_backend.services.monitoring_service.sentry_sdk.init")
-    def test_configure_sentry_registers_transaction_event_scrubber(self, mock_sentry_init: Mock) -> None:
+    def test_configure_sentry_registers_event_filters(self, mock_sentry_init: Mock) -> None:
         app = Flask(__name__)
         app.config.update(
             SPIFFWORKFLOW_BACKEND_SENTRY_DSN="https://public@example.com/1",
@@ -108,6 +147,7 @@ class TestMonitoringService(unittest.TestCase):
 
         configure_sentry(app)
 
+        self.assertIs(mock_sentry_init.call_args.kwargs["before_send"], filter_sentry_error_event)
         self.assertIs(mock_sentry_init.call_args.kwargs["before_send_transaction"], scrub_transaction_event)
 
     def test_not_found_is_not_captured(self) -> None:

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_monitoring_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_monitoring_service.py
@@ -102,6 +102,9 @@ class TestMonitoringService(unittest.TestCase):
 
         self.assertIsNone(filter_sentry_error_event(event, hint))
 
+    def test_filter_sentry_error_event_drops_direct_message_without_exception_info(self) -> None:
+        self.assertIsNone(filter_sentry_error_event({"message": "boom"}, {}))
+
     def test_filter_sentry_error_event_keeps_log_with_exception_info(self) -> None:
         exception = ValueError("boom")
         exc_info = (ValueError, exception, None)


### PR DESCRIPTION
This adds a filter to remove any errors going to sentry that do not have an exc_info value. This is to avoid sending `logger.error` logs to sentry which I don't believe we ever intended to do. They cause duplicate and unnecessary sentry events that we do not need.