### PR TITLE
Stub a few more arena functions in common

### DIFF
--- a/spiff-arena-common/pyproject.toml
+++ b/spiff-arena-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spiff-arena-common"
-version = "0.1.45"
+version = "0.1.46"
 description = "Shared Python utilities for Spiff Arena frontend and backend components"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/spiff-arena-common/src/spiff_arena_common/runner.py
+++ b/spiff-arena-common/src/spiff_arena_common/runner.py
@@ -6,7 +6,6 @@ import json
 import logging
 import time
 import uuid
-from copy import deepcopy
 from types import ModuleType
 
 import jsonschema
@@ -298,7 +297,9 @@ class CustomEnvironment(TaskDataEnvironment):
             "email": "current_user@example.com",
             "display_name": "Mr. Current User",
         }
-        external_context["get_process_initiator_user"] = lambda: deepcopy(process_initiator_user)
+        external_context["get_process_initiator_user"] = lambda: {
+            key: value for key, value in process_initiator_user.items()
+        }
         external_context["get_group_members"] = lambda group_name: [
             "group_member_1@example.com",
             "group_member_2@example.com",
@@ -317,11 +318,11 @@ class CustomEnvironment(TaskDataEnvironment):
 class CustomScriptEngine(PythonScriptEngine):
     def __init__(self, external_context=None):
         super().__init__(environment=CustomEnvironment())
-        self.external_context = deepcopy(external_context or {})
+        self.external_context = external_context or {}
 
     def execute(self, task, script, external_context=None):
         if self.external_context:
-            task.data[_EXTERNAL_CONTEXT_KEY] = deepcopy(self.external_context)
+            task.data[_EXTERNAL_CONTEXT_KEY] = self.external_context
         return super().execute(task, script, external_context)
 
     def call_service(
@@ -811,9 +812,7 @@ def advance_workflow(specs, state, completed_task, strategy_name, start_params, 
     start_data = dict(start_params.get("data", {})) if start_params else {}
     workflow = hydrate_workflow(specs, state, session_id=session_id)
     if _EXTERNAL_CONTEXT_KEY in start_data:
-        workflow.script_engine.external_context = deepcopy(
-            start_data.pop(_EXTERNAL_CONTEXT_KEY, {})
-        )
+        workflow.script_engine.external_context = start_data.pop(_EXTERNAL_CONTEXT_KEY, {})
     if state == {} and start_params:
         for task in workflow.get_tasks(task_filter=TaskFilter(state=TaskState.READY, spec_name="Start")):
             task.data.update(start_data)

--- a/spiff-arena-common/src/spiff_arena_common/runner.py
+++ b/spiff-arena-common/src/spiff_arena_common/runner.py
@@ -269,7 +269,7 @@ class CustomEnvironment(TaskDataEnvironment):
             "process_model_identifier": "local",
         }
         external_context["get_url_for_task"] = lambda task_guid, public=False: (
-            f"http://localhost:5173{'/public' if public is True else ''}/tasks/0/{task_guid}"
+            f"http://local.spiff{'/public' if public is True else ''}/tasks/0/{task_guid}"
         )
         external_context["get_task_potential_owners"] = lambda task_guid: {
             "users": ["task_owner_1@example.com", "task_owner_2@example.com"],

--- a/spiff-arena-common/src/spiff_arena_common/runner.py
+++ b/spiff-arena-common/src/spiff_arena_common/runner.py
@@ -268,6 +268,9 @@ class CustomEnvironment(TaskDataEnvironment):
             "process_instance_id": 0,
             "process_model_identifier": "local",
         }
+        external_context["get_url_for_task"] = lambda task_guid, public=False: (
+            f"http://localhost:5173{'/public' if public is True else ''}/tasks/0/{task_guid}"
+        )
         external_context["get_current_user"] = lambda: {
             "email": "current_user@example.com",
             "display_name": "Mr. Current User",

--- a/spiff-arena-common/src/spiff_arena_common/runner.py
+++ b/spiff-arena-common/src/spiff_arena_common/runner.py
@@ -264,7 +264,7 @@ class CustomEnvironment(TaskDataEnvironment):
             external_context = {}
 
         external_context["get_task_data_value"] = lambda k, d=None: context.get(k, d)
-        external_context["get_top_level_process_info"] = lambda: {
+        external_context["get_toplevel_process_info"] = lambda: {
             "process_instance_id": 0,
             "process_model_identifier": "local",
         }

--- a/spiff-arena-common/src/spiff_arena_common/runner.py
+++ b/spiff-arena-common/src/spiff_arena_common/runner.py
@@ -6,6 +6,7 @@ import json
 import logging
 import time
 import uuid
+from copy import deepcopy
 from types import ModuleType
 
 import jsonschema
@@ -64,6 +65,18 @@ from SpiffWorkflow.util.task import TaskFilter, TaskState  # noqa: E402
 logging.basicConfig(level=logging.ERROR)
 
 _INTERNAL_KEYS = {"__builtins__", "__annotations__"}
+_EXTERNAL_CONTEXT_KEY = "spiff__external_context"
+_DEFAULT_PROCESS_INITIATOR_USER = {
+    "id": 1,
+    "username": "initiator_user",
+    "email": "initiator_user@example.com",
+    "display_name": "Mr. Process Initiator User",
+    "tenant_specific_field_1": "initiator_tenant_specific_field_1",
+    "tenant_specific_field_2": "initiator_tenant_specific_field_2",
+    "tenant_specific_field_3": "initiator_tenant_specific_field_3",
+    "updated_at_in_seconds": 0,
+    "created_at_in_seconds": 0,
+}
 
 class CustomManualTask(ManualTask):
     def _run(self, task):
@@ -263,6 +276,12 @@ class CustomEnvironment(TaskDataEnvironment):
         if external_context is None:
             external_context = {}
 
+        configured_external_context = context.pop(_EXTERNAL_CONTEXT_KEY, {})
+        process_initiator_user = configured_external_context.get(
+            "get_process_initiator_user",
+            _DEFAULT_PROCESS_INITIATOR_USER,
+        )
+
         external_context["get_task_data_value"] = lambda k, d=None: context.get(k, d)
         external_context["get_toplevel_process_info"] = lambda: {
             "process_instance_id": 0,
@@ -279,17 +298,7 @@ class CustomEnvironment(TaskDataEnvironment):
             "email": "current_user@example.com",
             "display_name": "Mr. Current User",
         }
-        external_context["get_process_initiator_user"] = lambda: {
-            "id": 1,
-            "username": "initiator_user",
-            "email": "initiator_user@example.com",
-            "display_name": "Mr. Process Initiator User",
-            "tenant_specific_field_1": "initiator_tenant_specific_field_1",
-            "tenant_specific_field_2": "initiator_tenant_specific_field_2",
-            "tenant_specific_field_3": "initiator_tenant_specific_field_3",
-            "updated_at_in_seconds": 0,
-            "created_at_in_seconds": 0,
-        }
+        external_context["get_process_initiator_user"] = lambda: deepcopy(process_initiator_user)
         external_context["get_group_members"] = lambda group_name: [
             "group_member_1@example.com",
             "group_member_2@example.com",
@@ -305,12 +314,15 @@ class CustomEnvironment(TaskDataEnvironment):
         return super().execute(script or "", context, external_context)
 
 
-custom_environment = CustomEnvironment()
-
-
 class CustomScriptEngine(PythonScriptEngine):
-    def __init__(self):
-        super().__init__(environment=custom_environment)
+    def __init__(self, external_context=None):
+        super().__init__(environment=CustomEnvironment())
+        self.external_context = deepcopy(external_context or {})
+
+    def execute(self, task, script, external_context=None):
+        if self.external_context:
+            task.data[_EXTERNAL_CONTEXT_KEY] = deepcopy(self.external_context)
+        return super().execute(task, script, external_context)
 
     def call_service(
         self,
@@ -796,10 +808,15 @@ def advance_workflow(specs, state, completed_task, strategy_name, start_params, 
         if 0 <= jump_to_step_idx < len(steps):
             state = steps[jump_to_step_idx]
 
+    start_data = dict(start_params.get("data", {})) if start_params else {}
     workflow = hydrate_workflow(specs, state, session_id=session_id)
+    if _EXTERNAL_CONTEXT_KEY in start_data:
+        workflow.script_engine.external_context = deepcopy(
+            start_data.pop(_EXTERNAL_CONTEXT_KEY, {})
+        )
     if state == {} and start_params:
         for task in workflow.get_tasks(task_filter=TaskFilter(state=TaskState.READY, spec_name="Start")):
-            task.data.update(start_params.get("data", {}))
+            task.data.update(start_data)
             break
 
     try:

--- a/spiff-arena-common/src/spiff_arena_common/runner.py
+++ b/spiff-arena-common/src/spiff_arena_common/runner.py
@@ -271,6 +271,10 @@ class CustomEnvironment(TaskDataEnvironment):
         external_context["get_url_for_task"] = lambda task_guid, public=False: (
             f"http://localhost:5173{'/public' if public is True else ''}/tasks/0/{task_guid}"
         )
+        external_context["get_task_potential_owners"] = lambda task_guid: {
+            "users": ["task_owner_1@example.com", "task_owner_2@example.com"],
+            "groups": ["task_owners"],
+        }
         external_context["get_current_user"] = lambda: {
             "email": "current_user@example.com",
             "display_name": "Mr. Current User",

--- a/spiff-arena-common/tests/spiff_arena_common/test_runner.py
+++ b/spiff-arena-common/tests/spiff_arena_common/test_runner.py
@@ -88,6 +88,20 @@ def test_custom_environment_get_toplevel_process_info_returns_local_stub():
     }
 
 
+def test_custom_environment_get_url_for_task_returns_local_task_urls():
+    context = {}
+
+    result = runner.CustomEnvironment().execute(
+        'task_url = get_url_for_task("task-guid-123")\n'
+        'public_task_url = get_url_for_task("task-guid-123", public=True)',
+        context,
+    )
+
+    assert result is True
+    assert context["task_url"] == "http://localhost:5173/tasks/0/task-guid-123"
+    assert context["public_task_url"] == "http://localhost:5173/public/tasks/0/task-guid-123"
+
+
 def test_custom_environment_get_process_initiator_user_returns_serialized_stub_user():
     context = {}
 

--- a/spiff-arena-common/tests/spiff_arena_common/test_runner.py
+++ b/spiff-arena-common/tests/spiff_arena_common/test_runner.py
@@ -144,6 +144,119 @@ def test_custom_environment_get_process_initiator_user_returns_serialized_stub_u
     }
 
 
+def test_custom_environment_uses_configured_process_initiator_and_cleans_transport_data():
+    configured_user = {
+        "id": 23,
+        "username": "bob",
+        "email": "bob@example.com",
+        "display_name": "Bob Example",
+    }
+    context = {
+        "spiff__external_context": {
+            "get_process_initiator_user": configured_user,
+        },
+    }
+
+    result = runner.CustomEnvironment().execute(
+        "first_user = get_process_initiator_user()\n"
+        'first_user["username"] = "changed"\n'
+        "second_user = get_process_initiator_user()",
+        context,
+    )
+
+    assert result is True
+    assert context["first_user"]["username"] == "changed"
+    assert context["second_user"] == configured_user
+    assert "spiff__external_context" not in context
+
+
+def test_custom_script_engine_supplies_external_context_to_each_script():
+    configured_external_context = {
+        "get_process_initiator_user": {"username": "bob"},
+    }
+    engine = runner.CustomScriptEngine(configured_external_context)
+    first_task = SimpleNamespace(data={})
+    second_task = SimpleNamespace(data={})
+
+    engine.execute(first_task, 'username = get_process_initiator_user()["username"]')
+    engine.execute(second_task, 'username = get_process_initiator_user()["username"]')
+
+    assert first_task.data == {"username": "bob"}
+    assert second_task.data == {"username": "bob"}
+
+
+def test_advance_workflow_extracts_external_context_without_mutating_start_params(monkeypatch):
+    configured_external_context = {
+        "get_process_initiator_user": {"username": "bob"},
+    }
+    start_task = FakeTask()
+    workflow = SimpleNamespace(
+        script_engine=runner.CustomScriptEngine(),
+        get_tasks=lambda task_filter: [start_task],
+    )
+    start_params = {
+        "data": {
+            "case_id": "case-1",
+            "spiff__external_context": configured_external_context,
+        },
+    }
+    original_start_params = {
+        "data": {
+            "case_id": "case-1",
+            "spiff__external_context": configured_external_context,
+        },
+    }
+    monkeypatch.setattr(runner, "hydrate_workflow", lambda *args, **kwargs: workflow)
+    monkeypatch.setattr(runner, "next_task", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        runner,
+        "_advance_workflow",
+        lambda *args, **kwargs: {"status": "ok"},
+    )
+
+    result = runner.advance_workflow(
+        specs={},
+        state={},
+        completed_task=None,
+        strategy_name="oneAtATime",
+        start_params=start_params,
+    )
+
+    assert result == {"status": "ok"}
+    assert workflow.script_engine.external_context == configured_external_context
+    assert start_task.data == {"case_id": "case-1"}
+    assert start_params == original_start_params
+
+
+def test_advance_workflow_restores_external_context_after_rehydration(monkeypatch):
+    configured_external_context = {
+        "get_process_initiator_user": {"username": "bob"},
+    }
+    workflow = SimpleNamespace(script_engine=runner.CustomScriptEngine())
+    monkeypatch.setattr(runner, "hydrate_workflow", lambda *args, **kwargs: workflow)
+    monkeypatch.setattr(runner, "next_task", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        runner,
+        "_advance_workflow",
+        lambda *args, **kwargs: {"status": "ok"},
+    )
+
+    result = runner.advance_workflow(
+        specs={},
+        state={"restored": True},
+        completed_task=None,
+        strategy_name="oneAtATime",
+        start_params={
+            "data": {
+                "spiff__external_context": configured_external_context,
+            },
+        },
+    )
+
+    assert result == {"status": "ok"}
+    assert workflow.script_engine.external_context == configured_external_context
+
+
 def test_advance_workflow_prints_unittest_break_when_no_ready_task_is_unexpected(monkeypatch, capsys):
     task = FakeTask(bpmn_id="InitialTask")
     workflow = SimpleNamespace(subprocess_specs={}, completed=False)

--- a/spiff-arena-common/tests/spiff_arena_common/test_runner.py
+++ b/spiff-arena-common/tests/spiff_arena_common/test_runner.py
@@ -98,8 +98,8 @@ def test_custom_environment_get_url_for_task_returns_local_task_urls():
     )
 
     assert result is True
-    assert context["task_url"] == "http://localhost:5173/tasks/0/task-guid-123"
-    assert context["public_task_url"] == "http://localhost:5173/public/tasks/0/task-guid-123"
+    assert context["task_url"] == "http://local.spiff/tasks/0/task-guid-123"
+    assert context["public_task_url"] == "http://local.spiff/public/tasks/0/task-guid-123"
 
 
 def test_custom_environment_get_task_potential_owners_returns_local_stub_owners():

--- a/spiff-arena-common/tests/spiff_arena_common/test_runner.py
+++ b/spiff-arena-common/tests/spiff_arena_common/test_runner.py
@@ -102,6 +102,24 @@ def test_custom_environment_get_url_for_task_returns_local_task_urls():
     assert context["public_task_url"] == "http://localhost:5173/public/tasks/0/task-guid-123"
 
 
+def test_custom_environment_get_task_potential_owners_returns_local_stub_owners():
+    context = {}
+
+    result = runner.CustomEnvironment().execute(
+        'owners = get_task_potential_owners("task-guid-123")\n'
+        'owners_by_keyword = get_task_potential_owners(task_guid="task-guid-456")',
+        context,
+    )
+
+    expected = {
+        "users": ["task_owner_1@example.com", "task_owner_2@example.com"],
+        "groups": ["task_owners"],
+    }
+    assert result is True
+    assert context["owners"] == expected
+    assert context["owners_by_keyword"] == expected
+
+
 def test_custom_environment_get_process_initiator_user_returns_serialized_stub_user():
     context = {}
 

--- a/spiff-arena-common/tests/spiff_arena_common/test_runner.py
+++ b/spiff-arena-common/tests/spiff_arena_common/test_runner.py
@@ -73,6 +73,21 @@ def test_custom_environment_get_current_task_data_filters_internal_keys():
     assert context["result"] == {"visible": 1}
 
 
+def test_custom_environment_get_toplevel_process_info_returns_local_stub():
+    context = {}
+
+    result = runner.CustomEnvironment().execute(
+        "process_info = get_toplevel_process_info()",
+        context,
+    )
+
+    assert result is True
+    assert context["process_info"] == {
+        "process_instance_id": 0,
+        "process_model_identifier": "local",
+    }
+
+
 def test_custom_environment_get_process_initiator_user_returns_serialized_stub_user():
     context = {}
 

--- a/uv.lock
+++ b/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "spiff-arena-common"
-version = "0.1.45"
+version = "0.1.46"
 source = { editable = "spiff-arena-common" }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
Previously there was a typo in the `get_toplevel_process_info` function, corrected that. Stubbed out a few more functions needed for some client process models and added the ability to inject the results of `get_process_initiator_user` since that controls some flows for the previously mentioned process models. I didn't stub/allow injecting all the things due to lack of current need. Figured we can add more in as required.