### PR TITLE
Validate Content Studio catalogs against existing Arena revisions

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/catalog_localization_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/catalog_localization_service.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import copy
+import re
+from typing import Any
+
+from spiffworkflow_backend.services.jinja_service import JinjaService
+
+ARRAY_INDEX_PATTERN = re.compile(r"0|[1-9][0-9]*")
+
+
+class CatalogLocalizationError(ValueError):
+    pass
+
+
+class CatalogLocalizationService:
+    PRESENTATION_KEYS = {"description", "title", "ui:description", "ui:title"}
+
+    @classmethod
+    def render_instruction_before_jinja(
+        cls,
+        source_template: str,
+        task_data: dict[str, Any],
+        translated_template: str | None = None,
+    ) -> str:
+        template = translated_template if translated_template is not None else source_template
+        return JinjaService.render_jinja_template(template, task_data=task_data)
+
+    @classmethod
+    def localize_json_presentation(
+        cls,
+        source_document: dict[str, Any],
+        translations_by_json_pointer: dict[str, str],
+    ) -> dict[str, Any]:
+        localized_document = copy.deepcopy(source_document)
+        for pointer, translated_value in translations_by_json_pointer.items():
+            cls._replace_presentation_value(localized_document, pointer, translated_value)
+        return localized_document
+
+    @classmethod
+    def _replace_presentation_value(cls, document: dict[str, Any], pointer: str, translated_value: str) -> None:
+        if not isinstance(translated_value, str):
+            raise CatalogLocalizationError(f"Translation for {pointer} must be a string")
+        segments = cls._json_pointer_segments(pointer)
+        if not segments or segments[-1] not in cls.PRESENTATION_KEYS:
+            raise CatalogLocalizationError(f"Translation target is not a presentation field: {pointer}")
+
+        parent: Any = document
+        for segment in segments[:-1]:
+            if isinstance(parent, list):
+                if ARRAY_INDEX_PATTERN.fullmatch(segment) is None:
+                    raise CatalogLocalizationError(f"Invalid translation pointer: {pointer}")
+                try:
+                    parent = parent[int(segment)]
+                except IndexError as exception:
+                    raise CatalogLocalizationError(f"Invalid translation pointer: {pointer}") from exception
+            elif isinstance(parent, dict) and segment in parent:
+                parent = parent[segment]
+            else:
+                raise CatalogLocalizationError(f"Invalid translation pointer: {pointer}")
+
+        leaf = segments[-1]
+        if not isinstance(parent, dict) or leaf not in parent or not isinstance(parent[leaf], str):
+            raise CatalogLocalizationError(f"Translation pointer does not identify a source string: {pointer}")
+        parent[leaf] = translated_value
+
+    @staticmethod
+    def _json_pointer_segments(pointer: str) -> list[str]:
+        if pointer == "":
+            return []
+        if not pointer.startswith("/"):
+            raise CatalogLocalizationError(f"Invalid JSON Pointer: {pointer}")
+        return [segment.replace("~1", "/").replace("~0", "~") for segment in pointer[1:].split("/")]

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/locale_catalog_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/locale_catalog_service.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any
+
+SHA256_PATTERN = re.compile(r"^sha256-[a-f0-9]{64}$")
+
+
+class LocaleCatalogValidationError(ValueError):
+    pass
+
+
+def locale_catalog_digest(catalog: dict[str, Any]) -> str:
+    unsigned_catalog = {key: value for key, value in catalog.items() if key != "integrity"}
+    digest = hashlib.sha256(_canonical_json(unsigned_catalog).encode("utf-8")).hexdigest()
+    return f"sha256-{digest}"
+
+
+def validate_compatible_locale_catalog(
+    catalog: dict[str, Any],
+    *,
+    process_model_identifier: str,
+    bpmn_version_control_identifier: str,
+    requested_locale: str,
+) -> dict[str, Any]:
+    required = {
+        "contract_version",
+        "catalog_id",
+        "catalog_version",
+        "workspace_id",
+        "source_artifact_ref",
+        "process_model_identifiers",
+        "bpmn_version_control_identifier",
+        "source_locale",
+        "target_locale",
+        "fallback_locale",
+        "published_at",
+        "messages",
+        "integrity",
+    }
+    allowed = required | {"published_by", "validation_summary", "provenance"}
+    if set(catalog) - allowed:
+        raise LocaleCatalogValidationError("Locale catalog contains unsupported fields")
+    if required - set(catalog):
+        raise LocaleCatalogValidationError("Locale catalog is missing required fields")
+    if catalog.get("contract_version") != "1.0":
+        raise LocaleCatalogValidationError("Unsupported locale catalog contract version")
+    for key in (
+        "catalog_id",
+        "workspace_id",
+        "bpmn_version_control_identifier",
+        "source_locale",
+        "target_locale",
+        "fallback_locale",
+        "published_at",
+    ):
+        if not isinstance(catalog.get(key), str) or not catalog[key]:
+            raise LocaleCatalogValidationError(f"Locale catalog {key} must be a non-empty string")
+    if not isinstance(catalog.get("source_artifact_ref"), dict):
+        raise LocaleCatalogValidationError("Locale catalog source_artifact_ref must be an object")
+    if not isinstance(catalog.get("catalog_version"), int) or isinstance(catalog["catalog_version"], bool):
+        raise LocaleCatalogValidationError("Locale catalog version must be an integer")
+    if catalog["catalog_version"] < 1:
+        raise LocaleCatalogValidationError("Locale catalog version must be positive")
+    if "published_by" in catalog and (not isinstance(catalog["published_by"], str) or not catalog["published_by"]):
+        raise LocaleCatalogValidationError("Locale catalog published_by must be a non-empty string")
+    for metadata_key in ("validation_summary", "provenance"):
+        if metadata_key in catalog and not isinstance(catalog[metadata_key], dict):
+            raise LocaleCatalogValidationError(f"Locale catalog {metadata_key} must be an object")
+    if catalog["bpmn_version_control_identifier"] != bpmn_version_control_identifier:
+        raise LocaleCatalogValidationError("Locale catalog BPMN revision does not match the process instance")
+    if catalog["target_locale"] != requested_locale:
+        raise LocaleCatalogValidationError("Locale catalog target locale does not match the requested locale")
+
+    process_model_identifiers = catalog.get("process_model_identifiers")
+    if (
+        not isinstance(process_model_identifiers, list)
+        or not process_model_identifiers
+        or not all(isinstance(identifier, str) and identifier for identifier in process_model_identifiers)
+        or len(set(process_model_identifiers)) != len(process_model_identifiers)
+    ):
+        raise LocaleCatalogValidationError("Locale catalog process_model_identifiers must be unique non-empty strings")
+    if process_model_identifier not in process_model_identifiers:
+        raise LocaleCatalogValidationError("Locale catalog does not include the requested process model")
+
+    messages = catalog.get("messages")
+    if not isinstance(messages, dict) or not messages:
+        raise LocaleCatalogValidationError("Locale catalog must contain at least one message")
+    for content_unit_id, message in messages.items():
+        if not isinstance(content_unit_id, str) or not content_unit_id or not isinstance(message, dict):
+            raise LocaleCatalogValidationError("Locale catalog messages are invalid")
+        if set(message) != {"value", "source_fingerprint", "token_signature"}:
+            raise LocaleCatalogValidationError(f"Locale catalog message {content_unit_id} has unsupported fields")
+        if not isinstance(message.get("value"), str):
+            raise LocaleCatalogValidationError(f"Locale catalog message {content_unit_id} has an invalid value")
+        if (
+            not isinstance(message.get("source_fingerprint"), str)
+            or SHA256_PATTERN.fullmatch(message["source_fingerprint"]) is None
+        ):
+            raise LocaleCatalogValidationError(f"Locale catalog message {content_unit_id} has an invalid source fingerprint")
+        if not isinstance(message.get("token_signature"), list) or not all(
+            isinstance(token, str) for token in message["token_signature"]
+        ):
+            raise LocaleCatalogValidationError(f"Locale catalog message {content_unit_id} has an invalid token signature")
+
+    integrity = catalog.get("integrity")
+    if not isinstance(integrity, str) or SHA256_PATTERN.fullmatch(integrity) is None:
+        raise LocaleCatalogValidationError("Locale catalog integrity digest is invalid")
+    if locale_catalog_digest(catalog) != integrity:
+        raise LocaleCatalogValidationError("Locale catalog integrity digest does not match its content")
+    return catalog
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        _canonical_value(value),
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=False,
+    )
+
+
+def _canonical_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        if not all(isinstance(key, str) for key in value):
+            raise LocaleCatalogValidationError("Canonical JSON object keys must be strings")
+        return {key: _canonical_value(value[key]) for key in sorted(value, key=lambda candidate: candidate.encode("utf-16be"))}
+    if isinstance(value, list):
+        return [_canonical_value(child) for child in value]
+    if isinstance(value, float):
+        raise LocaleCatalogValidationError("Canonical JSON contracts support only finite integer numbers")
+    if value is None or isinstance(value, str | int | bool):
+        return value
+    raise LocaleCatalogValidationError(f"Canonical JSON does not support {type(value).__name__}")

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_catalog_localization_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_catalog_localization_service.py
@@ -1,0 +1,63 @@
+from typing import Any
+
+import pytest
+
+from spiffworkflow_backend.services.catalog_localization_service import CatalogLocalizationError
+from spiffworkflow_backend.services.catalog_localization_service import CatalogLocalizationService
+
+
+def test_instruction_translation_is_applied_before_jinja_rendering() -> None:
+    rendered = CatalogLocalizationService.render_instruction_before_jinja(
+        "Welcome, {{ pilot_name }}.",
+        {"pilot_name": "<Artemis>"},
+        translated_template="Bienvenido, {{ pilot_name }}.",
+    )
+
+    assert rendered == "Bienvenido, &lt;Artemis&gt;."
+
+
+def test_static_choice_titles_localize_without_changing_canonical_values() -> None:
+    source_schema: dict[str, Any] = {
+        "type": "object",
+        "properties": {
+            "destination": {
+                "title": "Destination",
+                "oneOf": [
+                    {"const": "moon", "title": "Moon"},
+                    {"const": "mars", "title": "Mars"},
+                ],
+            }
+        },
+    }
+
+    localized_schema = CatalogLocalizationService.localize_json_presentation(
+        source_schema,
+        {
+            "/properties/destination/title": "Destino",
+            "/properties/destination/oneOf/0/title": "Luna",
+            "/properties/destination/oneOf/1/title": "Marte",
+        },
+    )
+
+    assert localized_schema["properties"]["destination"]["oneOf"] == [
+        {"const": "moon", "title": "Luna"},
+        {"const": "mars", "title": "Marte"},
+    ]
+    assert source_schema["properties"]["destination"]["oneOf"][0]["title"] == "Moon"
+
+
+def test_schema_localization_rejects_canonical_value_targets() -> None:
+    with pytest.raises(CatalogLocalizationError, match="not a presentation field"):
+        CatalogLocalizationService.localize_json_presentation(
+            {"oneOf": [{"const": "moon", "title": "Moon"}]},
+            {"/oneOf/0/const": "luna"},
+        )
+
+
+@pytest.mark.parametrize("array_index", ["-1", "00", "01"])
+def test_schema_localization_rejects_noncanonical_array_indexes(array_index: str) -> None:
+    with pytest.raises(CatalogLocalizationError, match="Invalid translation pointer"):
+        CatalogLocalizationService.localize_json_presentation(
+            {"oneOf": [{"const": "moon", "title": "Moon"}]},
+            {f"/oneOf/{array_index}/title": "Luna"},
+        )

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_locale_catalog_service.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/unit/test_locale_catalog_service.py
@@ -1,0 +1,66 @@
+from typing import Any
+
+import pytest
+
+from spiffworkflow_backend.services.locale_catalog_service import LocaleCatalogValidationError
+from spiffworkflow_backend.services.locale_catalog_service import locale_catalog_digest
+from spiffworkflow_backend.services.locale_catalog_service import validate_compatible_locale_catalog
+
+
+def locale_catalog() -> dict[str, Any]:
+    return {
+        "contract_version": "1.0",
+        "catalog_id": "catalog-es",
+        "catalog_version": 1,
+        "workspace_id": "workspace-1",
+        "source_artifact_ref": {
+            "contract_version": "1.0",
+            "tenant_id": "tenant-1",
+            "provider": "filestore",
+            "project_id": "project-1",
+            "snapshot_id": "snapshot-1",
+            "manifest_sha256": f"sha256-{'a' * 64}",
+        },
+        "process_model_identifiers": ["artemis/mission"],
+        "bpmn_version_control_identifier": "abc1234",
+        "source_locale": "en",
+        "target_locale": "es",
+        "fallback_locale": "en",
+        "published_at": "2026-08-30T12:00:00Z",
+        "messages": {
+            "bpmn:launch:instructions": {
+                "value": "Bienvenido, {{ pilot_name }}.",
+                "source_fingerprint": f"sha256-{'b' * 64}",
+                "token_signature": ["{{ pilot_name }}"],
+            }
+        },
+    }
+
+
+def test_catalog_matches_the_existing_process_model_revision_linkage() -> None:
+    catalog = locale_catalog()
+    catalog["integrity"] = locale_catalog_digest(catalog)
+    assert catalog["integrity"] == "sha256-4834da259608e538f90a6f2ebe72cd72efc70c8a2ca2bd27395369c6caec830b"
+
+    assert (
+        validate_compatible_locale_catalog(
+            catalog,
+            process_model_identifier="artemis/mission",
+            bpmn_version_control_identifier="abc1234",
+            requested_locale="es",
+        )
+        == catalog
+    )
+
+
+def test_catalog_rejects_a_different_process_model_revision() -> None:
+    catalog = locale_catalog()
+    catalog["integrity"] = locale_catalog_digest(catalog)
+
+    with pytest.raises(LocaleCatalogValidationError, match="BPMN revision does not match"):
+        validate_compatible_locale_catalog(
+            catalog,
+            process_model_identifier="artemis/mission",
+            bpmn_version_control_identifier="def5678",
+            requested_locale="es",
+        )


### PR DESCRIPTION
## Summary
Adds a migration-free Arena foundation for validating and applying Content Studio locale catalogs. Catalogs match process instances through the existing Arena `process_model_identifier` and `bpmn_version_control_identifier` fields.

## What changed
- Validates catalog integrity, locale, process-model scope, and the existing Arena Git revision.
- Applies translated instruction templates before Jinja rendering.
- Localizes allowlisted JSON presentation fields without changing canonical choice values.
- Adds focused coverage for revision mismatch, token rendering, canonical-value preservation, and invalid JSON Pointer indexes.

## Scope
- No database migrations or schema changes.
- No changes to existing process models, process instances, Filestore import, or queued-instruction persistence.
- Catalog publication, binding, queued-instruction localization, and the workflow-language selector remain later work.

## Verification
- 8 focused tests passed.
- Ruff, formatting, and mypy passed.

## Notes
- Replaces #2994 with a substantially reduced scope.
- No workflow BPMN or diagram/DI content changed.