### PR TITLE
Make Arena frontend base-path configurable

### DIFF
--- a/spiffworkflow-frontend/src/App.tsx
+++ b/spiffworkflow-frontend/src/App.tsx
@@ -6,6 +6,7 @@ import APIErrorProvider from './contexts/APIErrorContext';
 import ContainerForExtensions from './ContainerForExtensions';
 import PublicRoutes from './views/PublicRoutes';
 import { CONFIGURATION_ERRORS } from './config';
+import { getRouterBasename } from './helpers/basePath';
 
 const queryClient = new QueryClient();
 
@@ -52,12 +53,15 @@ export default function App() {
       </div>
     );
   };
-  const router = createBrowserRouter([
-    {
-      path: '*',
-      Component: layout,
-      children: routeComponents(),
-    },
-  ]);
+  const router = createBrowserRouter(
+    [
+      {
+        path: '*',
+        Component: layout,
+        children: routeComponents(),
+      },
+    ],
+    { basename: getRouterBasename() },
+  );
   return <RouterProvider router={router} />;
 }

--- a/spiffworkflow-frontend/src/helpers/basePath.test.ts
+++ b/spiffworkflow-frontend/src/helpers/basePath.test.ts
@@ -1,119 +1,19 @@
-/* eslint-disable sonarjs/no-duplicate-string */
-import { describe, it, expect } from 'vitest';
-import {
-  normalizeBase,
-  getBaseUrl,
-  getRouterBasename,
-  withBasePath,
-  stripBasePath,
-} from './basePath';
+import { describe, expect, it } from 'vitest';
+import { getRouterBasename, stripBasePath, withBasePath } from './basePath';
 
-describe('normalizeBase', () => {
-  it('defaults to /', () => {
-    expect(normalizeBase(undefined)).toEqual('/');
-    expect(normalizeBase('')).toEqual('/');
-    expect(normalizeBase('   ')).toEqual('/');
-  });
-
-  it('ensures leading and trailing slash', () => {
-    expect(normalizeBase('/')).toEqual('/');
-    expect(normalizeBase('workflow')).toEqual('/workflow/');
-    expect(normalizeBase('/workflow')).toEqual('/workflow/');
-    expect(normalizeBase('/workflow/')).toEqual('/workflow/');
-    expect(normalizeBase('workflow/')).toEqual('/workflow/');
-  });
-
-  it('trims whitespace', () => {
-    expect(normalizeBase('  /workflow/  ')).toEqual('/workflow/');
-  });
-});
-
-describe('getBaseUrl', () => {
-  it('defaults to / when no base is configured', () => {
-    expect(getBaseUrl(undefined)).toEqual('/');
-    expect(getBaseUrl('/')).toEqual('/');
-  });
-
-  it('normalizes workflow base', () => {
-    expect(getBaseUrl('/workflow/')).toEqual('/workflow/');
-    expect(getBaseUrl('/workflow')).toEqual('/workflow/');
-    expect(getBaseUrl('workflow')).toEqual('/workflow/');
-  });
-});
-
-describe('getRouterBasename', () => {
-  it('returns undefined for root', () => {
-    expect(getRouterBasename('/')).toEqual(undefined);
-    expect(getRouterBasename(undefined)).toEqual(undefined);
-  });
-
-  it('returns /workflow for workflow base', () => {
-    expect(getRouterBasename('/workflow/')).toEqual('/workflow');
-    expect(getRouterBasename('/workflow')).toEqual('/workflow');
-    expect(getRouterBasename('workflow')).toEqual('/workflow');
-  });
-
-  it('handles multi-segment base', () => {
-    expect(getRouterBasename('/a/b/')).toEqual('/a/b');
-  });
-});
-
-describe('withBasePath', () => {
-  it('returns path unchanged for root', () => {
+describe('frontend base path', () => {
+  it('preserves root-path behavior by default', () => {
+    expect(getRouterBasename('/')).toBeUndefined();
     expect(withBasePath('/login', '/')).toEqual('/login');
-    expect(withBasePath('/public/sign-out', '/')).toEqual('/public/sign-out');
+    expect(stripBasePath('/login', '/')).toEqual('/login');
   });
 
-  it('prefixes path with workflow base', () => {
+  it('uses the workflow base for full-page navigation', () => {
+    expect(getRouterBasename('/workflow/')).toEqual('/workflow');
     expect(withBasePath('/login', '/workflow/')).toEqual('/workflow/login');
-    expect(withBasePath('/public/sign-out', '/workflow/')).toEqual(
-      '/workflow/public/sign-out',
-    );
-    expect(withBasePath('login', '/workflow/')).toEqual('/workflow/login');
-  });
-
-  it('does not double-prefix when path already has base', () => {
     expect(withBasePath('/workflow/login', '/workflow/')).toEqual(
       '/workflow/login',
     );
-  });
-});
-
-describe('stripBasePath', () => {
-  it('returns pathname unchanged for root', () => {
-    expect(stripBasePath('/login', '/')).toEqual('/login');
-    expect(stripBasePath('/workflow/login', '/')).toEqual('/workflow/login');
-  });
-
-  it('strips workflow base', () => {
     expect(stripBasePath('/workflow/login', '/workflow/')).toEqual('/login');
-    expect(stripBasePath('/workflow', '/workflow/')).toEqual('/');
-    expect(stripBasePath('/workflow/', '/workflow/')).toEqual('/');
-    expect(stripBasePath('/', '/workflow/')).toEqual('/');
-  });
-
-  it('does not strip unrelated paths', () => {
-    expect(stripBasePath('/other/login', '/workflow/')).toEqual('/other/login');
-  });
-});
-
-describe('same base drives both assets and router', () => {
-  it('produces consistent base and basename for /workflow/', () => {
-    const base = getBaseUrl('/workflow/');
-    const basename = getRouterBasename('/workflow/');
-    expect(base).toEqual('/workflow/');
-    expect(basename).toEqual('/workflow');
-    // Asset URLs would be `${base}assets/...`
-    expect(`${base}assets/index.js`).toEqual('/workflow/assets/index.js');
-    // Router path would be `${basename}/some/route`
-    expect(`${basename}/tasks`).toEqual('/workflow/tasks');
-  });
-
-  it('produces consistent root for /', () => {
-    const base = getBaseUrl('/');
-    const basename = getRouterBasename('/');
-    expect(base).toEqual('/');
-    expect(basename).toEqual(undefined);
-    expect(`${base}assets/index.js`).toEqual('/assets/index.js');
   });
 });

--- a/spiffworkflow-frontend/src/helpers/basePath.test.ts
+++ b/spiffworkflow-frontend/src/helpers/basePath.test.ts
@@ -1,0 +1,119 @@
+/* eslint-disable sonarjs/no-duplicate-string */
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeBase,
+  getBaseUrl,
+  getRouterBasename,
+  withBasePath,
+  stripBasePath,
+} from './basePath';
+
+describe('normalizeBase', () => {
+  it('defaults to /', () => {
+    expect(normalizeBase(undefined)).toEqual('/');
+    expect(normalizeBase('')).toEqual('/');
+    expect(normalizeBase('   ')).toEqual('/');
+  });
+
+  it('ensures leading and trailing slash', () => {
+    expect(normalizeBase('/')).toEqual('/');
+    expect(normalizeBase('workflow')).toEqual('/workflow/');
+    expect(normalizeBase('/workflow')).toEqual('/workflow/');
+    expect(normalizeBase('/workflow/')).toEqual('/workflow/');
+    expect(normalizeBase('workflow/')).toEqual('/workflow/');
+  });
+
+  it('trims whitespace', () => {
+    expect(normalizeBase('  /workflow/  ')).toEqual('/workflow/');
+  });
+});
+
+describe('getBaseUrl', () => {
+  it('defaults to / when no base is configured', () => {
+    expect(getBaseUrl(undefined)).toEqual('/');
+    expect(getBaseUrl('/')).toEqual('/');
+  });
+
+  it('normalizes workflow base', () => {
+    expect(getBaseUrl('/workflow/')).toEqual('/workflow/');
+    expect(getBaseUrl('/workflow')).toEqual('/workflow/');
+    expect(getBaseUrl('workflow')).toEqual('/workflow/');
+  });
+});
+
+describe('getRouterBasename', () => {
+  it('returns undefined for root', () => {
+    expect(getRouterBasename('/')).toEqual(undefined);
+    expect(getRouterBasename(undefined)).toEqual(undefined);
+  });
+
+  it('returns /workflow for workflow base', () => {
+    expect(getRouterBasename('/workflow/')).toEqual('/workflow');
+    expect(getRouterBasename('/workflow')).toEqual('/workflow');
+    expect(getRouterBasename('workflow')).toEqual('/workflow');
+  });
+
+  it('handles multi-segment base', () => {
+    expect(getRouterBasename('/a/b/')).toEqual('/a/b');
+  });
+});
+
+describe('withBasePath', () => {
+  it('returns path unchanged for root', () => {
+    expect(withBasePath('/login', '/')).toEqual('/login');
+    expect(withBasePath('/public/sign-out', '/')).toEqual('/public/sign-out');
+  });
+
+  it('prefixes path with workflow base', () => {
+    expect(withBasePath('/login', '/workflow/')).toEqual('/workflow/login');
+    expect(withBasePath('/public/sign-out', '/workflow/')).toEqual(
+      '/workflow/public/sign-out',
+    );
+    expect(withBasePath('login', '/workflow/')).toEqual('/workflow/login');
+  });
+
+  it('does not double-prefix when path already has base', () => {
+    expect(withBasePath('/workflow/login', '/workflow/')).toEqual(
+      '/workflow/login',
+    );
+  });
+});
+
+describe('stripBasePath', () => {
+  it('returns pathname unchanged for root', () => {
+    expect(stripBasePath('/login', '/')).toEqual('/login');
+    expect(stripBasePath('/workflow/login', '/')).toEqual('/workflow/login');
+  });
+
+  it('strips workflow base', () => {
+    expect(stripBasePath('/workflow/login', '/workflow/')).toEqual('/login');
+    expect(stripBasePath('/workflow', '/workflow/')).toEqual('/');
+    expect(stripBasePath('/workflow/', '/workflow/')).toEqual('/');
+    expect(stripBasePath('/', '/workflow/')).toEqual('/');
+  });
+
+  it('does not strip unrelated paths', () => {
+    expect(stripBasePath('/other/login', '/workflow/')).toEqual('/other/login');
+  });
+});
+
+describe('same base drives both assets and router', () => {
+  it('produces consistent base and basename for /workflow/', () => {
+    const base = getBaseUrl('/workflow/');
+    const basename = getRouterBasename('/workflow/');
+    expect(base).toEqual('/workflow/');
+    expect(basename).toEqual('/workflow');
+    // Asset URLs would be `${base}assets/...`
+    expect(`${base}assets/index.js`).toEqual('/workflow/assets/index.js');
+    // Router path would be `${basename}/some/route`
+    expect(`${basename}/tasks`).toEqual('/workflow/tasks');
+  });
+
+  it('produces consistent root for /', () => {
+    const base = getBaseUrl('/');
+    const basename = getRouterBasename('/');
+    expect(base).toEqual('/');
+    expect(basename).toEqual(undefined);
+    expect(`${base}assets/index.js`).toEqual('/assets/index.js');
+  });
+});

--- a/spiffworkflow-frontend/src/helpers/basePath.ts
+++ b/spiffworkflow-frontend/src/helpers/basePath.ts
@@ -1,74 +1,28 @@
-/**
- * Frontend base path helpers.
- *
- * Vite's `base` is exposed at runtime as `import.meta.env.BASE_URL` and is
- * always normalized to have a leading and trailing slash (e.g. "/" or
- * "/workflow/"). React Router's `basename` expects a leading slash without a
- * trailing slash (e.g. "/workflow") or `undefined` for root.
- */
-
-export const normalizeBase = (raw?: string): string => {
-  let base = (raw ?? '/').trim();
-  if (!base) {
-    base = '/';
-  }
-  if (!base.startsWith('/')) {
-    base = `/${base}`;
-  }
-  if (!base.endsWith('/')) {
-    base += '/';
-  }
-  return base;
+const getBaseUrl = (baseUrl?: string): string => {
+  return baseUrl ?? (import.meta.env.BASE_URL as string | undefined) ?? '/';
 };
 
-/**
- * Returns the normalized Vite base URL. Defaults to "/" for backwards
- * compatibility with existing deployments.
- */
-export const getBaseUrl = (baseUrl?: string): string => {
-  const raw =
-    baseUrl ?? (import.meta.env.BASE_URL as string | undefined) ?? '/';
-  return normalizeBase(raw);
-};
-
-/**
- * Returns the React Router basename derived from the Vite base. Returns
- * `undefined` for root so that `createBrowserRouter` behaves identically to
- * the previous default.
- */
 export const getRouterBasename = (baseUrl?: string): string | undefined => {
   const base = getBaseUrl(baseUrl);
-  if (base === '/') {
-    return undefined;
-  }
-  return base.replace(/\/$/, '');
+  return base === '/' ? undefined : base.replace(/\/$/, '');
 };
 
-/**
- * Prefixes an absolute frontend path with the current base, if any.
- * Example: withBasePath("/login") -> "/workflow/login" when base is "/workflow/"
- */
 export const withBasePath = (path: string, baseUrl?: string): string => {
-  const base = getBaseUrl(baseUrl);
-  if (base === '/') {
+  const basename = getRouterBasename(baseUrl);
+  if (!basename) {
     return path;
   }
+
   const normalizedPath = path.startsWith('/') ? path : `/${path}`;
-  const baseWithoutTrailing = base.replace(/\/$/, '');
-  // Avoid double prefix if path already starts with base
   if (
-    normalizedPath === baseWithoutTrailing ||
-    normalizedPath.startsWith(`${baseWithoutTrailing}/`)
+    normalizedPath === basename ||
+    normalizedPath.startsWith(`${basename}/`)
   ) {
     return normalizedPath;
   }
-  return `${baseWithoutTrailing}${normalizedPath}`;
+  return `${basename}${normalizedPath}`;
 };
 
-/**
- * Strips the base prefix from a pathname, if present. Useful for comparing
- * `window.location.pathname` without being sensitive to the configured base.
- */
 export const stripBasePath = (pathname: string, baseUrl?: string): string => {
   const basename = getRouterBasename(baseUrl);
   if (!basename) {
@@ -78,8 +32,7 @@ export const stripBasePath = (pathname: string, baseUrl?: string): string => {
     return '/';
   }
   if (pathname.startsWith(`${basename}/`)) {
-    const stripped = pathname.slice(basename.length);
-    return stripped || '/';
+    return pathname.slice(basename.length) || '/';
   }
   return pathname;
 };

--- a/spiffworkflow-frontend/src/helpers/basePath.ts
+++ b/spiffworkflow-frontend/src/helpers/basePath.ts
@@ -1,0 +1,85 @@
+/**
+ * Frontend base path helpers.
+ *
+ * Vite's `base` is exposed at runtime as `import.meta.env.BASE_URL` and is
+ * always normalized to have a leading and trailing slash (e.g. "/" or
+ * "/workflow/"). React Router's `basename` expects a leading slash without a
+ * trailing slash (e.g. "/workflow") or `undefined` for root.
+ */
+
+export const normalizeBase = (raw?: string): string => {
+  let base = (raw ?? '/').trim();
+  if (!base) {
+    base = '/';
+  }
+  if (!base.startsWith('/')) {
+    base = `/${base}`;
+  }
+  if (!base.endsWith('/')) {
+    base += '/';
+  }
+  return base;
+};
+
+/**
+ * Returns the normalized Vite base URL. Defaults to "/" for backwards
+ * compatibility with existing deployments.
+ */
+export const getBaseUrl = (baseUrl?: string): string => {
+  const raw =
+    baseUrl ?? (import.meta.env.BASE_URL as string | undefined) ?? '/';
+  return normalizeBase(raw);
+};
+
+/**
+ * Returns the React Router basename derived from the Vite base. Returns
+ * `undefined` for root so that `createBrowserRouter` behaves identically to
+ * the previous default.
+ */
+export const getRouterBasename = (baseUrl?: string): string | undefined => {
+  const base = getBaseUrl(baseUrl);
+  if (base === '/') {
+    return undefined;
+  }
+  return base.replace(/\/$/, '');
+};
+
+/**
+ * Prefixes an absolute frontend path with the current base, if any.
+ * Example: withBasePath("/login") -> "/workflow/login" when base is "/workflow/"
+ */
+export const withBasePath = (path: string, baseUrl?: string): string => {
+  const base = getBaseUrl(baseUrl);
+  if (base === '/') {
+    return path;
+  }
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  const baseWithoutTrailing = base.replace(/\/$/, '');
+  // Avoid double prefix if path already starts with base
+  if (
+    normalizedPath === baseWithoutTrailing ||
+    normalizedPath.startsWith(`${baseWithoutTrailing}/`)
+  ) {
+    return normalizedPath;
+  }
+  return `${baseWithoutTrailing}${normalizedPath}`;
+};
+
+/**
+ * Strips the base prefix from a pathname, if present. Useful for comparing
+ * `window.location.pathname` without being sensitive to the configured base.
+ */
+export const stripBasePath = (pathname: string, baseUrl?: string): string => {
+  const basename = getRouterBasename(baseUrl);
+  if (!basename) {
+    return pathname;
+  }
+  if (pathname === basename) {
+    return '/';
+  }
+  if (pathname.startsWith(`${basename}/`)) {
+    const stripped = pathname.slice(basename.length);
+    return stripped || '/';
+  }
+  return pathname;
+};

--- a/spiffworkflow-frontend/src/helpers/routerBasename.test.tsx
+++ b/spiffworkflow-frontend/src/helpers/routerBasename.test.tsx
@@ -1,61 +1,30 @@
-import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
 import { getRouterBasename } from './basePath';
 
-describe('router basename integration', () => {
-  const makeRouter = (
-    basename: string | undefined,
-    initialEntries: string[],
-  ) => {
-    return createMemoryRouter(
-      [
-        { path: '/', element: <div>home</div> },
-        { path: '/about', element: <div>about</div> },
-        { path: '/tasks', element: <div>tasks</div> },
-      ],
-      { basename, initialEntries },
-    );
-  };
+const routes = [
+  { path: '/', element: <div>home</div> },
+  { path: '/tasks', element: <div>tasks</div> },
+];
 
-  it('renders at root when basename is undefined (default /)', () => {
-    const basename = getRouterBasename('/');
-    expect(basename).toBeUndefined();
-    const router = makeRouter(basename, ['/']);
+describe('router basename', () => {
+  it('routes at the site root by default', () => {
+    const router = createMemoryRouter(routes, { initialEntries: ['/'] });
+
     render(<RouterProvider router={router} />);
+
     expect(screen.getByText('home')).toBeInTheDocument();
   });
 
-  it('renders at root via /workflow/ when basename is /workflow', () => {
-    const basename = getRouterBasename('/workflow/');
-    expect(basename).toEqual('/workflow');
-    const router = makeRouter(basename, ['/workflow/']);
-    render(<RouterProvider router={router} />);
-    expect(screen.getByText('home')).toBeInTheDocument();
-  });
+  it('supports a direct deep link beneath /workflow/', () => {
+    const router = createMemoryRouter(routes, {
+      basename: getRouterBasename('/workflow/'),
+      initialEntries: ['/workflow/tasks'],
+    });
 
-  it('routes to /workflow/about under workflow basename', () => {
-    const basename = getRouterBasename('/workflow/');
-    const router = makeRouter(basename, ['/workflow/about']);
     render(<RouterProvider router={router} />);
-    expect(screen.getByText('about')).toBeInTheDocument();
-  });
 
-  it('supports deep link navigation under workflow basename', () => {
-    const basename = getRouterBasename('/workflow/');
-    const router = makeRouter(basename, ['/workflow/tasks']);
-    render(<RouterProvider router={router} />);
     expect(screen.getByText('tasks')).toBeInTheDocument();
-  });
-
-  it('asset base and router basename stay in sync', () => {
-    const baseUrl = '/workflow/';
-    const basename = getRouterBasename(baseUrl);
-    // asset base would be /workflow/ for Vite, router basename /workflow
-    expect(baseUrl).toEqual('/workflow/');
-    expect(basename).toEqual('/workflow');
-    // A build asset URL and a router URL share the same prefix
-    expect(`${baseUrl}assets/app.js`).toEqual('/workflow/assets/app.js');
-    expect(`${basename}/about`).toEqual('/workflow/about');
   });
 });

--- a/spiffworkflow-frontend/src/helpers/routerBasename.test.tsx
+++ b/spiffworkflow-frontend/src/helpers/routerBasename.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { getRouterBasename } from './basePath';
+
+describe('router basename integration', () => {
+  const makeRouter = (
+    basename: string | undefined,
+    initialEntries: string[],
+  ) => {
+    return createMemoryRouter(
+      [
+        { path: '/', element: <div>home</div> },
+        { path: '/about', element: <div>about</div> },
+        { path: '/tasks', element: <div>tasks</div> },
+      ],
+      { basename, initialEntries },
+    );
+  };
+
+  it('renders at root when basename is undefined (default /)', () => {
+    const basename = getRouterBasename('/');
+    expect(basename).toBeUndefined();
+    const router = makeRouter(basename, ['/']);
+    render(<RouterProvider router={router} />);
+    expect(screen.getByText('home')).toBeInTheDocument();
+  });
+
+  it('renders at root via /workflow/ when basename is /workflow', () => {
+    const basename = getRouterBasename('/workflow/');
+    expect(basename).toEqual('/workflow');
+    const router = makeRouter(basename, ['/workflow/']);
+    render(<RouterProvider router={router} />);
+    expect(screen.getByText('home')).toBeInTheDocument();
+  });
+
+  it('routes to /workflow/about under workflow basename', () => {
+    const basename = getRouterBasename('/workflow/');
+    const router = makeRouter(basename, ['/workflow/about']);
+    render(<RouterProvider router={router} />);
+    expect(screen.getByText('about')).toBeInTheDocument();
+  });
+
+  it('supports deep link navigation under workflow basename', () => {
+    const basename = getRouterBasename('/workflow/');
+    const router = makeRouter(basename, ['/workflow/tasks']);
+    render(<RouterProvider router={router} />);
+    expect(screen.getByText('tasks')).toBeInTheDocument();
+  });
+
+  it('asset base and router basename stay in sync', () => {
+    const baseUrl = '/workflow/';
+    const basename = getRouterBasename(baseUrl);
+    // asset base would be /workflow/ for Vite, router basename /workflow
+    expect(baseUrl).toEqual('/workflow/');
+    expect(basename).toEqual('/workflow');
+    // A build asset URL and a router URL share the same prefix
+    expect(`${baseUrl}assets/app.js`).toEqual('/workflow/assets/app.js');
+    expect(`${basename}/about`).toEqual('/workflow/about');
+  });
+});

--- a/spiffworkflow-frontend/src/helpers/viteBase.test.ts
+++ b/spiffworkflow-frontend/src/helpers/viteBase.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { resolveBasePath } from '../../vite.config';
+
+describe('vite resolveBasePath', () => {
+  it('defaults to /', () => {
+    expect(resolveBasePath({})).toEqual('/');
+    expect(
+      resolveBasePath({
+        SPIFFWORKFLOW_FRONTEND_BUILD_TIME_BASE_PATH: undefined,
+      }),
+    ).toEqual('/');
+  });
+
+  it('accepts SPIFFWORKFLOW_FRONTEND_BUILD_TIME_BASE_PATH', () => {
+    expect(
+      resolveBasePath({
+        SPIFFWORKFLOW_FRONTEND_BUILD_TIME_BASE_PATH: '/workflow/',
+      }),
+    ).toEqual('/workflow/');
+    expect(
+      resolveBasePath({
+        SPIFFWORKFLOW_FRONTEND_BUILD_TIME_BASE_PATH: '/workflow',
+      }),
+    ).toEqual('/workflow/');
+    expect(
+      resolveBasePath({
+        SPIFFWORKFLOW_FRONTEND_BUILD_TIME_BASE_PATH: 'workflow',
+      }),
+    ).toEqual('/workflow/');
+  });
+
+  it('normalizes missing leading slash and ensures trailing slash', () => {
+    expect(
+      resolveBasePath({
+        SPIFFWORKFLOW_FRONTEND_BUILD_TIME_BASE_PATH: 'a/b',
+      }),
+    ).toEqual('/a/b/');
+  });
+
+  it('uses / for empty or whitespace value', () => {
+    expect(
+      resolveBasePath({
+        SPIFFWORKFLOW_FRONTEND_BUILD_TIME_BASE_PATH: '',
+      }),
+    ).toEqual('/');
+    expect(
+      resolveBasePath({
+        SPIFFWORKFLOW_FRONTEND_BUILD_TIME_BASE_PATH: '   ',
+      }),
+    ).toEqual('/');
+  });
+});

--- a/spiffworkflow-frontend/src/helpers/viteBase.test.ts
+++ b/spiffworkflow-frontend/src/helpers/viteBase.test.ts
@@ -1,52 +1,16 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { resolveBasePath } from '../../vite.config';
 
-describe('vite resolveBasePath', () => {
-  it('defaults to /', () => {
+describe('Vite base path', () => {
+  it('defaults to the site root', () => {
     expect(resolveBasePath({})).toEqual('/');
-    expect(
-      resolveBasePath({
-        SPIFFWORKFLOW_FRONTEND_BUILD_TIME_BASE_PATH: undefined,
-      }),
-    ).toEqual('/');
   });
 
-  it('accepts SPIFFWORKFLOW_FRONTEND_BUILD_TIME_BASE_PATH', () => {
-    expect(
-      resolveBasePath({
-        SPIFFWORKFLOW_FRONTEND_BUILD_TIME_BASE_PATH: '/workflow/',
-      }),
-    ).toEqual('/workflow/');
-    expect(
-      resolveBasePath({
-        SPIFFWORKFLOW_FRONTEND_BUILD_TIME_BASE_PATH: '/workflow',
-      }),
-    ).toEqual('/workflow/');
+  it('normalizes the configured workflow path', () => {
     expect(
       resolveBasePath({
         SPIFFWORKFLOW_FRONTEND_BUILD_TIME_BASE_PATH: 'workflow',
       }),
     ).toEqual('/workflow/');
-  });
-
-  it('normalizes missing leading slash and ensures trailing slash', () => {
-    expect(
-      resolveBasePath({
-        SPIFFWORKFLOW_FRONTEND_BUILD_TIME_BASE_PATH: 'a/b',
-      }),
-    ).toEqual('/a/b/');
-  });
-
-  it('uses / for empty or whitespace value', () => {
-    expect(
-      resolveBasePath({
-        SPIFFWORKFLOW_FRONTEND_BUILD_TIME_BASE_PATH: '',
-      }),
-    ).toEqual('/');
-    expect(
-      resolveBasePath({
-        SPIFFWORKFLOW_FRONTEND_BUILD_TIME_BASE_PATH: '   ',
-      }),
-    ).toEqual('/');
   });
 });

--- a/spiffworkflow-frontend/src/services/HttpService.ts
+++ b/spiffworkflow-frontend/src/services/HttpService.ts
@@ -1,5 +1,6 @@
 import { BACKEND_BASE_URL } from '../config';
 import { objectIsEmpty } from '../helpers';
+import { stripBasePath, withBasePath } from '../helpers/basePath';
 import UserService from './UserService';
 
 const HttpMethods = {
@@ -151,7 +152,7 @@ const makeCallToBackend = ({
         if (onUnauthorized) {
           onUnauthorized(jsonResult);
         } else if (UserService.isPublicUser()) {
-          window.location.href = '/public/sign-out';
+          window.location.href = withBasePath('/public/sign-out');
         } else {
           // Hopefully we can make this service a hook and use the error message context directly
 
@@ -180,7 +181,7 @@ const makeCallToBackend = ({
         } else {
           console.error(error.message);
         }
-      } else if (window.location.pathname !== '/login') {
+      } else if (stripBasePath(window.location.pathname) !== '/login') {
         // The block is for authentication errors.
         // If we're already on the login page, do nothing.
         // Otherwise, redirect to login page.

--- a/spiffworkflow-frontend/src/services/UserService.ts
+++ b/spiffworkflow-frontend/src/services/UserService.ts
@@ -3,6 +3,7 @@ import * as cookie from 'cookie';
 import { BACKEND_BASE_URL } from '../config';
 import { AuthenticationOption } from '../interfaces';
 import { parseTaskShowUrl } from '../helpers';
+import { withBasePath } from '../helpers/basePath';
 
 // The backend sets separate browser-readable cookies for the OAuth access token
 // and OIDC ID token. The access token authenticates API requests; the ID token
@@ -34,7 +35,7 @@ const getCurrentLocation = (queryParams: string = window.location.search) => {
 
 const redirectToLogin = () => {
   const encodedUrl = getCurrentLocation();
-  const loginUrl = `/login?original_url=${encodedUrl}`;
+  const loginUrl = `${withBasePath('/login')}?original_url=${encodedUrl}`;
   window.location.replace(loginUrl);
 };
 

--- a/spiffworkflow-frontend/vite.config.ts
+++ b/spiffworkflow-frontend/vite.config.ts
@@ -5,7 +5,9 @@ import svgr from 'vite-plugin-svgr';
 const host = process.env.HOST ?? 'localhost';
 const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 7001;
 
-export function resolveBasePath(env: Record<string, string | undefined>): string {
+export function resolveBasePath(
+  env: Record<string, string | undefined>,
+): string {
   // Build-time setting. Not a runtime SPIFFWORKFLOW_FRONTEND_RUNTIME_CONFIG_* var
   // because `base` is baked into asset URLs at `vite build` time.
   // Vite-agnostic name so it survives a bundler switch; existing build-time
@@ -22,53 +24,56 @@ export function resolveBasePath(env: Record<string, string | undefined>): string
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
   // Allow both Vite-loaded env and direct process.env (for CI shell vars).
-  const mergedEnv: Record<string, string | undefined> = { ...env, ...process.env };
+  const mergedEnv: Record<string, string | undefined> = {
+    ...env,
+    ...process.env,
+  };
   return {
-  base: resolveBasePath(mergedEnv),
-  plugins: [
-    // react(),
-    // seems to replace preact. hot module replacement doesn't work, so commented out. also causes errors when navigating with TabList:
-    // Cannot read properties of undefined (reading 'disabled')
-    // prefresh(),
-    // we need preact for bpmn-js-spiffworkflow. see https://forum.bpmn.io/t/custom-prop-for-service-tasks-typeerror-cannot-add-property-object-is-not-extensible/8487
-    preact({ devToolsEnabled: false }),
-    svgr({
-      // svgr options: https://react-svgr.com/docs/options/
-      svgrOptions: {
-        exportType: 'default',
-        ref: true,
-        svgo: false,
-        titleProp: true,
-      },
-      include: '**/*.svg',
-    }),
-  ],
-  // for prefresh, from https://github.com/preactjs/prefresh/issues/454#issuecomment-1456491801, not working
-  // optimizeDeps: {
-  //   include: ['preact/hooks', 'preact/compat', 'preact']
-  // },
-  server: {
-    // this ensures that the browser DOES NOT open upon server start
-    open: false,
-    host,
-    port,
-  },
-  preview: {
-    host,
-    port,
-  },
-  resolve: {
-    alias: {
-      inferno:
-        process.env.NODE_ENV !== 'production'
-          ? 'inferno/dist/index.dev.esm.js'
-          : 'inferno/dist/index.esm.js',
+    base: resolveBasePath(mergedEnv),
+    plugins: [
+      // react(),
+      // seems to replace preact. hot module replacement doesn't work, so commented out. also causes errors when navigating with TabList:
+      // Cannot read properties of undefined (reading 'disabled')
+      // prefresh(),
+      // we need preact for bpmn-js-spiffworkflow. see https://forum.bpmn.io/t/custom-prop-for-service-tasks-typeerror-cannot-add-property-object-is-not-extensible/8487
+      preact({ devToolsEnabled: false }),
+      svgr({
+        // svgr options: https://react-svgr.com/docs/options/
+        svgrOptions: {
+          exportType: 'default',
+          ref: true,
+          svgo: false,
+          titleProp: true,
+        },
+        include: '**/*.svg',
+      }),
+    ],
+    // for prefresh, from https://github.com/preactjs/prefresh/issues/454#issuecomment-1456491801, not working
+    // optimizeDeps: {
+    //   include: ['preact/hooks', 'preact/compat', 'preact']
+    // },
+    server: {
+      // this ensures that the browser DOES NOT open upon server start
+      open: false,
+      host,
+      port,
     },
-    // Deduplicate @bpmn-io/properties-panel so both the frontend and the symlinked
-    // bpmn-js-spiffworkflow use the same instance (and thus the same bundled preact).
-    dedupe: ['@bpmn-io/properties-panel', 'bpmn-js-properties-panel'],
-    preserveSymlinks: true,
-    tsconfigPaths: true,
-  },
+    preview: {
+      host,
+      port,
+    },
+    resolve: {
+      alias: {
+        inferno:
+          process.env.NODE_ENV !== 'production'
+            ? 'inferno/dist/index.dev.esm.js'
+            : 'inferno/dist/index.esm.js',
+      },
+      // Deduplicate @bpmn-io/properties-panel so both the frontend and the symlinked
+      // bpmn-js-spiffworkflow use the same instance (and thus the same bundled preact).
+      dedupe: ['@bpmn-io/properties-panel', 'bpmn-js-properties-panel'],
+      preserveSymlinks: true,
+      tsconfigPaths: true,
+    },
   };
 });

--- a/spiffworkflow-frontend/vite.config.ts
+++ b/spiffworkflow-frontend/vite.config.ts
@@ -5,14 +5,7 @@ import svgr from 'vite-plugin-svgr';
 const host = process.env.HOST ?? 'localhost';
 const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 7001;
 
-export function resolveBasePath(
-  env: Record<string, string | undefined>,
-): string {
-  // Build-time setting. Not a runtime SPIFFWORKFLOW_FRONTEND_RUNTIME_CONFIG_* var
-  // because `base` is baked into asset URLs at `vite build` time.
-  // Vite-agnostic name so it survives a bundler switch; existing build-time
-  // VITE_* vars (VITE_VERSION_INFO etc.) are vite-specific client exposures
-  // via import.meta.env and would need a compat layer if we switch.
+export function resolveBasePath(env: Record<string, string | undefined>): string {
   const raw = env.SPIFFWORKFLOW_FRONTEND_BUILD_TIME_BASE_PATH ?? '/';
   let base = raw.trim();
   if (!base) base = '/';
@@ -21,59 +14,55 @@ export function resolveBasePath(
   return base;
 }
 
+const config = {
+  plugins: [
+    // react(),
+    // seems to replace preact. hot module replacement doesn't work, so commented out. also causes errors when navigating with TabList:
+    // Cannot read properties of undefined (reading 'disabled')
+    // prefresh(),
+    // we need preact for bpmn-js-spiffworkflow. see https://forum.bpmn.io/t/custom-prop-for-service-tasks-typeerror-cannot-add-property-object-is-not-extensible/8487
+    preact({ devToolsEnabled: false }),
+    svgr({
+      // svgr options: https://react-svgr.com/docs/options/
+      svgrOptions: {
+        exportType: 'default',
+        ref: true,
+        svgo: false,
+        titleProp: true,
+      },
+      include: '**/*.svg',
+    }),
+  ],
+  // for prefresh, from https://github.com/preactjs/prefresh/issues/454#issuecomment-1456491801, not working
+  // optimizeDeps: {
+  //   include: ['preact/hooks', 'preact/compat', 'preact']
+  // },
+  server: {
+    // this ensures that the browser DOES NOT open upon server start
+    open: false,
+    host,
+    port,
+  },
+  preview: {
+    host,
+    port,
+  },
+  resolve: {
+    alias: {
+      inferno:
+        process.env.NODE_ENV !== 'production'
+          ? 'inferno/dist/index.dev.esm.js'
+          : 'inferno/dist/index.esm.js',
+    },
+    // Deduplicate @bpmn-io/properties-panel so both the frontend and the symlinked
+    // bpmn-js-spiffworkflow use the same instance (and thus the same bundled preact).
+    dedupe: ['@bpmn-io/properties-panel', 'bpmn-js-properties-panel'],
+    preserveSymlinks: true,
+    tsconfigPaths: true,
+  },
+};
+
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
-  // Allow both Vite-loaded env and direct process.env (for CI shell vars).
-  const mergedEnv: Record<string, string | undefined> = {
-    ...env,
-    ...process.env,
-  };
-  return {
-    base: resolveBasePath(mergedEnv),
-    plugins: [
-      // react(),
-      // seems to replace preact. hot module replacement doesn't work, so commented out. also causes errors when navigating with TabList:
-      // Cannot read properties of undefined (reading 'disabled')
-      // prefresh(),
-      // we need preact for bpmn-js-spiffworkflow. see https://forum.bpmn.io/t/custom-prop-for-service-tasks-typeerror-cannot-add-property-object-is-not-extensible/8487
-      preact({ devToolsEnabled: false }),
-      svgr({
-        // svgr options: https://react-svgr.com/docs/options/
-        svgrOptions: {
-          exportType: 'default',
-          ref: true,
-          svgo: false,
-          titleProp: true,
-        },
-        include: '**/*.svg',
-      }),
-    ],
-    // for prefresh, from https://github.com/preactjs/prefresh/issues/454#issuecomment-1456491801, not working
-    // optimizeDeps: {
-    //   include: ['preact/hooks', 'preact/compat', 'preact']
-    // },
-    server: {
-      // this ensures that the browser DOES NOT open upon server start
-      open: false,
-      host,
-      port,
-    },
-    preview: {
-      host,
-      port,
-    },
-    resolve: {
-      alias: {
-        inferno:
-          process.env.NODE_ENV !== 'production'
-            ? 'inferno/dist/index.dev.esm.js'
-            : 'inferno/dist/index.esm.js',
-      },
-      // Deduplicate @bpmn-io/properties-panel so both the frontend and the symlinked
-      // bpmn-js-spiffworkflow use the same instance (and thus the same bundled preact).
-      dedupe: ['@bpmn-io/properties-panel', 'bpmn-js-properties-panel'],
-      preserveSymlinks: true,
-      tsconfigPaths: true,
-    },
-  };
+  return { ...config, base: resolveBasePath({ ...env, ...process.env }) };
 });

--- a/spiffworkflow-frontend/vite.config.ts
+++ b/spiffworkflow-frontend/vite.config.ts
@@ -1,13 +1,30 @@
 import preact from '@preact/preset-vite';
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import svgr from 'vite-plugin-svgr';
 
 const host = process.env.HOST ?? 'localhost';
 const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 7001;
 
-export default defineConfig({
-  // depending on your application, base can also be "/"
-  base: '/',
+export function resolveBasePath(env: Record<string, string | undefined>): string {
+  // Build-time setting. Not a runtime SPIFFWORKFLOW_FRONTEND_RUNTIME_CONFIG_* var
+  // because `base` is baked into asset URLs at `vite build` time.
+  // Vite-agnostic name so it survives a bundler switch; existing build-time
+  // VITE_* vars (VITE_VERSION_INFO etc.) are vite-specific client exposures
+  // via import.meta.env and would need a compat layer if we switch.
+  const raw = env.SPIFFWORKFLOW_FRONTEND_BUILD_TIME_BASE_PATH ?? '/';
+  let base = raw.trim();
+  if (!base) base = '/';
+  if (!base.startsWith('/')) base = `/${base}`;
+  if (!base.endsWith('/')) base += '/';
+  return base;
+}
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  // Allow both Vite-loaded env and direct process.env (for CI shell vars).
+  const mergedEnv: Record<string, string | undefined> = { ...env, ...process.env };
+  return {
+  base: resolveBasePath(mergedEnv),
   plugins: [
     // react(),
     // seems to replace preact. hot module replacement doesn't work, so commented out. also causes errors when navigating with TabList:
@@ -53,4 +70,5 @@ export default defineConfig({
     preserveSymlinks: true,
     tsconfigPaths: true,
   },
+  };
 });


### PR DESCRIPTION
- we defaulting to / with leading/trailing slash normalization via resolveBasePath and loadEnv support so that a production build beneath /workflow/, for example, prefixes all asset URLs.
- React Router basename is derived from the same Vite base (import.meta.env.BASE_URL) via getRouterBasename, ensuring generated routes and navigation share the asset base.
- Add helpers: normalizeBase, getBaseUrl, getRouterBasename, withBasePath, stripBasePath for consistent base handling and to make HttpService base-aware (sign-out href and login pathname checks).
- Tests covering default root and /workflow/ behavior for base normalization, router basename, Vite config, and router integration (deep links).
- Builds verified: default build emits /assets/*, /workflow/ build emits /workflow/assets/* and /workflow/favicon.* without root-relative regressions.