### PR TITLE
More work to stub arena functions in common

### DIFF
--- a/spiff-arena-common/pyproject.toml
+++ b/spiff-arena-common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spiff-arena-common"
-version = "0.1.46"
+version = "0.1.47"
 description = "Shared Python utilities for Spiff Arena frontend and backend components."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/spiff-arena-common/src/spiff_arena_common/runner.py
+++ b/spiff-arena-common/src/spiff_arena_common/runner.py
@@ -271,7 +271,7 @@ class CustomEnvironment(TaskDataEnvironment):
             "timedelta": datetime.timedelta,
         })
 
-    def execute(self, script, context, external_context=None):
+    def _build_external_context(self, context, external_context=None):
         if external_context is None:
             external_context = {}
 
@@ -312,7 +312,14 @@ class CustomEnvironment(TaskDataEnvironment):
             for k, v in DefaultRegistry().convert(context).items()
             if k not in hidden_keys and not callable(v) and not isinstance(v, ModuleType)
         }
+        return external_context
 
+    def evaluate(self, expression, context, external_context=None):
+        external_context = self._build_external_context(context, external_context)
+        return super().evaluate(expression, context, external_context)
+
+    def execute(self, script, context, external_context=None):
+        external_context = self._build_external_context(context, external_context)
         return super().execute(script or "", context, external_context)
 
 
@@ -321,9 +328,16 @@ class CustomScriptEngine(PythonScriptEngine):
         super().__init__(environment=CustomEnvironment())
         self.external_context = external_context or {}
 
-    def execute(self, task, script, external_context=None):
+    def _apply_external_context(self, task):
         if self.external_context:
             task.data[_EXTERNAL_CONTEXT_KEY] = self.external_context
+
+    def evaluate(self, task, expression, external_context=None):
+        self._apply_external_context(task)
+        return super().evaluate(task, expression, external_context)
+
+    def execute(self, task, script, external_context=None):
+        self._apply_external_context(task)
         return super().execute(task, script, external_context)
 
     def call_service(

--- a/spiff-arena-common/src/spiff_arena_common/runner.py
+++ b/spiff-arena-common/src/spiff_arena_common/runner.py
@@ -286,6 +286,7 @@ class CustomEnvironment(TaskDataEnvironment):
             "process_instance_id": 0,
             "process_model_identifier": "local",
         }
+        external_context["get_frontend_url"] = lambda: "http://local.spiff"
         external_context["get_url_for_task"] = lambda task_guid, public=False: (
             f"http://local.spiff{'/public' if public is True else ''}/tasks/0/{task_guid}"
         )

--- a/spiff-arena-common/tests/spiff_arena_common/test_runner.py
+++ b/spiff-arena-common/tests/spiff_arena_common/test_runner.py
@@ -182,6 +182,129 @@ def test_custom_environment_uses_configured_process_initiator_and_cleans_transpo
     assert "spiff__external_context" not in context
 
 
+def test_service_task_property_evaluation_has_all_local_stubs():
+    bpmn = """
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:spiffworkflow="http://spiffworkflow.org/bpmn/schema/1.0/core" id="Definitions_service_stub_context" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_service_stub_context" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_start_service</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_start_service" sourceRef="StartEvent_1" targetRef="ServiceTask_1" />
+    <bpmn:serviceTask id="ServiceTask_1" name="Service Task">
+      <bpmn:extensionElements>
+        <spiffworkflow:serviceTaskOperator id="http/GetRequest" resultVariable="response">
+          <spiffworkflow:parameters>
+            <spiffworkflow:parameter id="task_data_value" type="str" value="get_task_data_value(&quot;case_id&quot;)" />
+            <spiffworkflow:parameter id="process_instance_id" type="int" value="get_toplevel_process_info()[&quot;process_instance_id&quot;]" />
+            <spiffworkflow:parameter id="frontend_url" type="str" value="get_frontend_url()" />
+            <spiffworkflow:parameter id="task_url" type="str" value="get_url_for_task(&quot;task-guid-123&quot;)" />
+            <spiffworkflow:parameter id="task_owners" type="json" value="get_task_potential_owners(&quot;task-guid-123&quot;)" />
+            <spiffworkflow:parameter id="current_user" type="json" value="get_current_user()" />
+            <spiffworkflow:parameter id="initiator_user" type="json" value="get_process_initiator_user()" />
+            <spiffworkflow:parameter id="group_members" type="json" value="get_group_members(&quot;reviewers&quot;)" />
+            <spiffworkflow:parameter id="current_task_data" type="json" value="get_current_task_data()" />
+          </spiffworkflow:parameters>
+        </spiffworkflow:serviceTaskOperator>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_start_service</bpmn:incoming>
+      <bpmn:outgoing>Flow_service_end</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_service_end" sourceRef="ServiceTask_1" targetRef="EndEvent_1" />
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_service_end</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+</bpmn:definitions>
+"""
+    configured_user = {
+        "id": 23,
+        "username": "bob",
+        "email": "bob@example.com",
+        "display_name": "Bob Example",
+    }
+    specs, err = runner.specs_from_xml([("service_stub_context.bpmn", bpmn)])
+    assert err is None
+
+    session_id = "service-stub-context-test"
+    first_step = json.loads(
+        runner.advance_workflow(
+            specs,
+            {},
+            None,
+            "oneAtATime",
+            {
+                "data": {
+                    "case_id": "case-1",
+                    "spiff__external_context": {
+                        "get_process_initiator_user": configured_user,
+                    },
+                },
+            },
+            session_id=session_id,
+        )
+    )
+    start_task = next(
+        task
+        for task in first_step["pending_tasks"]
+        if task["task_spec"]["typename"] == "StartEvent"
+    )
+    service_ready_step = json.loads(
+        runner.advance_workflow(
+            specs,
+            None,
+            {"id": start_task["id"], "data": {}},
+            "oneAtATime",
+            None,
+            session_id=session_id,
+        )
+    )
+    service_task = next(
+        task
+        for task in service_ready_step["pending_tasks"]
+        if task["task_spec"]["bpmn_id"] == "ServiceTask_1"
+    )
+    result = json.loads(
+        runner.advance_workflow(
+            specs,
+            None,
+            {"id": service_task["id"], "data": {}},
+            "oneAtATime",
+            None,
+            session_id=session_id,
+        )
+    )
+
+    assert result["status"] == "ok", result.get("message")
+    started_service_task = next(
+        task
+        for task in result["pending_tasks"]
+        if task["id"] == service_task["id"]
+    )
+    params = started_service_task["data"]["response"]["operation_params"]
+    assert params == {
+        "task_data_value": "case-1",
+        "process_instance_id": 0,
+        "frontend_url": "http://local.spiff",
+        "task_url": "http://local.spiff/tasks/0/task-guid-123",
+        "task_owners": {
+            "users": ["task_owner_1@example.com", "task_owner_2@example.com"],
+            "groups": ["task_owners"],
+        },
+        "current_user": {
+            "email": "current_user@example.com",
+            "display_name": "Mr. Current User",
+        },
+        "initiator_user": configured_user,
+        "group_members": [
+            "group_member_1@example.com",
+            "group_member_2@example.com",
+            "group_member_3@example.com",
+        ],
+        "current_task_data": {"case_id": "case-1"},
+        "spiff__task_data": {"case_id": "case-1"},
+    }
+
+
 def test_custom_script_engine_supplies_external_context_to_each_script():
     configured_external_context = {
         "get_process_initiator_user": {"username": "bob"},

--- a/spiff-arena-common/tests/spiff_arena_common/test_runner.py
+++ b/spiff-arena-common/tests/spiff_arena_common/test_runner.py
@@ -88,6 +88,18 @@ def test_custom_environment_get_toplevel_process_info_returns_local_stub():
     }
 
 
+def test_custom_environment_get_frontend_url_returns_local_stub():
+    context = {}
+
+    result = runner.CustomEnvironment().execute(
+        "frontend_url = get_frontend_url()",
+        context,
+    )
+
+    assert result is True
+    assert context["frontend_url"] == "http://local.spiff"
+
+
 def test_custom_environment_get_url_for_task_returns_local_task_urls():
     context = {}
 

--- a/uv.lock
+++ b/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "spiff-arena-common"
-version = "0.1.46"
+version = "0.1.47"
 source = { editable = "spiff-arena-common" }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
This adds a stub for `get_frontend_url` and also makes the stubs available for use from `evaluate` so they can be used from service task properties, gateways, etc. Prior they were only exposed to script tasks via `execute`. These are required for some client process models.