### PR TITLE
show multi-instance selection in dark mode

### DIFF
--- a/spiffworkflow-frontend/packages/bpmn-js-spiffworkflow-react/src/styles/bpmn-js-properties-panel.css
+++ b/spiffworkflow-frontend/packages/bpmn-js-spiffworkflow-react/src/styles/bpmn-js-properties-panel.css
@@ -119,6 +119,10 @@
     background-color: white;
     color: black;
 }
+[data-theme='dark'] .bpmn-js-container .canvas .djs-popup-header button.entry:not(.active) {
+    /* Native buttons use the dark color scheme before the canvas is inverted. */
+    color: black;
+}
 [data-theme='dark'] .bpmn-js-container .canvas .djs-popup .selected {
     background-color: grey;
 }

--- a/spiffworkflow-frontend/test/browser/test_dark_mode.py
+++ b/spiffworkflow-frontend/test/browser/test_dark_mode.py
@@ -35,6 +35,20 @@ def test_dark_mode_uses_dark_background_and_light_text(page: Page) -> None:
     expect(name_input).to_be_visible()
     expect(name_input).to_have_css("background-color", "rgb(43, 43, 43)")
 
+    page.locator("g[data-element-id=process_script]").click()
+    page.locator(".djs-context-pad [data-action=replace]").click()
+    change_element_popup = page.locator(".djs-popup")
+    expect(change_element_popup).to_be_visible()
+    expect(
+        change_element_popup.locator("[data-id=toggle-parallel-mi]")
+    ).to_have_css("color", "rgb(0, 0, 0)")
+    expect(
+        change_element_popup.locator("[data-id=toggle-sequential-mi]")
+    ).to_have_css("color", "rgb(0, 0, 0)")
+    expect(
+        change_element_popup.locator("[data-id=toggle-loop]")
+    ).to_have_css("color", "rgb(0, 0, 0)")
+
     model_url = (
         f"{BASE_URL}/process-models/"
         "misc:acceptance-tests-group-one:acceptance-tests-model-1"


### PR DESCRIPTION
This fixes a dark mode issue when editing a bpmn diagram. The multi-instance options could not display in the element panel.