### PR TITLE
Update PyPI publishing action

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -34,7 +34,7 @@ jobs:
         run: uv build spiff-arena-common
       - name: Publish distribution 📦 to PyPI
         if: github.ref == 'refs/heads/main'
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           user: __token__
           password: ${{ secrets.COMMON_PYPI_KEY }}


### PR DESCRIPTION
The last pypi pushed failed, thinking is that the action was old and emitted a no longer accepted metadata version. Attempting to fix.