### PR TITLE
local dev: default frontend url to http://localhost:$((PORT + 1)) instead of hardcoded 7001

### DIFF
--- a/spiffworkflow-backend/bin/local_development_environment_setup
+++ b/spiffworkflow-backend/bin/local_development_environment_setup
@@ -13,6 +13,14 @@ if [ "${BASH_SOURCE[0]}" -ef "$0" ]; then
 fi
 
 PORT="${SPIFFWORKFLOW_BACKEND_PORT:-7000}"
+
+# by convention the frontend dev server runs on the port one above the backend
+# (spiffworkflow-frontend/src/config.tsx assumes backend = frontend port - 1).
+# keep login redirect_url validation in sync with that convention when the
+# backend runs on a non-default port, or login fails with InvalidRedirectUrlError.
+if [[ -z "${SPIFFWORKFLOW_BACKEND_URL_FOR_FRONTEND:-}" ]]; then
+  export SPIFFWORKFLOW_BACKEND_URL_FOR_FRONTEND="http://localhost:$((PORT + 1))"
+fi
 acceptance_test_mode="false"
 
 use_local_open_id="true"


### PR DESCRIPTION
Running the backend on a non-default port broke login with `InvalidRedirectUrlError`, because `SPIFFWORKFLOW_BACKEND_URL_FOR_FRONTEND` stayed hardcoded to `http://localhost:7001` while the frontend conventionally runs on backend port + 1. This change derives the frontend port number from the backend port number.