### PR TITLE
Sync deleted tasks with spiff

### DIFF
--- a/docs/reference/bpmn/timer_events.md
+++ b/docs/reference/bpmn/timer_events.md
@@ -95,6 +95,10 @@ On an e-commerce platform, a product is available at a flash sale price for just
 When customers add this item to their cart, a timer boundary event of 24 hours is set.
 If they don't purchase within this time frame, the timer activates, removing the limited offering.
 
+When an interrupting timer boundary event is attached to a multi-instance task, completed instances remain completed.
+Any unfinished parallel instances are discarded, and a sequential multi-instance task does not create its remaining future instances.
+The process continues along the timer event's outgoing sequence flow.
+
 **Timer Boundary Event (non-interrupting):**
 
 A company prides itself on responding to customer support queries within 12 hours.
@@ -119,8 +123,8 @@ Just remember to have a mechanism in place to eventually break out of the loop a
 
 ## Timer Event Configuration
 
-| 💻 Form                                | ⌨ Field Input                      | 📝 Description                                                                              |
-| -------------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------- |
+| 💻 Form                                 | ⌨ Field Input                       | 📝 Description                                                                              |
+| --------------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------- |
 | ![name_field](/images/name_field.png)   | **Name:** Cancel Order              | A descriptive name given to the element, providing a human-readable label or title.         |
 | ![id_field](/images/id_field.png)       | **ID:** Example - cancel_order      | An identifier used to uniquely identify the element within the BPMN model.                  |
 | ![timer_field](/images/timer_field.png) | **Type:** Duration **Value:** PT48H | Choose the type of trigger you want to set: Specific Date/Time, Duration, or Cycle Trigger. |

--- a/docs/reference/bpmn/timer_events.md
+++ b/docs/reference/bpmn/timer_events.md
@@ -96,7 +96,8 @@ When customers add this item to their cart, a timer boundary event of 24 hours i
 If they don't purchase within this time frame, the timer activates, removing the limited offering.
 
 When an interrupting timer boundary event is attached to a multi-instance task, completed instances remain completed.
-Any unfinished parallel instances are discarded, and a sequential multi-instance task does not create its remaining future instances.
+All currently active unfinished instances are discarded.
+For sequential execution, remaining future instances are not created.
 The process continues along the timer event's outgoing sequence flow.
 
 **Timer Boundary Event (non-interrupting):**

--- a/spiffworkflow-backend/pyproject.toml
+++ b/spiffworkflow-backend/pyproject.toml
@@ -98,7 +98,7 @@ dev = [
 ]
 
 [tool.uv.sources]
-SpiffWorkflow = { git = "https://github.com/sartography/SpiffWorkflow", tag = "v3.1.3a3" }
+SpiffWorkflow = { git = "https://github.com/sartography/SpiffWorkflow", tag = "task-removed-event" }
 # SpiffWorkflow = { path = "../../SpiffWorkflow", editable = true }
 spiffworkflow-connector-command = { git = "https://github.com/sartography/spiffworkflow-connector-command.git", branch = "main" }
 sqlalchemy-stubs = { git = "https://github.com/burnettk/sqlalchemy-stubs.git", branch = "scoped-session-delete" }

--- a/spiffworkflow-backend/pyproject.toml
+++ b/spiffworkflow-backend/pyproject.toml
@@ -98,7 +98,7 @@ dev = [
 ]
 
 [tool.uv.sources]
-SpiffWorkflow = { git = "https://github.com/sartography/SpiffWorkflow", tag = "task-removed-event" }
+SpiffWorkflow = { git = "https://github.com/sartography/SpiffWorkflow", branch = "main" }
 # SpiffWorkflow = { path = "../../SpiffWorkflow", editable = true }
 spiffworkflow-connector-command = { git = "https://github.com/sartography/spiffworkflow-connector-command.git", branch = "main" }
 sqlalchemy-stubs = { git = "https://github.com/burnettk/sqlalchemy-stubs.git", branch = "scoped-session-delete" }

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/task_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/task_service.py
@@ -261,7 +261,7 @@ class TaskService:
             deleted_children_by_parent.setdefault(parent_guid, set()).add(str(deleted_spiff_task.id))
 
         for parent_guid, deleted_child_guids in deleted_children_by_parent.items():
-            parent_task_model = self.task_models.get(parent_guid) or self._find_existing_task_model(parent_guid)
+            parent_task_model = self.task_models.get(parent_guid) or self.find_existing_task_model(parent_guid)
             if parent_task_model is None:
                 continue
             children = parent_task_model.properties_json.get("children")
@@ -494,7 +494,7 @@ class TaskService:
             self.json_data_dicts[python_env_dict["hash"]] = python_env_dict
         task_model.runtime_info = spiff_task.task_spec.task_info(spiff_task)
 
-    def _find_existing_task_model(self, task_guid: str) -> TaskModel | None:
+    def find_existing_task_model(self, task_guid: str) -> TaskModel | None:
         task_model = self.task_model_mapping.get(task_guid)
         cached_model_has_identity = task_model is not None and sqlalchemy_inspect(task_model).has_identity
         if self._should_query_task_models and not cached_model_has_identity:
@@ -508,7 +508,7 @@ class TaskService:
         spiff_task: SpiffTask,
     ) -> tuple[BpmnProcessModel | None, TaskModel]:
         spiff_task_guid = str(spiff_task.id)
-        task_model = self._find_existing_task_model(spiff_task_guid)
+        task_model = self.find_existing_task_model(spiff_task_guid)
         bpmn_process = None
         if task_model is None:
             bpmn_process = self.task_bpmn_process(spiff_task)
@@ -662,7 +662,7 @@ class TaskService:
             if spiff_task.has_state(TaskState.PREDICTED_MASK):
                 self.__class__.remove_spiff_task_from_parent(spiff_task, self.task_models)
                 continue
-            task_model = self._find_existing_task_model(task_id)
+            task_model = self.find_existing_task_model(task_id)
             if task_model is None:
                 task_model = self.__class__._create_task(
                     bpmn_process,

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/task_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/task_service.py
@@ -245,6 +245,37 @@ class TaskService:
             new_properties_json["children"] = valid_children
             task_model.properties_json = new_properties_json
 
+    def prune_deleted_child_references(
+        self,
+        deleted_spiff_tasks: list[SpiffTask],
+        deleted_task_guids: set[str],
+    ) -> None:
+        """Drop known deleted child links without reserializing parent task data."""
+        deleted_children_by_parent: dict[str, set[str]] = {}
+        for deleted_spiff_task in deleted_spiff_tasks:
+            if deleted_spiff_task.parent is None:
+                continue
+            parent_guid = str(deleted_spiff_task.parent.id)
+            if parent_guid in deleted_task_guids:
+                continue
+            deleted_children_by_parent.setdefault(parent_guid, set()).add(str(deleted_spiff_task.id))
+
+        for parent_guid, deleted_child_guids in deleted_children_by_parent.items():
+            parent_task_model = self.task_models.get(parent_guid) or self._find_existing_task_model(parent_guid)
+            if parent_task_model is None:
+                continue
+            children = parent_task_model.properties_json.get("children")
+            if not children:
+                continue
+            retained_children = [child_guid for child_guid in children if child_guid not in deleted_child_guids]
+            if len(retained_children) == len(children):
+                continue
+
+            new_properties_json = copy.copy(parent_task_model.properties_json)
+            new_properties_json["children"] = retained_children
+            parent_task_model.properties_json = new_properties_json
+            self.task_models[parent_guid] = parent_task_model
+
     def queue_task_model_deletions_by_guid(
         self,
         deleted_task_guids: set[str],

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/task_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/task_service.py
@@ -136,18 +136,25 @@ class TaskService:
         self.json_data_dicts: dict[str, JsonDataDict] = {}
         self.process_instance_events: dict[str, ProcessInstanceEventModel] = {}
         self.dirty_bpmn_process_updates: dict[str, tuple[BpmnWorkflow, BpmnProcessModel]] = {}
+        self.task_model_guids_to_delete: set[str] = set()
+        self.human_task_guids_to_delete: set[str] = set()
+        self.bpmn_process_guids_to_delete: set[str] = set()
         self._should_query_task_models = len(self.task_model_mapping) > 0
         self._subprocess_guid_lookup_by_top_workflow: dict[int, dict[int, str]] = {}
 
         self.run_started_at: float | None = run_started_at
 
     def save_objects_to_database(self, save_process_instance_events: bool = True) -> None:
+        self._add_queued_deletions_to_db_session()
         self.flush_dirty_bpmn_process_updates()
         db.session.bulk_save_objects(self.bpmn_processes.values())
         db.session.bulk_save_objects(self.task_models.values())
         if save_process_instance_events:
             db.session.bulk_save_objects(self.process_instance_events.values())
         JsonDataModel.insert_or_update_json_data_records(self.json_data_dicts)
+        self.task_model_guids_to_delete.clear()
+        self.human_task_guids_to_delete.clear()
+        self.bpmn_process_guids_to_delete.clear()
 
     def get_guid_to_db_object_mappings(self) -> tuple[dict[str, TaskModel], dict[str, BpmnProcessModel]]:
         return (self.task_model_mapping, self.bpmn_subprocess_mapping)
@@ -237,6 +244,61 @@ class TaskService:
             new_properties_json = copy.copy(task_model.properties_json)
             new_properties_json["children"] = valid_children
             task_model.properties_json = new_properties_json
+
+    def queue_task_model_deletions_by_guid(
+        self,
+        deleted_task_guids: set[str],
+        additional_human_task_guid: str | None = None,
+    ) -> None:
+        """Queue persisted projections for deletion when TaskService next saves."""
+        if not deleted_task_guids and additional_human_task_guid is None:
+            return
+
+        self.task_model_guids_to_delete.update(deleted_task_guids)
+        self.human_task_guids_to_delete.update(deleted_task_guids)
+        self.bpmn_process_guids_to_delete.update(deleted_task_guids)
+        if additional_human_task_guid is not None:
+            self.human_task_guids_to_delete.add(additional_human_task_guid)
+
+        for deleted_task_guid in deleted_task_guids:
+            bpmn_process = self.bpmn_subprocess_mapping.get(deleted_task_guid)
+            if bpmn_process is not None:
+                dirty_key = str(bpmn_process.id or bpmn_process.guid or "top_level")
+                self.dirty_bpmn_process_updates.pop(dirty_key, None)
+
+            self.task_model_mapping.pop(deleted_task_guid, None)
+            self.task_models.pop(deleted_task_guid, None)
+            self.process_instance_events.pop(deleted_task_guid, None)
+            self.bpmn_subprocess_mapping.pop(deleted_task_guid, None)
+            self.bpmn_processes.pop(deleted_task_guid, None)
+
+    def _add_queued_deletions_to_db_session(self) -> None:
+        """Resolve and add queued deletions to the session as one part of the save operation."""
+        with db.session.no_autoflush:
+            human_tasks_to_delete = (
+                HumanTaskModel.query.filter(
+                    HumanTaskModel.task_id.in_(self.human_task_guids_to_delete)  # type: ignore
+                ).all()
+                if self.human_task_guids_to_delete
+                else []
+            )
+            task_models_to_delete = (
+                TaskModel.query.filter(TaskModel.guid.in_(self.task_model_guids_to_delete)).all()  # type: ignore
+                if self.task_model_guids_to_delete
+                else []
+            )
+            bpmn_processes_to_delete = (
+                BpmnProcessModel.query.filter(
+                    BpmnProcessModel.guid.in_(self.bpmn_process_guids_to_delete)  # type: ignore
+                )
+                .order_by(BpmnProcessModel.id.desc())  # type: ignore
+                .all()
+                if self.bpmn_process_guids_to_delete
+                else []
+            )
+
+        for db_model in human_tasks_to_delete + task_models_to_delete + bpmn_processes_to_delete:
+            db.session.delete(db_model)
 
     def update_task_model_with_spiff_task(
         self,
@@ -589,32 +651,9 @@ class TaskService:
     ) -> None:
         """Update given spiff tasks in the database and remove deleted tasks."""
         # Remove all the deleted/pruned tasks from the database.
-        deleted_task_guids = [str(t.id) for t in deleted_spiff_tasks]
-        tasks_to_clear = TaskModel.query.filter(TaskModel.guid.in_(deleted_task_guids)).all()  # type: ignore
-
-        human_task_guids_to_clear = deleted_task_guids
-
-        # ensure we clear out any human tasks that were associated with this guid in case it was a human task
-        if to_task_guid is not None:
-            human_task_guids_to_clear.append(to_task_guid)
-        human_tasks_to_clear = HumanTaskModel.query.filter(
-            HumanTaskModel.task_id.in_(human_task_guids_to_clear)  # type: ignore
-        ).all()
-
-        # delete human tasks first to avoid potential conflicts when deleting tasks.
-        # otherwise sqlalchemy returns several warnings.
-        for task in human_tasks_to_clear + tasks_to_clear:
-            db.session.delete(task)
-
-        bpmn_processes_to_delete = (
-            BpmnProcessModel.query.filter(BpmnProcessModel.guid.in_(deleted_task_guids))  # type: ignore
-            .order_by(BpmnProcessModel.id.desc())  # type: ignore
-            .all()
-        )
-        for bpmn_process in bpmn_processes_to_delete:
-            db.session.delete(bpmn_process)
-
-        self.sync_parents_for_deleted_spiff_tasks(deleted_spiff_tasks, set(deleted_task_guids))
+        deleted_task_guids = {str(t.id) for t in deleted_spiff_tasks}
+        self.queue_task_model_deletions_by_guid(deleted_task_guids, additional_human_task_guid=to_task_guid)
+        self.sync_parents_for_deleted_spiff_tasks(deleted_spiff_tasks, deleted_task_guids)
 
         # Note: Can't restrict this to definite, because some things are updated and are now CANCELLED
         # and other things may have been COMPLETED and are now MAYBE

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
@@ -498,6 +498,24 @@ class TaskModelSavingDelegate(EngineStepDelegate):
         ):
             self.task_service.update_task_model_with_spiff_task(waiting_spiff_task)
 
+        top_workflow = bpmn_process_instance.top_workflow
+        workflows = [top_workflow, *top_workflow.subprocesses.values()]
+        spiff_tasks_by_guid = {str(spiff_task.id): spiff_task for workflow in workflows for spiff_task in workflow.get_tasks()}
+        deleted_task_guids = set()
+        for task_guid, task_model in self.task_service.task_model_mapping.items():
+            if (
+                task_guid in spiff_tasks_by_guid
+                or task_model.state in {"COMPLETED", "CANCELLED", "ERROR"}
+                or task_model.properties_json.get("triggered") is not True
+            ):
+                continue
+            parent_task = spiff_tasks_by_guid.get(task_model.parent_guid())
+            if parent_task is not None and parent_task.has_state(TaskState.CANCELLED):
+                deleted_task_guids.add(task_guid)
+
+        self.task_service.queue_task_model_deletions_by_guid(deleted_task_guids)
+        self.task_service.prune_missing_child_references(set(spiff_tasks_by_guid))
+
         self.task_service.save_objects_to_database()
 
         if self.secondary_engine_step_delegate:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
@@ -509,7 +509,10 @@ class TaskModelSavingDelegate(EngineStepDelegate):
                 or task_model.properties_json.get("triggered") is not True
             ):
                 continue
-            parent_task = spiff_tasks_by_guid.get(task_model.parent_guid())
+            parent_task_guid = task_model.parent_guid()
+            if parent_task_guid is None:
+                continue
+            parent_task = spiff_tasks_by_guid.get(parent_task_guid)
             if parent_task is not None and parent_task.has_state(TaskState.CANCELLED):
                 deleted_task_guids.add(task_guid)
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
@@ -117,6 +117,10 @@ class EngineStepDelegate:
         pass
 
     @abstractmethod
+    def did_remove_task(self, workflow: Any, spiff_task: SpiffTask) -> None:
+        pass
+
+    @abstractmethod
     def add_object_to_db_session(self, bpmn_process_instance: BpmnWorkflow) -> None:
         pass
 
@@ -210,7 +214,7 @@ class ExecutionStrategy:
         self, bpmn_process_instance: BpmnWorkflow, process_instance_model: ProcessInstanceModel, exit_at: None = None
     ) -> TaskRunnability:
         while True:
-            bpmn_process_instance.refresh_due_waiting_tasks()
+            bpmn_process_instance.refresh_timers()
             self.should_do_before(bpmn_process_instance, process_instance_model)
             engine_steps = self.get_ready_engine_steps(bpmn_process_instance)
             num_steps = len(engine_steps)
@@ -398,6 +402,7 @@ class TaskModelSavingDelegate(EngineStepDelegate):
         self._last_completed_spiff_task: SpiffTask | None = None
         self.spiff_tasks_to_process: set[UUID] = set()
         self.spiff_task_timestamps: dict[UUID, StartAndEndTimes] = {}
+        self.removed_spiff_tasks: dict[UUID, SpiffTask] = {}
 
         self.task_service = TaskService(
             process_instance=self.process_instance,
@@ -478,6 +483,12 @@ class TaskModelSavingDelegate(EngineStepDelegate):
         if self.secondary_engine_step_delegate:
             self.secondary_engine_step_delegate.did_complete_task(spiff_task)
 
+    def did_remove_task(self, workflow: Any, spiff_task: SpiffTask) -> None:
+        self.removed_spiff_tasks[spiff_task.id] = spiff_task
+
+        if self.secondary_engine_step_delegate:
+            self.secondary_engine_step_delegate.did_remove_task(workflow, spiff_task)
+
     def add_object_to_db_session(self, bpmn_process_instance: BpmnWorkflow) -> None:
         # NOTE: process-all-tasks: All tests pass with this but it's less efficient and would be nice to replace
         # excludes COMPLETED. the others were required to get PP1 to go to completion.
@@ -498,26 +509,21 @@ class TaskModelSavingDelegate(EngineStepDelegate):
         ):
             self.task_service.update_task_model_with_spiff_task(waiting_spiff_task)
 
-        top_workflow = bpmn_process_instance.top_workflow
-        workflows = [top_workflow, *top_workflow.subprocesses.values()]
-        spiff_tasks_by_guid = {str(spiff_task.id): spiff_task for workflow in workflows for spiff_task in workflow.get_tasks()}
-        deleted_task_guids = set()
-        for task_guid, task_model in self.task_service.task_model_mapping.items():
+        reported_removed_spiff_tasks = list(self.removed_spiff_tasks.values())
+        self.removed_spiff_tasks.clear()
+        removed_spiff_tasks = []
+        for removed_spiff_task in reported_removed_spiff_tasks:
+            task_model = self.task_service.task_model_mapping.get(str(removed_spiff_task.id))
             if (
-                task_guid in spiff_tasks_by_guid
-                or task_model.state in {"COMPLETED", "CANCELLED", "ERROR"}
-                or task_model.properties_json.get("triggered") is not True
+                task_model is not None
+                and task_model.state not in {"COMPLETED", "CANCELLED", "ERROR"}
+                and task_model.properties_json.get("triggered") is True
             ):
-                continue
-            parent_task_guid = task_model.parent_guid()
-            if parent_task_guid is None:
-                continue
-            parent_task = spiff_tasks_by_guid.get(parent_task_guid)
-            if parent_task is not None and parent_task.has_state(TaskState.CANCELLED):
-                deleted_task_guids.add(task_guid)
+                removed_spiff_tasks.append(removed_spiff_task)
+        deleted_task_guids = {str(spiff_task.id) for spiff_task in removed_spiff_tasks}
 
         self.task_service.queue_task_model_deletions_by_guid(deleted_task_guids)
-        self.task_service.prune_missing_child_references(set(spiff_tasks_by_guid))
+        self.task_service.prune_deleted_child_references(removed_spiff_tasks, deleted_task_guids)
 
         self.task_service.save_objects_to_database()
 
@@ -590,7 +596,7 @@ class QueueInstructionsForEndUserExecutionStrategy(ExecutionStrategy):
         return engine_steps[: max_tasks - self.completed_task_count]
 
     def task_runnability_when_breaking_after(self, bpmn_process_instance: BpmnWorkflow) -> TaskRunnability:
-        bpmn_process_instance.refresh_due_waiting_tasks()
+        bpmn_process_instance.refresh_timers()
         return (
             TaskRunnability.has_ready_tasks
             if self.get_ready_engine_steps(bpmn_process_instance)
@@ -718,6 +724,8 @@ class WorkflowExecutionService:
                         "The current thread has not obtained a lock for this process"
                         f" instance ({self.process_instance_model.id})."
                     )
+        task_removed_event = self.bpmn_process_instance.task_removed_event
+        task_removed_event.connect(self.execution_strategy.delegate.did_remove_task)
         try:
             self.refresh_due_service_task_retries()
 
@@ -746,13 +754,16 @@ class WorkflowExecutionService:
             raise ApiError.from_workflow_exception("task_error", str(swe), swe) from swe
 
         finally:
-            if self.process_instance_model.persistence_level != "none":
-                # even if a task fails, try to persist all tasks, which will include the error state.
-                self.execution_strategy.add_object_to_db_session(self.bpmn_process_instance)
-                if save:
-                    self.process_instance_saver()
-                    if should_schedule_waiting_timer_events:
-                        self.schedule_waiting_timer_events()
+            try:
+                if self.process_instance_model.persistence_level != "none":
+                    # even if a task fails, try to persist all tasks, which will include the error state.
+                    self.execution_strategy.add_object_to_db_session(self.bpmn_process_instance)
+                    if save:
+                        self.process_instance_saver()
+                        if should_schedule_waiting_timer_events:
+                            self.schedule_waiting_timer_events()
+            finally:
+                task_removed_event.disconnect(self.execution_strategy.delegate.did_remove_task)
 
     def refresh_due_service_task_retries(self) -> None:
         current_time = round(time.time())

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/workflow_execution_service.py
@@ -513,11 +513,11 @@ class TaskModelSavingDelegate(EngineStepDelegate):
         self.removed_spiff_tasks.clear()
         removed_spiff_tasks = []
         for removed_spiff_task in reported_removed_spiff_tasks:
-            task_model = self.task_service.task_model_mapping.get(str(removed_spiff_task.id))
+            task_model = self.task_service.find_existing_task_model(str(removed_spiff_task.id))
             if (
                 task_model is not None
                 and task_model.state not in {"COMPLETED", "CANCELLED", "ERROR"}
-                and task_model.properties_json.get("triggered") is True
+                and (task_model.properties_json.get("triggered") is True or task_model.state in {"READY", "WAITING", "STARTED"})
             ):
                 removed_spiff_tasks.append(removed_spiff_task)
         deleted_task_guids = {str(spiff_task.id) for spiff_task in removed_spiff_tasks}

--- a/spiffworkflow-backend/tests/data/multiinstance_human_task_with_timer/multiinstance-manual-task-with-timer.bpmn
+++ b/spiffworkflow-backend/tests/data/multiinstance_human_task_with_timer/multiinstance-manual-task-with-timer.bpmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:spiffworkflow="http://spiffworkflow.org/bpmn/schema/1.0/core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_MultiInstanceManualTimer" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_MultiInstanceManualTimer" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" />
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="SetInput" />
+    <bpmn:scriptTask id="SetInput">
+      <bpmn:script>items = ['a', 'b', 'c']</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="SetInput" targetRef="HumanTask" />
+    <bpmn:manualTask id="HumanTask" name="Parallel manual task">
+      <bpmn:multiInstanceLoopCharacteristics spiffworkflow:scriptsOnInstances="true">
+        <bpmn:loopDataInputRef>items</bpmn:loopDataInputRef>
+        <bpmn:loopDataOutputRef>results</bpmn:loopDataOutputRef>
+        <bpmn:inputDataItem id="item" name="item" />
+        <bpmn:outputDataItem id="result" name="result" />
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="Flow_3" sourceRef="HumanTask" targetRef="NormalEnd" />
+    <bpmn:endEvent id="NormalEnd" />
+    <bpmn:boundaryEvent id="TimerBoundary" attachedToRef="HumanTask">
+      <bpmn:timerEventDefinition>
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">"PT4H"</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_4" sourceRef="TimerBoundary" targetRef="TimerEnd" />
+    <bpmn:endEvent id="TimerEnd" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/spiffworkflow-backend/tests/data/multiinstance_human_task_with_timer/multiinstance-user-task-with-timer.bpmn
+++ b/spiffworkflow-backend/tests/data/multiinstance_human_task_with_timer/multiinstance-user-task-with-timer.bpmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:spiffworkflow="http://spiffworkflow.org/bpmn/schema/1.0/core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_MultiInstanceUserTimer" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_MultiInstanceUserTimer" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" />
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="SetInput" />
+    <bpmn:scriptTask id="SetInput">
+      <bpmn:script>items = ['a', 'b', 'c']</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="SetInput" targetRef="HumanTask" />
+    <bpmn:userTask id="HumanTask" name="Sequential user task">
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true" spiffworkflow:scriptsOnInstances="true">
+        <bpmn:loopDataInputRef>items</bpmn:loopDataInputRef>
+        <bpmn:loopDataOutputRef>results</bpmn:loopDataOutputRef>
+        <bpmn:inputDataItem id="item" name="item" />
+        <bpmn:outputDataItem id="result" name="result" />
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_3" sourceRef="HumanTask" targetRef="NormalEnd" />
+    <bpmn:endEvent id="NormalEnd" />
+    <bpmn:boundaryEvent id="TimerBoundary" attachedToRef="HumanTask">
+      <bpmn:timerEventDefinition>
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">"PT4H"</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_4" sourceRef="TimerBoundary" targetRef="TimerEnd" />
+    <bpmn:endEvent id="TimerEnd" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/spiffworkflow-backend/tests/data/task_removed_event/nested-parallel-manual-tasks.bpmn
+++ b/spiffworkflow-backend/tests/data/task_removed_event/nested-parallel-manual-tasks.bpmn
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="Definitions_NestedParallelTasks" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_NestedParallelTasks" isExecutable="true">
+    <bpmn:startEvent id="StartEvent" />
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent" targetRef="OuterScope" />
+    <bpmn:subProcess id="OuterScope" name="Nested scope">
+      <bpmn:startEvent id="InnerStart" />
+      <bpmn:sequenceFlow id="InnerFlow_1" sourceRef="InnerStart" targetRef="ParallelSplit" />
+      <bpmn:parallelGateway id="ParallelSplit" />
+      <bpmn:sequenceFlow id="InnerFlow_2" sourceRef="ParallelSplit" targetRef="NestedManualTaskA" />
+      <bpmn:sequenceFlow id="InnerFlow_3" sourceRef="ParallelSplit" targetRef="NestedManualTaskB" />
+      <bpmn:manualTask id="NestedManualTaskA" name="Nested manual task A" />
+      <bpmn:manualTask id="NestedManualTaskB" name="Nested manual task B" />
+      <bpmn:sequenceFlow id="InnerFlow_4" sourceRef="NestedManualTaskA" targetRef="ParallelJoin" />
+      <bpmn:sequenceFlow id="InnerFlow_5" sourceRef="NestedManualTaskB" targetRef="ParallelJoin" />
+      <bpmn:parallelGateway id="ParallelJoin" />
+      <bpmn:sequenceFlow id="InnerFlow_6" sourceRef="ParallelJoin" targetRef="InnerEnd" />
+      <bpmn:endEvent id="InnerEnd" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="OuterScope" targetRef="EndEvent" />
+    <bpmn:endEvent id="EndEvent" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_migrator.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_migrator.py
@@ -28,21 +28,24 @@ from tests.spiffworkflow_backend.helpers.test_data import load_test_spec
 
 
 class TestProcessInstanceMigrator(BaseTest):
-    def _remove_empty_delta_fields(self, data: dict | list) -> None:
-        """Remove delta fields from serialized workflow data for comparison."""
+    def _remove_new_serializer_fields(self, data: dict | list) -> None:
+        """Remove fields added by newer serializers from historical fixture comparisons."""
         if isinstance(data, dict):
             # Remove delta field if present (we store full data, not deltas)
             if "delta" in data:
                 del data["delta"]
+            for field in ("bpmn_start_events", "trigger_specs"):
+                if data.get(field) == []:
+                    del data[field]
 
             # Recursively process nested structures
             for value in list(data.values()):
                 if isinstance(value, dict | list):
-                    self._remove_empty_delta_fields(value)
+                    self._remove_new_serializer_fields(value)
         elif isinstance(data, list):
             for item in data:
                 if isinstance(item, dict | list):
-                    self._remove_empty_delta_fields(item)
+                    self._remove_new_serializer_fields(item)
 
     def test_data_migrations_directory_has_not_changed(
         self,
@@ -156,7 +159,7 @@ class TestProcessInstanceMigrator(BaseTest):
         bpmn_process_dict_version_4 = runtime.serialize(serialize_script_engine_state=False)
         self.round_last_state_change(bpmn_process_dict_version_4)
         self.round_last_state_change(bpmn_process_dict_version_4_from_spiff)
-        self._remove_empty_delta_fields(bpmn_process_dict_version_4)
+        self._remove_new_serializer_fields(bpmn_process_dict_version_4)
         assert bpmn_process_dict_version_4 == bpmn_process_dict_version_4_from_spiff
 
         bpmn_process_cache_version_4 = {

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_runtime.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_runtime.py
@@ -1802,6 +1802,11 @@ class TestProcessInstanceRuntime(BaseTest):
         assert completed_human_task.completed is True
         assert completed_human_task.task_status == "COMPLETED"
 
+        remaining_human_task_guids = {
+            task.task_id for task in HumanTaskModel.query.filter_by(process_instance_id=process_instance.id).all()
+        }
+        assert remaining_human_task_guids == {completed_task_guid}
+
         assert TaskModel.query.filter(TaskModel.guid.in_(unfinished_human_task_guids)).count() == 0  # type: ignore
         assert HumanTaskModel.query.filter(HumanTaskModel.task_id.in_(unfinished_human_task_guids)).count() == 0  # type: ignore
 

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_runtime.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_runtime.py
@@ -33,10 +33,12 @@ from spiffworkflow_backend.models.task_instructions_for_end_user import TaskInst
 from spiffworkflow_backend.routes.process_instances_controller import process_instance_resume
 from spiffworkflow_backend.routes.tasks_controller import task_data_update
 from spiffworkflow_backend.services.authorization_service import AuthorizationService
+from spiffworkflow_backend.services.bpmn_process_service import BpmnProcessService
 from spiffworkflow_backend.services.process_instance_persistence_service import ProcessInstancePersistenceService
 from spiffworkflow_backend.services.process_instance_runtime import ProcessInstanceRuntime
 from spiffworkflow_backend.services.process_instance_service import ProcessInstanceService
 from spiffworkflow_backend.services.user_service import UserService
+from spiffworkflow_backend.services.workflow_execution_service import TaskModelSavingDelegate
 from spiffworkflow_backend.services.workflow_execution_service import WorkflowExecutionServiceError
 from tests.spiffworkflow_backend.helpers.base_test import BaseTest
 from tests.spiffworkflow_backend.helpers.test_data import load_test_spec
@@ -1790,7 +1792,7 @@ class TestProcessInstanceRuntime(BaseTest):
         assert unfinished_human_task_guids
 
         timer_task = next(task for task in runtime.get_all_waiting_tasks() if task.task_spec.bpmn_id == "TimerBoundary")
-        timer_task._set_state(TaskState.READY)
+        timer_task.internal_data["event_fired"] = True
         task_removed_event = runtime.bpmn_process_instance.task_removed_event
         runtime.do_engine_steps(save=True)
         assert task_removed_event.n_subscribers() == 0
@@ -1815,6 +1817,65 @@ class TestProcessInstanceRuntime(BaseTest):
         multiinstance_wrapper = TaskModel.query.filter_by(guid=multiinstance_wrapper_guid).first()
         assert multiinstance_wrapper is not None
         assert multiinstance_wrapper.state == "CANCELLED"
+
+    def test_task_removal_event_removes_nested_task_models(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+    ) -> None:
+        bpmn_file_name = "nested-parallel-manual-tasks.bpmn"
+        process_model = load_test_spec(
+            process_model_id=f"group/{bpmn_file_name}",
+            process_model_source_directory="task_removed_event",
+            bpmn_file_name=bpmn_file_name,
+        )
+        process_instance = self.create_process_instance_from_process_model(process_model=process_model)
+        runtime = ProcessInstanceRuntime(process_instance)
+        runtime.do_engine_steps(save=True)
+
+        active_human_tasks = process_instance.active_human_tasks
+        assert len(active_human_tasks) == 2
+        nested_human_task_guids = {human_task.task_id for human_task in active_human_tasks}
+        nested_human_spiff_task = runtime.bpmn_process_instance.get_task_from_id(UUID(active_human_tasks[0].task_id))
+        removed_subtree_root = nested_human_spiff_task.parent
+        assert removed_subtree_root is not None
+        assert removed_subtree_root.task_spec.bpmn_id == "ParallelSplit"
+        assert {str(child.id) for child in removed_subtree_root.children} == nested_human_task_guids
+        removed_subtree_root_guid = str(removed_subtree_root.id)
+        assert removed_subtree_root.parent is not None
+
+        nested_human_task_models = TaskModel.query.filter(
+            TaskModel.guid.in_(nested_human_task_guids)  # type: ignore
+        ).all()
+        assert {task_model.guid for task_model in nested_human_task_models} == nested_human_task_guids
+        assert all(task_model.state in {"READY", "WAITING", "STARTED"} for task_model in nested_human_task_models)
+        assert all(task_model.properties_json.get("triggered") is False for task_model in nested_human_task_models)
+
+        task_model_delegate = TaskModelSavingDelegate(
+            serializer=BpmnProcessService.serializer,
+            process_instance=process_instance,
+            bpmn_definition_to_task_definitions_mappings=runtime.bpmn_definition_to_task_definitions_mappings,
+            bpmn_subprocess_mapping=runtime.bpmn_subprocess_mapping,
+            task_model_mapping=runtime.task_model_mapping,
+        )
+        assert nested_human_task_guids.isdisjoint(task_model_delegate.task_service.task_model_mapping)
+        task_removed_event = runtime.bpmn_process_instance.task_removed_event
+        task_removed_event.connect(task_model_delegate.did_remove_task)
+        try:
+            removed_subtree_root.workflow._remove_task(removed_subtree_root.id)
+        finally:
+            task_removed_event.disconnect(task_model_delegate.did_remove_task)
+
+        removed_task_guids = {str(task_guid) for task_guid in task_model_delegate.removed_spiff_tasks}
+        assert removed_subtree_root_guid in removed_task_guids
+        assert nested_human_task_guids <= removed_task_guids
+
+        task_model_delegate.add_object_to_db_session(runtime.bpmn_process_instance)
+        db.session.flush()
+
+        assert TaskModel.query.filter(TaskModel.guid.in_(nested_human_task_guids)).count() == 0  # type: ignore
+        assert HumanTaskModel.query.filter(HumanTaskModel.task_id.in_(nested_human_task_guids)).count() == 0  # type: ignore
 
     def test_can_store_summary(
         self,

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_runtime.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_runtime.py
@@ -1791,7 +1791,9 @@ class TestProcessInstanceRuntime(BaseTest):
 
         timer_task = next(task for task in runtime.get_all_waiting_tasks() if task.task_spec.bpmn_id == "TimerBoundary")
         timer_task._set_state(TaskState.READY)
+        task_removed_event = runtime.bpmn_process_instance.task_removed_event
         runtime.do_engine_steps(save=True)
+        assert task_removed_event.n_subscribers() == 0
 
         completed_task_model = TaskModel.query.filter_by(guid=completed_task_guid).first()
         assert completed_task_model is not None

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_runtime.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_runtime.py
@@ -21,6 +21,7 @@ from spiffworkflow_backend.exceptions.error import UserDoesNotHaveAccessToTaskEr
 from spiffworkflow_backend.models.bpmn_process import BpmnProcessModel
 from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.models.group import GroupModel
+from spiffworkflow_backend.models.human_task import HumanTaskModel
 from spiffworkflow_backend.models.json_data import JsonDataModel
 from spiffworkflow_backend.models.process_instance import ProcessInstanceModel
 from spiffworkflow_backend.models.process_instance import ProcessInstanceStatus
@@ -1744,6 +1745,69 @@ class TestProcessInstanceRuntime(BaseTest):
 
         runtime.do_engine_steps(save=True)
         assert process_instance.status == "complete"
+
+    @pytest.mark.parametrize(
+        "bpmn_file_name, expected_initial_human_tasks",
+        [
+            ("multiinstance-manual-task-with-timer.bpmn", 3),
+            ("multiinstance-user-task-with-timer.bpmn", 1),
+        ],
+    )
+    def test_interrupting_timer_prunes_only_unfinished_multiinstance_human_tasks(
+        self,
+        app: Flask,
+        client: TestClient,
+        with_db_and_bpmn_file_cleanup: None,
+        bpmn_file_name: str,
+        expected_initial_human_tasks: int,
+    ) -> None:
+        process_model = load_test_spec(
+            process_model_id=f"group/{bpmn_file_name}",
+            process_model_source_directory="multiinstance_human_task_with_timer",
+            bpmn_file_name=bpmn_file_name,
+        )
+        process_instance = self.create_process_instance_from_process_model(process_model=process_model)
+        runtime = ProcessInstanceRuntime(process_instance)
+        runtime.do_engine_steps(save=True)
+
+        active_human_tasks = process_instance.active_human_tasks
+        assert len(active_human_tasks) == expected_initial_human_tasks
+
+        completed_human_task = active_human_tasks[0]
+        completed_task_guid = completed_human_task.task_id
+        completed_spiff_task = runtime.bpmn_process_instance.get_task_from_id(UUID(completed_task_guid))
+        multiinstance_wrapper_guid = str(completed_spiff_task.parent.id)
+        completed_spiff_task.data["result"] = "completed"
+        runtime.complete_task(
+            completed_spiff_task,
+            user=process_instance.process_initiator,
+            human_task=completed_human_task,
+        )
+
+        process_instance = ProcessInstanceModel.query.filter_by(id=process_instance.id).first()
+        runtime = ProcessInstanceRuntime(process_instance)
+        unfinished_human_task_guids = {task.task_id for task in process_instance.active_human_tasks}
+        assert unfinished_human_task_guids
+
+        timer_task = next(task for task in runtime.get_all_waiting_tasks() if task.task_spec.bpmn_id == "TimerBoundary")
+        timer_task._set_state(TaskState.READY)
+        runtime.do_engine_steps(save=True)
+
+        completed_task_model = TaskModel.query.filter_by(guid=completed_task_guid).first()
+        assert completed_task_model is not None
+        assert completed_task_model.state == "COMPLETED"
+
+        completed_human_task = HumanTaskModel.query.filter_by(task_id=completed_task_guid).first()
+        assert completed_human_task is not None
+        assert completed_human_task.completed is True
+        assert completed_human_task.task_status == "COMPLETED"
+
+        assert TaskModel.query.filter(TaskModel.guid.in_(unfinished_human_task_guids)).count() == 0  # type: ignore
+        assert HumanTaskModel.query.filter(HumanTaskModel.task_id.in_(unfinished_human_task_guids)).count() == 0  # type: ignore
+
+        multiinstance_wrapper = TaskModel.query.filter_by(guid=multiinstance_wrapper_guid).first()
+        assert multiinstance_wrapper is not None
+        assert multiinstance_wrapper.state == "CANCELLED"
 
     def test_can_store_summary(
         self,

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_task_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_task_service.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import make_transient_to_detached
 
 from spiffworkflow_backend.models.bpmn_process import BpmnProcessModel
 from spiffworkflow_backend.models.bpmn_process_definition import BpmnProcessDefinitionModel
+from spiffworkflow_backend.models.db import db
 from spiffworkflow_backend.models.task import TaskModel
 from spiffworkflow_backend.models.task_definition import TaskDefinitionModel
 from spiffworkflow_backend.services.process_instance_runtime import ProcessInstanceRuntime
@@ -233,6 +234,41 @@ class TestTaskService(BaseTest):
 
         assert task_service.task_models["parent"].properties_json["children"] == ["child_a", "child_b"]
         assert task_service.task_models["untouched"].properties_json["children"] == ["child_c"]
+
+    def test_queue_task_model_deletions_does_not_touch_db_session(
+        self,
+        app: Flask,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        task_service: Any = TaskService.__new__(TaskService)
+        task_model = SimpleNamespace(guid="task")
+        bpmn_process = SimpleNamespace(id=123, guid="task")
+        task_service.task_model_guids_to_delete = set()
+        task_service.human_task_guids_to_delete = set()
+        task_service.bpmn_process_guids_to_delete = set()
+        task_service.task_model_mapping = {"task": task_model}
+        task_service.task_models = {"task": task_model}
+        task_service.process_instance_events = {"task": object()}
+        task_service.bpmn_subprocess_mapping = {"task": bpmn_process}
+        task_service.bpmn_processes = {"task": bpmn_process}
+        task_service.dirty_bpmn_process_updates = {"123": object()}
+
+        def fail_delete(_db_model: object) -> None:
+            pytest.fail("Queueing a deletion must not touch the database session")
+
+        monkeypatch.setattr(db.session, "delete", fail_delete)
+
+        task_service.queue_task_model_deletions_by_guid({"task"}, additional_human_task_guid="reset-task")
+
+        assert task_service.task_model_guids_to_delete == {"task"}
+        assert task_service.human_task_guids_to_delete == {"task", "reset-task"}
+        assert task_service.bpmn_process_guids_to_delete == {"task"}
+        assert task_service.task_model_mapping == {}
+        assert task_service.task_models == {}
+        assert task_service.process_instance_events == {}
+        assert task_service.bpmn_subprocess_mapping == {}
+        assert task_service.bpmn_processes == {}
+        assert task_service.dirty_bpmn_process_updates == {}
 
     def test_find_or_create_task_model_uses_mapping_before_querying(
         self,

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_task_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_task_service.py
@@ -235,6 +235,29 @@ class TestTaskService(BaseTest):
         assert task_service.task_models["parent"].properties_json["children"] == ["child_a", "child_b"]
         assert task_service.task_models["untouched"].properties_json["children"] == ["child_c"]
 
+    def test_prune_deleted_child_references_only_updates_parent_children(
+        self,
+        app: Flask,
+    ) -> None:
+        task_service: Any = TaskService.__new__(TaskService)
+        parent_task_model = SimpleNamespace(
+            properties_json={
+                "children": ["deleted_child", "retained_child"],
+                "state": "COMPLETED",
+            },
+        )
+        task_service.task_models = {"parent": parent_task_model}
+        task_service.task_model_mapping = {}
+        parent = SimpleNamespace(id="parent", parent=None)
+        deleted_child = SimpleNamespace(id="deleted_child", parent=parent)
+
+        TaskService.prune_deleted_child_references(task_service, [deleted_child], {"deleted_child"})
+
+        assert parent_task_model.properties_json == {
+            "children": ["retained_child"],
+            "state": "COMPLETED",
+        }
+
     def test_queue_task_model_deletions_does_not_touch_db_session(
         self,
         app: Flask,

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_workflow_execution_strategy.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_workflow_execution_strategy.py
@@ -25,6 +25,9 @@ class FakeDelegate(EngineStepDelegate):
     def did_complete_task(self, spiff_task: Any) -> None:
         pass
 
+    def did_remove_task(self, workflow: Any, spiff_task: Any) -> None:
+        pass
+
     def add_object_to_db_session(self, bpmn_process_instance: Any) -> None:
         pass
 

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_workflow_execution_strategy.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_workflow_execution_strategy.py
@@ -42,7 +42,7 @@ class FakeDelegate(EngineStepDelegate):
 
 
 class FakeWorkflow:
-    def refresh_due_waiting_tasks(self) -> None:
+    def refresh_timers(self) -> None:
         pass
 
     def get_tasks(self, **kwargs: Any) -> list[Any]:

--- a/spiffworkflow-backend/uv.lock
+++ b/spiffworkflow-backend/uv.lock
@@ -2999,7 +2999,7 @@ wheels = [
 [[package]]
 name = "spiffworkflow"
 version = "3.1.2"
-source = { git = "https://github.com/sartography/SpiffWorkflow?tag=v3.1.3a3#2cc94566579478a4925992ce9011f87ca49e75fa" }
+source = { git = "https://github.com/sartography/SpiffWorkflow?tag=task-removed-event#2228fc2eda9b60c2eb671e9262ad4a3fd9d11674" }
 dependencies = [
     { name = "lxml" },
 ]
@@ -3112,7 +3112,7 @@ requires-dist = [
     { name = "sentry-sdk", extras = ["flask"], specifier = ">=2.26" },
     { name = "simplejson", specifier = ">=3.20.1" },
     { name = "spiff-arena-common", specifier = ">=0.1.0" },
-    { name = "spiffworkflow", git = "https://github.com/sartography/SpiffWorkflow?tag=v3.1.3a3" },
+    { name = "spiffworkflow", git = "https://github.com/sartography/SpiffWorkflow?tag=task-removed-event" },
     { name = "spiffworkflow-connector-command", git = "https://github.com/sartography/spiffworkflow-connector-command.git?branch=main" },
     { name = "sqlalchemy", specifier = ">=2.0.31" },
     { name = "sqlalchemy-stubs", git = "https://github.com/burnettk/sqlalchemy-stubs.git?branch=scoped-session-delete" },

--- a/spiffworkflow-backend/uv.lock
+++ b/spiffworkflow-backend/uv.lock
@@ -2999,7 +2999,7 @@ wheels = [
 [[package]]
 name = "spiffworkflow"
 version = "3.1.2"
-source = { git = "https://github.com/sartography/SpiffWorkflow?tag=task-removed-event#d75ac3996e2f0900d6213fc203caae6d7a1017a2" }
+source = { git = "https://github.com/sartography/SpiffWorkflow?branch=main#85f7a4366058052a3921f0b63ec3c6bf19bb0f59" }
 dependencies = [
     { name = "lxml" },
 ]
@@ -3112,7 +3112,7 @@ requires-dist = [
     { name = "sentry-sdk", extras = ["flask"], specifier = ">=2.26" },
     { name = "simplejson", specifier = ">=3.20.1" },
     { name = "spiff-arena-common", specifier = ">=0.1.0" },
-    { name = "spiffworkflow", git = "https://github.com/sartography/SpiffWorkflow?tag=task-removed-event" },
+    { name = "spiffworkflow", git = "https://github.com/sartography/SpiffWorkflow?branch=main" },
     { name = "spiffworkflow-connector-command", git = "https://github.com/sartography/spiffworkflow-connector-command.git?branch=main" },
     { name = "sqlalchemy", specifier = ">=2.0.31" },
     { name = "sqlalchemy-stubs", git = "https://github.com/burnettk/sqlalchemy-stubs.git?branch=scoped-session-delete" },

--- a/spiffworkflow-backend/uv.lock
+++ b/spiffworkflow-backend/uv.lock
@@ -2999,7 +2999,7 @@ wheels = [
 [[package]]
 name = "spiffworkflow"
 version = "3.1.2"
-source = { git = "https://github.com/sartography/SpiffWorkflow?tag=task-removed-event#2228fc2eda9b60c2eb671e9262ad4a3fd9d11674" }
+source = { git = "https://github.com/sartography/SpiffWorkflow?tag=task-removed-event#d75ac3996e2f0900d6213fc203caae6d7a1017a2" }
 dependencies = [
     { name = "lxml" },
 ]


### PR DESCRIPTION
SpiffWorkflow deletes tasks if branches are canceled. This is include Timer Boundary Events on Multi-instance tasks. This updates arena to ensure we remove tasks that SpiffWorkflow deleted so we stay in sync.

Addresses https://github.com/sartography/spiff-arena/issues/2725