### PR TITLE
Stub out get_process_initiator_user func

### DIFF
--- a/spiff-arena-common/pyproject.toml
+++ b/spiff-arena-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spiff-arena-common"
-version = "0.1.44"
+version = "0.1.45"
 description = "Shared Python utilities for Spiff Arena frontend and backend components"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/spiff-arena-common/src/spiff_arena_common/runner.py
+++ b/spiff-arena-common/src/spiff_arena_common/runner.py
@@ -272,6 +272,10 @@ class CustomEnvironment(TaskDataEnvironment):
             "email": "current_user@example.com",
             "display_name": "Mr. Current User",
         }
+        external_context["get_process_initiator_user"] = lambda: {
+            "email": "initiator_user@example.com",
+            "display_name": "Mr. Process Initiator User",
+        }
         external_context["get_group_members"] = lambda group_name: [
             "group_member_1@example.com",
             "group_member_2@example.com",

--- a/spiff-arena-common/src/spiff_arena_common/runner.py
+++ b/spiff-arena-common/src/spiff_arena_common/runner.py
@@ -273,8 +273,15 @@ class CustomEnvironment(TaskDataEnvironment):
             "display_name": "Mr. Current User",
         }
         external_context["get_process_initiator_user"] = lambda: {
+            "id": 1,
+            "username": "initiator_user",
             "email": "initiator_user@example.com",
             "display_name": "Mr. Process Initiator User",
+            "tenant_specific_field_1": "initiator_tenant_specific_field_1",
+            "tenant_specific_field_2": "initiator_tenant_specific_field_2",
+            "tenant_specific_field_3": "initiator_tenant_specific_field_3",
+            "updated_at_in_seconds": 0,
+            "created_at_in_seconds": 0,
         }
         external_context["get_group_members"] = lambda group_name: [
             "group_member_1@example.com",

--- a/spiff-arena-common/tests/spiff_arena_common/test_runner.py
+++ b/spiff-arena-common/tests/spiff_arena_common/test_runner.py
@@ -73,6 +73,21 @@ def test_custom_environment_get_current_task_data_filters_internal_keys():
     assert context["result"] == {"visible": 1}
 
 
+def test_custom_environment_get_process_initiator_user_returns_stub_user():
+    context = {}
+
+    result = runner.CustomEnvironment().execute(
+        "process_initiator_user = get_process_initiator_user()",
+        context,
+    )
+
+    assert result is True
+    assert context["process_initiator_user"] == {
+        "email": "initiator_user@example.com",
+        "display_name": "Mr. Process Initiator User",
+    }
+
+
 def test_advance_workflow_prints_unittest_break_when_no_ready_task_is_unexpected(monkeypatch, capsys):
     task = FakeTask(bpmn_id="InitialTask")
     workflow = SimpleNamespace(subprocess_specs={}, completed=False)

--- a/spiff-arena-common/tests/spiff_arena_common/test_runner.py
+++ b/spiff-arena-common/tests/spiff_arena_common/test_runner.py
@@ -73,18 +73,27 @@ def test_custom_environment_get_current_task_data_filters_internal_keys():
     assert context["result"] == {"visible": 1}
 
 
-def test_custom_environment_get_process_initiator_user_returns_stub_user():
+def test_custom_environment_get_process_initiator_user_returns_serialized_stub_user():
     context = {}
 
     result = runner.CustomEnvironment().execute(
-        "process_initiator_user = get_process_initiator_user()",
+        "initiator_user = get_process_initiator_user()\n"
+        'username = initiator_user["username"]',
         context,
     )
 
     assert result is True
-    assert context["process_initiator_user"] == {
+    assert context["username"] == "initiator_user"
+    assert context["initiator_user"] == {
+        "id": 1,
+        "username": "initiator_user",
         "email": "initiator_user@example.com",
         "display_name": "Mr. Process Initiator User",
+        "tenant_specific_field_1": "initiator_tenant_specific_field_1",
+        "tenant_specific_field_2": "initiator_tenant_specific_field_2",
+        "tenant_specific_field_3": "initiator_tenant_specific_field_3",
+        "updated_at_in_seconds": 0,
+        "created_at_in_seconds": 0,
     }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "spiff-arena-common"
-version = "0.1.44"
+version = "0.1.45"
 source = { editable = "spiff-arena-common" }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
Was missing from the common runner's stubs of arena custom functions. 