### PR TITLE
Persist Content Studio provenance and add localization foundations

### DIFF
--- a/spiffworkflow-backend/migrations/versions/c8d7e4a91f2b_add_source_artifact_ref_to_process_instance.py
+++ b/spiffworkflow-backend/migrations/versions/c8d7e4a91f2b_add_source_artifact_ref_to_process_instance.py
@@ -1,0 +1,25 @@
+"""add source artifact reference to process instance
+
+Revision ID: c8d7e4a91f2b
+Revises: 2d68edd689b9
+Create Date: 2026-08-30 09:05:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c8d7e4a91f2b"
+down_revision = "2d68edd689b9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("process_instance", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("source_artifact_ref", sa.JSON(), nullable=True))
+
+def downgrade():
+    with op.batch_alter_table("process_instance", schema=None) as batch_op:
+        batch_op.drop_column("source_artifact_ref")

--- a/spiffworkflow-backend/migrations/versions/d6f2a9b47c31_preserve_instruction_render_context.py
+++ b/spiffworkflow-backend/migrations/versions/d6f2a9b47c31_preserve_instruction_render_context.py
@@ -1,0 +1,40 @@
+"""preserve instruction render context
+
+Revision ID: d6f2a9b47c31
+Revises: c8d7e4a91f2b
+Create Date: 2026-08-30 09:15:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d6f2a9b47c31"
+down_revision = "c8d7e4a91f2b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("task_instructions_for_end_user", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("instruction_template", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("task_data", sa.JSON(), nullable=True))
+        batch_op.add_column(sa.Column("process_model_identifier", sa.String(length=255), nullable=True))
+        batch_op.add_column(sa.Column("bpmn_file_name", sa.String(length=255), nullable=True))
+        batch_op.add_column(sa.Column("bpmn_process_identifier", sa.String(length=255), nullable=True))
+        batch_op.add_column(sa.Column("task_bpmn_identifier", sa.String(length=255), nullable=True))
+        batch_op.add_column(sa.Column("source_artifact_ref", sa.JSON(), nullable=True))
+        batch_op.add_column(sa.Column("bpmn_version_control_identifier", sa.String(length=255), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("task_instructions_for_end_user", schema=None) as batch_op:
+        batch_op.drop_column("bpmn_version_control_identifier")
+        batch_op.drop_column("source_artifact_ref")
+        batch_op.drop_column("task_bpmn_identifier")
+        batch_op.drop_column("bpmn_process_identifier")
+        batch_op.drop_column("bpmn_file_name")
+        batch_op.drop_column("process_model_identifier")
+        batch_op.drop_column("task_data")
+        batch_op.drop_column("instruction_template")

--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/process_instance.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/process_instance.py
@@ -104,6 +104,7 @@ class ProcessInstanceModel(SpiffworkflowBaseDBModel):
     bpmn_version_control_type: str | None = db.Column(db.String(50))
     # this could also be a blank string for older instances since we were putting blank strings in here as well
     bpmn_version_control_identifier: str | None = db.Column(db.String(255))
+    source_artifact_ref: dict[str, str] | None = db.Column(db.JSON, nullable=True)
     last_milestone_bpmn_name: str | None = db.Column(db.String(255), index=True)
 
     bpmn_xml_file_contents: str | None = None
@@ -153,6 +154,7 @@ class ProcessInstanceModel(SpiffworkflowBaseDBModel):
             "process_initiator_username": self.process_initiator.username,
             "process_model_display_name": self.process_model_display_name,
             "process_model_identifier": self.process_model_identifier,
+            "source_artifact_ref": self.source_artifact_ref,
             "start_in_seconds": self.start_in_seconds,
             "status": self.status,
             "summary": self.summary,

--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/process_model.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/process_model.py
@@ -19,6 +19,7 @@ PROCESS_MODEL_SUPPORTED_KEYS_FOR_DISK_SERIALIZATION = [
     "fault_or_suspend_on_exception",
     "exception_notification_addresses",
     "metadata_extraction_paths",
+    "source_artifact_ref",
 ]
 
 
@@ -40,6 +41,7 @@ class ProcessModelInfo:
     fault_or_suspend_on_exception: str = NotificationType.fault.value
     exception_notification_addresses: list[str] = field(default_factory=list)
     metadata_extraction_paths: list[dict[str, str]] | None = None
+    source_artifact_ref: dict[str, str] | None = None
 
     process_group: Any | None = None
     files: list[File] | None = field(default_factory=list[File])

--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/task_instructions_for_end_user.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/task_instructions_for_end_user.py
@@ -19,6 +19,14 @@ class TaskInstructionsForEndUserModel(SpiffworkflowBaseDBModel):
 
     task_guid: str = db.Column(db.String(36), primary_key=True)
     instruction: str = db.Column(db.Text(), nullable=False)
+    instruction_template: str | None = db.Column(db.Text(), nullable=True)
+    task_data: dict | None = db.Column(db.JSON, nullable=True)
+    process_model_identifier: str | None = db.Column(db.String(255), nullable=True)
+    bpmn_file_name: str | None = db.Column(db.String(255), nullable=True)
+    bpmn_process_identifier: str | None = db.Column(db.String(255), nullable=True)
+    task_bpmn_identifier: str | None = db.Column(db.String(255), nullable=True)
+    source_artifact_ref: dict[str, str] | None = db.Column(db.JSON, nullable=True)
+    bpmn_version_control_identifier: str | None = db.Column(db.String(255), nullable=True)
     process_instance_id: int = db.Column(ForeignKey("process_instance.id"), nullable=False, index=True)
     has_been_retrieved: bool = db.Column(db.Boolean, nullable=False, default=False, index=True)
 
@@ -26,12 +34,34 @@ class TaskInstructionsForEndUserModel(SpiffworkflowBaseDBModel):
     timestamp: float = db.Column(db.DECIMAL(17, 6), nullable=False, index=True)
 
     @classmethod
-    def insert_or_update_record(cls, task_guid: str, process_instance_id: int, instruction: str) -> None:
+    def insert_or_update_record(
+        cls,
+        task_guid: str,
+        process_instance_id: int,
+        instruction: str,
+        *,
+        instruction_template: str | None = None,
+        task_data: dict | None = None,
+        process_model_identifier: str | None = None,
+        bpmn_file_name: str | None = None,
+        bpmn_process_identifier: str | None = None,
+        task_bpmn_identifier: str | None = None,
+        source_artifact_ref: dict[str, str] | None = None,
+        bpmn_version_control_identifier: str | None = None,
+    ) -> None:
         record = [
             {
                 "task_guid": task_guid,
                 "process_instance_id": process_instance_id,
                 "instruction": instruction,
+                "instruction_template": instruction_template,
+                "task_data": task_data,
+                "process_model_identifier": process_model_identifier,
+                "bpmn_file_name": bpmn_file_name,
+                "bpmn_process_identifier": bpmn_process_identifier,
+                "task_bpmn_identifier": task_bpmn_identifier,
+                "source_artifact_ref": source_artifact_ref,
+                "bpmn_version_control_identifier": bpmn_version_control_identifier,
                 "timestamp": time.time(),
             }
         ]

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/catalog_localization_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/catalog_localization_service.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from spiffworkflow_backend.services.jinja_service import JinjaService
+
+
+class CatalogLocalizationError(ValueError):
+    pass
+
+
+class CatalogLocalizationService:
+    PRESENTATION_KEYS = {"description", "title", "ui:description", "ui:title"}
+
+    @classmethod
+    def render_instruction_before_jinja(
+        cls,
+        source_template: str,
+        task_data: dict[str, Any],
+        translated_template: str | None = None,
+    ) -> str:
+        template = translated_template if translated_template is not None else source_template
+        return JinjaService.render_jinja_template(template, task_data=task_data)
+
+    @classmethod
+    def localize_json_presentation(
+        cls,
+        source_document: dict[str, Any],
+        translations_by_json_pointer: dict[str, str],
+    ) -> dict[str, Any]:
+        localized_document = copy.deepcopy(source_document)
+        for pointer, translated_value in translations_by_json_pointer.items():
+            cls._replace_presentation_value(localized_document, pointer, translated_value)
+        return localized_document
+
+    @classmethod
+    def _replace_presentation_value(cls, document: dict[str, Any], pointer: str, translated_value: str) -> None:
+        if not isinstance(translated_value, str):
+            raise CatalogLocalizationError(f"Translation for {pointer} must be a string")
+        segments = cls._json_pointer_segments(pointer)
+        if not segments or segments[-1] not in cls.PRESENTATION_KEYS:
+            raise CatalogLocalizationError(f"Translation target is not a presentation field: {pointer}")
+
+        parent: Any = document
+        for segment in segments[:-1]:
+            if isinstance(parent, list):
+                try:
+                    parent = parent[int(segment)]
+                except (IndexError, ValueError) as exception:
+                    raise CatalogLocalizationError(f"Invalid translation pointer: {pointer}") from exception
+            elif isinstance(parent, dict) and segment in parent:
+                parent = parent[segment]
+            else:
+                raise CatalogLocalizationError(f"Invalid translation pointer: {pointer}")
+
+        leaf = segments[-1]
+        if not isinstance(parent, dict) or leaf not in parent or not isinstance(parent[leaf], str):
+            raise CatalogLocalizationError(f"Translation pointer does not identify a source string: {pointer}")
+        parent[leaf] = translated_value
+
+    @staticmethod
+    def _json_pointer_segments(pointer: str) -> list[str]:
+        if pointer == "":
+            return []
+        if not pointer.startswith("/"):
+            raise CatalogLocalizationError(f"Invalid JSON Pointer: {pointer}")
+        return [segment.replace("~1", "/").replace("~0", "~") for segment in pointer[1:].split("/")]

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/jinja_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/jinja_service.py
@@ -1,3 +1,4 @@
+import json
 from sys import exc_info
 
 import jinja2
@@ -7,6 +8,7 @@ from SpiffWorkflow.bpmn.exceptions import WorkflowTaskException  # type: ignore
 from SpiffWorkflow.task import Task as SpiffTask  # type: ignore
 
 from spiffworkflow_backend.exceptions.api_error import ApiError
+from spiffworkflow_backend.models.process_instance import ProcessInstanceModel
 from spiffworkflow_backend.models.task import TaskModel
 from spiffworkflow_backend.models.task_instructions_for_end_user import TaskInstructionsForEndUserModel
 from spiffworkflow_backend.services.task_service import TaskModelError
@@ -92,11 +94,43 @@ class JinjaService:
                 task_guid = str(spiff_task.id)
                 if task_guid in tasks_that_have_been_seen:
                     continue
+                instruction_template = spiff_task.task_spec.extensions["instructionsForEndUser"]
                 instruction = JinjaService.render_instructions_for_end_user(spiff_task)
                 if instruction != "":
+                    process_instance = ProcessInstanceModel.query.filter_by(id=process_instance_id).first()
+                    task_data = {key: value for key, value in spiff_task.data.items() if cls._is_jsonable(value)}
                     TaskInstructionsForEndUserModel.insert_or_update_record(
                         task_guid=str(spiff_task.id),
                         process_instance_id=process_instance_id,
                         instruction=instruction,
+                        instruction_template=instruction_template,
+                        task_data=task_data,
+                        process_model_identifier=(process_instance.process_model_identifier if process_instance else None),
+                        bpmn_file_name=getattr(spiff_task.workflow.spec, "file", None),
+                        bpmn_process_identifier=spiff_task.workflow.spec.name,
+                        task_bpmn_identifier=spiff_task.task_spec.bpmn_id,
+                        source_artifact_ref=(process_instance.source_artifact_ref if process_instance else None),
+                        bpmn_version_control_identifier=(
+                            process_instance.bpmn_version_control_identifier if process_instance else None
+                        ),
                     )
                     tasks_that_have_been_seen.add(str(spiff_task.id))
+
+    @staticmethod
+    def _is_jsonable(value: object) -> bool:
+        try:
+            json.dumps(value)
+            return True
+        except (TypeError, OverflowError, ValueError):
+            return False
+
+    @classmethod
+    def render_queued_instruction(
+        cls,
+        queued_instruction: TaskInstructionsForEndUserModel,
+        translated_template: str | None = None,
+    ) -> str:
+        template = translated_template if translated_template is not None else queued_instruction.instruction_template
+        if template is None or queued_instruction.task_data is None:
+            return queued_instruction.instruction
+        return cls.render_jinja_template(template, task_data=queued_instruction.task_data)

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/locale_catalog_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/locale_catalog_service.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from typing import Any
+
+from spiffworkflow_backend.services.source_artifact_service import SHA256_PATTERN
+from spiffworkflow_backend.services.source_artifact_service import canonical_json
+from spiffworkflow_backend.services.source_artifact_service import sha256
+
+
+class LocaleCatalogValidationError(ValueError):
+    pass
+
+
+def locale_catalog_digest(catalog: dict[str, Any]) -> str:
+    unsigned_catalog = {key: value for key, value in catalog.items() if key != "integrity"}
+    return sha256(canonical_json(unsigned_catalog))
+
+
+def validate_compatible_locale_catalog(
+    catalog: dict[str, Any],
+    *,
+    source_artifact_ref: dict[str, str],
+    process_model_identifier: str,
+    requested_locale: str,
+) -> dict[str, Any]:
+    required = {
+        "contract_version",
+        "catalog_id",
+        "catalog_version",
+        "workspace_id",
+        "source_artifact_ref",
+        "process_model_identifiers",
+        "source_locale",
+        "target_locale",
+        "fallback_locale",
+        "published_at",
+        "messages",
+        "integrity",
+    }
+    allowed = required | {"published_by", "validation_summary", "provenance"}
+    if set(catalog) - allowed:
+        raise LocaleCatalogValidationError("Locale catalog contains unsupported fields")
+    if required - set(catalog):
+        raise LocaleCatalogValidationError("Locale catalog is missing required fields")
+    if catalog.get("contract_version") != "1.0":
+        raise LocaleCatalogValidationError("Unsupported locale catalog contract version")
+    for key in ("catalog_id", "workspace_id", "source_locale", "target_locale", "fallback_locale", "published_at"):
+        if not isinstance(catalog.get(key), str) or not catalog[key]:
+            raise LocaleCatalogValidationError(f"Locale catalog {key} must be a non-empty string")
+    if not isinstance(catalog.get("catalog_version"), int) or isinstance(catalog["catalog_version"], bool):
+        raise LocaleCatalogValidationError("Locale catalog version must be an integer")
+    if catalog["catalog_version"] < 1:
+        raise LocaleCatalogValidationError("Locale catalog version must be positive")
+    if "published_by" in catalog and (
+        not isinstance(catalog["published_by"], str) or not catalog["published_by"]
+    ):
+        raise LocaleCatalogValidationError("Locale catalog published_by must be a non-empty string")
+    for metadata_key in ("validation_summary", "provenance"):
+        if metadata_key in catalog and not isinstance(catalog[metadata_key], dict):
+            raise LocaleCatalogValidationError(f"Locale catalog {metadata_key} must be an object")
+    if catalog.get("source_artifact_ref") != source_artifact_ref:
+        raise LocaleCatalogValidationError("Locale catalog source artifact does not match the process instance")
+    if catalog.get("target_locale") != requested_locale:
+        raise LocaleCatalogValidationError("Locale catalog target locale does not match the requested locale")
+
+    process_model_identifiers = catalog.get("process_model_identifiers")
+    if (
+        not isinstance(process_model_identifiers, list)
+        or not process_model_identifiers
+        or not all(isinstance(identifier, str) and identifier for identifier in process_model_identifiers)
+        or len(set(process_model_identifiers)) != len(process_model_identifiers)
+    ):
+        raise LocaleCatalogValidationError("Locale catalog process_model_identifiers must be unique non-empty strings")
+    if process_model_identifier not in process_model_identifiers:
+        raise LocaleCatalogValidationError("Locale catalog does not include the requested process model")
+
+    messages = catalog.get("messages")
+    if not isinstance(messages, dict) or not messages:
+        raise LocaleCatalogValidationError("Locale catalog must contain at least one message")
+    for content_unit_id, message in messages.items():
+        if not isinstance(content_unit_id, str) or not content_unit_id or not isinstance(message, dict):
+            raise LocaleCatalogValidationError("Locale catalog messages are invalid")
+        if set(message) != {"value", "source_fingerprint", "token_signature"}:
+            raise LocaleCatalogValidationError(f"Locale catalog message {content_unit_id} has unsupported fields")
+        if not isinstance(message.get("value"), str):
+            raise LocaleCatalogValidationError(f"Locale catalog message {content_unit_id} has an invalid value")
+        if not isinstance(message.get("source_fingerprint"), str) or SHA256_PATTERN.fullmatch(
+            message["source_fingerprint"]
+        ) is None:
+            raise LocaleCatalogValidationError(
+                f"Locale catalog message {content_unit_id} has an invalid source fingerprint"
+            )
+        if not isinstance(message.get("token_signature"), list) or not all(
+            isinstance(token, str) for token in message["token_signature"]
+        ):
+            raise LocaleCatalogValidationError(f"Locale catalog message {content_unit_id} has an invalid token signature")
+
+    integrity = catalog.get("integrity")
+    if not isinstance(integrity, str) or SHA256_PATTERN.fullmatch(integrity) is None:
+        raise LocaleCatalogValidationError("Locale catalog integrity digest is invalid")
+    if locale_catalog_digest(catalog) != integrity:
+        raise LocaleCatalogValidationError("Locale catalog integrity digest does not match its content")
+    return catalog

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_instance_service.py
@@ -168,6 +168,7 @@ class ProcessInstanceService:
                 start_in_seconds=round(time.time()),
                 bpmn_version_control_type="git",
                 bpmn_version_control_identifier=current_git_revision,
+                source_artifact_ref=(dict(process_model.source_artifact_ref) if process_model.source_artifact_ref else None),
             )
             db.session.add(process_instance_model)
 
@@ -999,6 +1000,7 @@ class ProcessInstanceService:
                 process_initiator_id=user_id,
                 process_model_identifier=process_model.id,
                 process_model_display_name=process_model.display_name,
+                source_artifact_ref=(dict(process_model.source_artifact_ref) if process_model.source_artifact_ref else None),
                 persistence_level=persistence_level,
             )
         else:

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/process_model_import_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/process_model_import_service.py
@@ -12,6 +12,8 @@ from lxml import etree  # type: ignore
 from spiffworkflow_backend.models.process_group import ProcessGroup
 from spiffworkflow_backend.models.process_model import ProcessModelInfo
 from spiffworkflow_backend.services.process_model_service import ProcessModelService
+from spiffworkflow_backend.services.source_artifact_service import SourceArtifactValidationError
+from spiffworkflow_backend.services.source_artifact_service import validate_source_artifact_package
 from spiffworkflow_backend.services.spec_file_service import SpecFileService
 
 
@@ -76,6 +78,14 @@ class ProcessModelImportService:
 
     @classmethod
     def import_from_filestore_package(cls, package: dict[str, Any], process_group_id: str) -> list[ProcessModelInfo]:
+        try:
+            source_artifact_ref = validate_source_artifact_package(package)
+        except SourceArtifactValidationError as exception:
+            raise InvalidFilestorePackageError(
+                message=str(exception),
+                error_code="invalid_filestore_package",
+            ) from exception
+
         process_group = cls._ensure_process_group(process_group_id)
         files = cls._filestore_files_relative_to_explicit_model(cls._filestore_files(package), package)
         model_dirs = cls._filestore_model_dirs(files)
@@ -109,8 +119,15 @@ class ProcessModelImportService:
                     id=full_process_model_id,
                     display_name=display_name,
                     description=description,
+                    source_artifact_ref=source_artifact_ref,
                 )
                 ProcessModelService.add_process_model(process_model)
+
+            if source_artifact_ref is not None and process_model.source_artifact_ref != source_artifact_ref:
+                ProcessModelService.update_process_model(
+                    process_model,
+                    {"source_artifact_ref": source_artifact_ref},
+                )
 
             for file_name, file_content in model_files.items():
                 if file_name == "process_model.json":

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/source_artifact_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/source_artifact_service.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any
+from typing import TypedDict
+
+SOURCE_ARTIFACT_CONTRACT_VERSION = "1.0"
+SHA256_PATTERN = re.compile(r"^sha256-[a-f0-9]{64}$")
+
+
+class SourceManifestFile(TypedDict):
+    path: str
+    revision: int
+    content_type: str
+    content_sha256: str
+
+
+class SourceArtifactValidationError(ValueError):
+    pass
+
+
+def sha256(value: str) -> str:
+    return f"sha256-{hashlib.sha256(value.encode('utf-8')).hexdigest()}"
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(
+        _canonical_value(value),
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=False,
+    )
+
+
+def _canonical_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        if not all(isinstance(key, str) for key in value):
+            raise SourceArtifactValidationError("Canonical JSON object keys must be strings")
+        return {
+            key: _canonical_value(value[key])
+            for key in sorted(value, key=lambda candidate: candidate.encode("utf-16be"))
+        }
+    if isinstance(value, list):
+        return [_canonical_value(child) for child in value]
+    if isinstance(value, float):
+        raise SourceArtifactValidationError("Canonical JSON contracts support only finite integer numbers")
+    if value is None or isinstance(value, str | int | bool):
+        return value
+    raise SourceArtifactValidationError(f"Canonical JSON does not support {type(value).__name__}")
+
+
+def source_manifest_digest(files: list[dict[str, Any]]) -> str:
+    canonical_files: list[SourceManifestFile] = []
+    seen_paths = set()
+    for file in files:
+        path = file.get("path")
+        revision = file.get("revision")
+        content_type = file.get("content_type")
+        content_sha256 = file.get("content_sha256")
+        if not isinstance(path, str) or not path or path.startswith("/") or ".." in path.split("/"):
+            raise SourceArtifactValidationError(f"Invalid source manifest path: {path}")
+        if path in seen_paths:
+            raise SourceArtifactValidationError(f"Duplicate source manifest path: {path}")
+        if not isinstance(revision, int) or isinstance(revision, bool) or revision < 1:
+            raise SourceArtifactValidationError(f"Invalid revision for {path}")
+        if not isinstance(content_type, str) or not content_type:
+            raise SourceArtifactValidationError(f"Missing content type for {path}")
+        if not isinstance(content_sha256, str) or SHA256_PATTERN.fullmatch(content_sha256) is None:
+            raise SourceArtifactValidationError(f"Invalid content digest for {path}")
+        seen_paths.add(path)
+        canonical_files.append(
+            {
+                "path": path,
+                "revision": revision,
+                "content_type": content_type,
+                "content_sha256": content_sha256,
+            }
+        )
+
+    # JavaScript compares strings by UTF-16 code units. Using UTF-16BE here keeps
+    # the digest stable even when source paths contain non-BMP characters.
+    canonical_files.sort(key=lambda file: file["path"].encode("utf-16be"))
+    return sha256(canonical_json({"files": canonical_files}))
+
+
+def validate_source_artifact_package(package: dict[str, Any]) -> dict[str, str] | None:
+    raw_ref = package.get("source_artifact_ref")
+    if raw_ref is None:
+        return None
+    if not isinstance(raw_ref, dict):
+        raise SourceArtifactValidationError("source_artifact_ref must be an object")
+
+    required = {
+        "contract_version",
+        "tenant_id",
+        "provider",
+        "project_id",
+        "snapshot_id",
+        "manifest_sha256",
+    }
+    allowed = required | {"entry_process_model_id"}
+    if set(raw_ref) - allowed:
+        raise SourceArtifactValidationError("source_artifact_ref contains unsupported fields")
+    if required - set(raw_ref):
+        raise SourceArtifactValidationError("source_artifact_ref is missing required fields")
+    if any(not isinstance(raw_ref[key], str) or not raw_ref[key].strip() for key in required):
+        raise SourceArtifactValidationError("source_artifact_ref fields must be non-empty strings")
+    if raw_ref["contract_version"] != SOURCE_ARTIFACT_CONTRACT_VERSION:
+        raise SourceArtifactValidationError("Unsupported source_artifact_ref contract version")
+    if raw_ref["provider"] != "filestore":
+        raise SourceArtifactValidationError("Unsupported source artifact provider")
+    if SHA256_PATTERN.fullmatch(raw_ref["manifest_sha256"]) is None:
+        raise SourceArtifactValidationError("Invalid source artifact manifest digest")
+    entry_process_model_id = raw_ref.get("entry_process_model_id")
+    if entry_process_model_id is not None and (
+        not isinstance(entry_process_model_id, str) or not entry_process_model_id.strip()
+    ):
+        raise SourceArtifactValidationError("entry_process_model_id must be a non-empty string")
+
+    for package_key, ref_key in (
+        ("tenant_id", "tenant_id"),
+        ("project_id", "project_id"),
+        ("snapshot_id", "snapshot_id"),
+    ):
+        if package.get(package_key) != raw_ref[ref_key]:
+            raise SourceArtifactValidationError(f"source_artifact_ref {ref_key} does not match package {package_key}")
+
+    raw_files = package.get("files")
+    if not isinstance(raw_files, list):
+        raise SourceArtifactValidationError("Files package must include a files array")
+    manifest_files = []
+    for raw_file in raw_files:
+        if not isinstance(raw_file, dict):
+            raise SourceArtifactValidationError("Source artifact files must be objects")
+        content = raw_file.get("content")
+        content_sha256 = raw_file.get("content_sha256")
+        if not isinstance(content, str) or not isinstance(content_sha256, str):
+            raise SourceArtifactValidationError("Source artifact files must include string content and content_sha256")
+        if sha256(content) != content_sha256:
+            raise SourceArtifactValidationError(f"Content digest mismatch for {raw_file.get('path')}")
+        manifest_files.append(
+            {
+                "path": raw_file.get("source_path"),
+                "revision": raw_file.get("revision"),
+                "content_type": raw_file.get("content_type"),
+                "content_sha256": content_sha256,
+            }
+        )
+
+    if source_manifest_digest(manifest_files) != raw_ref["manifest_sha256"]:
+        raise SourceArtifactValidationError("Source artifact manifest digest does not match package files")
+
+    return {str(key): str(value) for key, value in raw_ref.items()}

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_model_import_controller.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/integration/test_process_model_import_controller.py
@@ -16,14 +16,109 @@ from starlette.testclient import TestClient
 from spiffworkflow_backend.models.process_model import ProcessModelInfo
 from spiffworkflow_backend.models.user import UserModel
 from spiffworkflow_backend.services.file_system_service import FileSystemService
+from spiffworkflow_backend.services.process_instance_service import ProcessInstanceService
 from spiffworkflow_backend.services.process_model_import_service import InvalidFilestorePackageError
 from spiffworkflow_backend.services.process_model_import_service import ProcessModelImportService
+from spiffworkflow_backend.services.process_model_service import ProcessModelService
+from spiffworkflow_backend.services.source_artifact_service import sha256
+from spiffworkflow_backend.services.source_artifact_service import source_manifest_digest
 from spiffworkflow_backend.services.spec_file_service import SpecFileService
 from tests.spiffworkflow_backend.helpers.base_test import BaseTest
 from tests.spiffworkflow_backend.helpers.test_data import load_test_spec
 
 
 class TestProcessModelImportController(BaseTest):
+    @staticmethod
+    def filestore_package_with_source_artifact(bpmn: str) -> tuple[dict, dict[str, str]]:
+        manifest_files = [
+            {
+                "path": "main.bpmn",
+                "revision": 1,
+                "content_type": "application/xml",
+                "content_sha256": sha256(bpmn),
+            }
+        ]
+        source_artifact_ref = {
+            "contract_version": "1.0",
+            "tenant_id": "tenant-1",
+            "provider": "filestore",
+            "project_id": "files-project",
+            "snapshot_id": "snapshot-1",
+            "manifest_sha256": source_manifest_digest(manifest_files),
+        }
+        return (
+            {
+                "tenant_id": "tenant-1",
+                "project_id": "files-project",
+                "project_name": "Source Project",
+                "snapshot_id": "snapshot-1",
+                "source_artifact_ref": source_artifact_ref,
+                "files": [
+                    {
+                        "path": "main.bpmn",
+                        "source_path": "main.bpmn",
+                        "revision": 1,
+                        "content_type": "application/xml",
+                        "content_sha256": sha256(bpmn),
+                        "content": bpmn,
+                    }
+                ],
+            },
+            source_artifact_ref,
+        )
+
+    def test_process_model_import_persists_verified_source_artifact_reference(
+        self,
+        app: Flask,
+        with_db_and_bpmn_file_cleanup: None,
+    ) -> None:
+        bpmn = Path("tests/data/simple_script/simple_script.bpmn").read_text()
+        package, source_artifact_ref = self.filestore_package_with_source_artifact(bpmn)
+
+        process_models = ProcessModelImportService.import_from_filestore_package(package, "filestore")
+
+        assert process_models[0].source_artifact_ref == source_artifact_ref
+        reloaded_model = ProcessModelService.get_process_model(process_models[0].id)
+        assert reloaded_model.source_artifact_ref == source_artifact_ref
+
+    def test_process_instance_pins_the_imported_source_artifact_reference(
+        self,
+        app: Flask,
+        with_db_and_bpmn_file_cleanup: None,
+    ) -> None:
+        bpmn = Path("tests/data/simple_script/simple_script.bpmn").read_text()
+        package, source_artifact_ref = self.filestore_package_with_source_artifact(bpmn)
+        process_model = ProcessModelImportService.import_from_filestore_package(package, "filestore")[0]
+        user = self.find_or_create_user()
+
+        process_instance, _ = ProcessInstanceService.create_process_instance(
+            process_model,
+            user,
+            start_configuration=(0, 0, 0),
+            load_bpmn_process_model=False,
+        )
+
+        assert process_instance.source_artifact_ref == source_artifact_ref
+        assert process_model.source_artifact_ref is not None
+        process_model.source_artifact_ref["snapshot_id"] = "later-source-snapshot"
+        assert process_instance.source_artifact_ref == source_artifact_ref
+        process_instance.process_initiator = user
+        assert process_instance.serialized()["source_artifact_ref"] == source_artifact_ref
+
+    def test_process_model_import_rejects_mismatched_source_artifact_reference(
+        self,
+        app: Flask,
+        with_db_and_bpmn_file_cleanup: None,
+    ) -> None:
+        bpmn = Path("tests/data/simple_script/simple_script.bpmn").read_text()
+        package, _ = self.filestore_package_with_source_artifact(bpmn)
+        package["snapshot_id"] = "different-snapshot"
+
+        with pytest.raises(InvalidFilestorePackageError) as exception_info:
+            ProcessModelImportService.import_from_filestore_package(package, "filestore")
+
+        assert "snapshot_id does not match" in exception_info.value.message
+
     def test_process_model_import_from_filestore_package_preserves_process_model_directories(
         self,
         app: Flask,

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_catalog_localization_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_catalog_localization_service.py
@@ -1,0 +1,67 @@
+import pytest
+
+from spiffworkflow_backend.models.task_instructions_for_end_user import TaskInstructionsForEndUserModel
+from spiffworkflow_backend.services.catalog_localization_service import CatalogLocalizationError
+from spiffworkflow_backend.services.catalog_localization_service import CatalogLocalizationService
+from spiffworkflow_backend.services.jinja_service import JinjaService
+
+
+def test_instruction_translation_is_applied_before_jinja_rendering() -> None:
+    rendered = CatalogLocalizationService.render_instruction_before_jinja(
+        "Welcome, {{ pilot_name }}.",
+        {"pilot_name": "<Artemis>"},
+        translated_template="Bienvenido, {{ pilot_name }}.",
+    )
+
+    assert rendered == "Bienvenido, &lt;Artemis&gt;."
+
+
+def test_static_choice_titles_localize_without_changing_canonical_values() -> None:
+    source_schema = {
+        "type": "object",
+        "properties": {
+            "destination": {
+                "title": "Destination",
+                "oneOf": [
+                    {"const": "moon", "title": "Moon"},
+                    {"const": "mars", "title": "Mars"},
+                ],
+            }
+        },
+    }
+
+    localized_schema = CatalogLocalizationService.localize_json_presentation(
+        source_schema,
+        {
+            "/properties/destination/title": "Destino",
+            "/properties/destination/oneOf/0/title": "Luna",
+            "/properties/destination/oneOf/1/title": "Marte",
+        },
+    )
+
+    assert localized_schema["properties"]["destination"]["oneOf"] == [
+        {"const": "moon", "title": "Luna"},
+        {"const": "mars", "title": "Marte"},
+    ]
+    assert source_schema["properties"]["destination"]["oneOf"][0]["title"] == "Moon"
+
+
+def test_schema_localization_rejects_canonical_value_targets() -> None:
+    with pytest.raises(CatalogLocalizationError, match="not a presentation field"):
+        CatalogLocalizationService.localize_json_presentation(
+            {"oneOf": [{"const": "moon", "title": "Moon"}]},
+            {"/oneOf/0/const": "luna"},
+        )
+
+
+def test_queued_instruction_can_be_rendered_later_from_preserved_context() -> None:
+    queued_instruction = TaskInstructionsForEndUserModel(
+        instruction="Welcome, Artemis.",
+        instruction_template="Welcome, {{ mission_name }}.",
+        task_data={"mission_name": "Artemis"},
+    )
+
+    assert JinjaService.render_queued_instruction(
+        queued_instruction,
+        translated_template="Bienvenida, {{ mission_name }}.",
+    ) == "Bienvenida, Artemis."

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_locale_catalog_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_locale_catalog_service.py
@@ -1,0 +1,61 @@
+import pytest
+
+from spiffworkflow_backend.services.locale_catalog_service import LocaleCatalogValidationError
+from spiffworkflow_backend.services.locale_catalog_service import locale_catalog_digest
+from spiffworkflow_backend.services.locale_catalog_service import validate_compatible_locale_catalog
+
+
+def locale_catalog() -> dict:
+    return {
+        "contract_version": "1.0",
+        "catalog_id": "catalog-es",
+        "catalog_version": 1,
+        "workspace_id": "workspace-1",
+        "source_artifact_ref": {
+            "contract_version": "1.0",
+            "tenant_id": "tenant-1",
+            "provider": "filestore",
+            "project_id": "project-1",
+            "snapshot_id": "snapshot-1",
+            "manifest_sha256": f"sha256-{'a' * 64}",
+        },
+        "process_model_identifiers": ["artemis/mission"],
+        "source_locale": "en",
+        "target_locale": "es",
+        "fallback_locale": "en",
+        "published_at": "2026-08-30T12:00:00Z",
+        "messages": {
+            "bpmn:launch:instructions": {
+                "value": "Bienvenido, {{ pilot_name }}.",
+                "source_fingerprint": f"sha256-{'b' * 64}",
+                "token_signature": ["{{ pilot_name }}"],
+            }
+        },
+    }
+
+
+def test_catalog_matches_an_exact_pinned_source_process_and_locale() -> None:
+    catalog = locale_catalog()
+    catalog["integrity"] = locale_catalog_digest(catalog)
+    assert catalog["integrity"] == "sha256-4c94e27a6e3cb912eb230fa4f2725d5a858259569dfc0b9ef560ff85e1d63688"
+
+    assert validate_compatible_locale_catalog(
+        catalog,
+        source_artifact_ref=catalog["source_artifact_ref"],
+        process_model_identifier="artemis/mission",
+        requested_locale="es",
+    ) == catalog
+
+
+def test_catalog_rejects_a_different_source_snapshot() -> None:
+    catalog = locale_catalog()
+    catalog["integrity"] = locale_catalog_digest(catalog)
+    different_source = {**catalog["source_artifact_ref"], "snapshot_id": "snapshot-2"}
+
+    with pytest.raises(LocaleCatalogValidationError, match="does not match the process instance"):
+        validate_compatible_locale_catalog(
+            catalog,
+            source_artifact_ref=different_source,
+            process_model_identifier="artemis/mission",
+            requested_locale="es",
+        )

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_runtime.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_process_instance_runtime.py
@@ -1511,6 +1511,12 @@ class TestProcessInstanceRuntime(BaseTest):
         user_instructions = TaskInstructionsForEndUserModel.entries_for_process_instance(process_instance.id)
         assert len(user_instructions) == 1
         assert user_instructions[0].instruction == "We run script one"
+        assert user_instructions[0].instruction_template == "We run script one"
+        assert user_instructions[0].task_data is not None
+        assert user_instructions[0].process_model_identifier == process_model.id
+        assert user_instructions[0].bpmn_file_name == "script_task_with_instruction.bpmn"
+        assert user_instructions[0].bpmn_process_identifier is not None
+        assert user_instructions[0].task_bpmn_identifier is not None
         runtime.do_engine_steps(execution_strategy_name="run_current_ready_tasks")
 
         runtime.do_engine_steps(save=True, execution_strategy_name="queue_instructions_for_end_user")

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_source_artifact_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_source_artifact_service.py
@@ -1,0 +1,64 @@
+import pytest
+
+from spiffworkflow_backend.services.source_artifact_service import SourceArtifactValidationError
+from spiffworkflow_backend.services.source_artifact_service import sha256
+from spiffworkflow_backend.services.source_artifact_service import source_manifest_digest
+from spiffworkflow_backend.services.source_artifact_service import validate_source_artifact_package
+
+
+def test_source_manifest_digest_matches_the_cross_runtime_contract_vector() -> None:
+    files = [
+        {
+            "path": "main/schema.json",
+            "revision": 3,
+            "content_type": "application/json",
+            "content_sha256": f"sha256-{'b' * 64}",
+        },
+        {
+            "path": "main/main.bpmn",
+            "revision": 2,
+            "content_type": "application/xml",
+            "content_sha256": f"sha256-{'a' * 64}",
+        },
+    ]
+
+    assert source_manifest_digest(files) == "sha256-64d09005728871107173d8716641663e0c337c6d524b3cf7bf705055655022cf"
+    assert source_manifest_digest(list(reversed(files))) == source_manifest_digest(files)
+
+
+def test_source_artifact_package_rejects_content_tampering() -> None:
+    content = "trusted"
+    manifest_files = [
+        {
+            "path": "main.bpmn",
+            "revision": 1,
+            "content_type": "application/xml",
+            "content_sha256": sha256(content),
+        }
+    ]
+    package = {
+        "tenant_id": "tenant-1",
+        "project_id": "project-1",
+        "snapshot_id": "snapshot-1",
+        "source_artifact_ref": {
+            "contract_version": "1.0",
+            "tenant_id": "tenant-1",
+            "provider": "filestore",
+            "project_id": "project-1",
+            "snapshot_id": "snapshot-1",
+            "manifest_sha256": source_manifest_digest(manifest_files),
+        },
+        "files": [
+            {
+                "path": "main.bpmn",
+                "source_path": "main.bpmn",
+                "revision": 1,
+                "content_type": "application/xml",
+                "content_sha256": sha256(content),
+                "content": "tampered",
+            }
+        ],
+    }
+
+    with pytest.raises(SourceArtifactValidationError, match="Content digest mismatch"):
+        validate_source_artifact_package(package)


### PR DESCRIPTION
## Summary
Adds the Arena-side foundation for safely matching localized content to an exact Filestore snapshot and pinning that source identity when a process instance is created.

## What changed
- Validates Filestore file hashes and canonical manifest digests before importing a referenced snapshot. Legacy packages without the new reference remain supported.
- Persists `source_artifact_ref` on imported process models and copies it onto new process instances so later source updates cannot silently change an existing instance.
- Adds locale-catalog validation for exact source, process-model, locale, and integrity compatibility.
- Adds localization-before-Jinja helpers and protects canonical JSON Schema choice values from translation.
- Preserves queued instruction templates, task data, BPMN identity, source reference, and Git fallback revision so automated instructions can be rendered in the selected locale later.
- Adds migrations for process-instance provenance and queued-instruction render context.

## Verification
- 25 focused unit and integration tests passed using SQLite.
- Ruff and mypy checks passed.
- Both migrations applied successfully; `d6f2a9b47c31` is the single Alembic head.

## Notes
- This establishes runtime contracts and persistence; catalog publication, binding, and the Arena locale selector remain later phases.
- No workflow BPMN or diagram/DI content changed.