### PR TITLE
fix full-box border on selected sidenav item, keeping left accent

### DIFF
--- a/spiffworkflow-frontend/src/components/SideNav.tsx
+++ b/spiffworkflow-frontend/src/components/SideNav.tsx
@@ -359,10 +359,9 @@ function SideNav({
                           ? 'background.light'
                           : 'inherit',
                       color: selectedTab === item.id ? mainBlue : 'inherit',
-                      borderColor:
+                      borderLeft: '4px solid',
+                      borderLeftColor:
                         selectedTab === item.id ? mainBlue : 'transparent',
-                      borderLeftWidth: '4px',
-                      borderStyle: 'solid',
                       justifyContent: isCollapsed ? 'center' : 'flex-start',
                     }}
                   >


### PR DESCRIPTION
The selected nav item rendered a blue border on all four sides: borderColor + borderStyle 'solid' apply to every side, and the three non-left sides used the default border width. Restrict the styling to the left side only so the item keeps its 4px accent bar without the box outline. Selection remains conveyed by the light background + blue label.

The highlight has shipped since 11c918a9c (#2244, Mar 2025); it became visible after f109b984c (#2922) removed the Carbon chrome. This change restores the visual design to the pre-f109b984c baseline.